### PR TITLE
Some initial revisions of the data model

### DIFF
--- a/etc/PrimarySourceDataModelSample.json
+++ b/etc/PrimarySourceDataModelSample.json
@@ -2,17 +2,18 @@
   "@context": [
     "http://schema.org/",
     {
-      "ore": "http://www.openarchives.org/ore/terms/"
+      "ore": "http://www.openarchives.org/ore/terms/",
+      "dct": "http://purl.org/dc/terms/"
     }
   ],
   "@id": "http://dp.la/primarysourceset/frenchindianwar/source/87037c8c0dc514bfd19bddbce9ff2ce7",
   "@type": "MediaObject",
-  "isPartOf": "http://dp.la/primarysourceset/frenchindinanwar",
+  "isPartOf": "http://dp.la/primarysourceset/frenchindianwar",
   "name": "Diary of Major George Washington, 1753",
   "thumbnailUrl": "http://dp.la/assets/path-to-thumbnail.jpg",
   "endcodingFormat": "pdf",
   "contentUrl": "http://path-to-file.pdf",
-  "dplaer:aggregation": {
+  "dct:references": {
     "@id": "http://dp.la/item/87037c8c0dc514bfd19bddbce9ff2ce7",
     "@type": "ore:Aggregation"
   },

--- a/etc/PrimarySourceSetDataModelSample.json
+++ b/etc/PrimarySourceSetDataModelSample.json
@@ -138,7 +138,7 @@
   ],
   "inLanguage": [
     {
-      "@id": "http://www.lexvo.org/page/term/eng/English",
+      "@id": "http://lexvo.org/id/term/eng/English",
       "@type": "Language",
       "name": "English"
     }

--- a/etc/PrimarySourceSetDataModelSample.json
+++ b/etc/PrimarySourceSetDataModelSample.json
@@ -3,13 +3,13 @@
     "http://schema.org/",
     {
       "ccss": "http://www.corestandards.org/",
-      "dc": "http://purl.org/dc/elements/1.1/",
+      "dct": "http://purl.org/dc/terms/",
       "dcmitype": "http://purl.org/dc/dcmitype/",
     }
   ],
-  "@id": "http://dp.la/primarysourceset/frenchindinanwar",
+  "@id": "http://dp.la/primarysourceset/frenchindianwar",
   "@type": "CreativeWork",
-  "dc:type": "dcmitype:InteractiveResource",
+  "dct:type": "dcmitype:InteractiveResource",
   "name": "The French and Indian War",
   "image": "http://path-to-image.jpg",
   "thumbnailUrl": "http://dp.la/assets/path-to-thumbnail.jpg",
@@ -37,7 +37,7 @@
       "name": "Thirteen Colonies"
     }
   ],
-  "dplaer:timePeriod": [
+  "dct:temporal": [
     { "name": "Colonial America" }
   ],
   "description": "This collection uses primary sources to explore the French and Indian War.",
@@ -77,43 +77,43 @@
   "hasPart": [
     { 
       "@id": "http://dp.la/primarysourceset/frenchindianwar/teaching-guide",
-      "dplaer:type": "TeachingGuide"
+      "@type": "CreativeWork"
     },
     {   
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/87037c8c0dc514bfd19bddbce9ff2ce7",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     { 
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/732c1d33eb211983e532f0ccc808c3f5",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     { 
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/14e1f06f68b9f954a1936424d29673ea",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     {
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/38af90d3a1a85936681a7d8bd156f6a3",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     { 
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/ee4949c9e4647ecf1a2358f616f96a52",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     {
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/684ba704a6cafcab5203490eac01aaa1",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     { 
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/5ddde164906d8eb172e4f3e8e1acef81",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     {
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/54d4bb2c2364cd32096e713d83696d8f",
-      "dplaer:type": "PrimarySource"
+      "@type": "MediaObject"
     },
     {
       "@id": "http://dp.la/primarysourceset/frenchindianwar/source/318dfdb4c12448304693d02384447b07",
-      "dpler:type": "PriamrySource"
+      "@type": "MediaObject"
     }
   ],
   "relatedLink": [

--- a/etc/TeachingGuideDataModelSample.json
+++ b/etc/TeachingGuideDataModelSample.json
@@ -1,5 +1,14 @@
 {
-  "@context": "http://schema.org/",
+  "@context": [ 
+    "http://schema.org/",
+    {
+      "text":
+      {
+        "@id": "http://schema.org/text",
+        "@type": "http://ns.ontowiki.net/SysOnt/Markdown"
+      }
+    }
+  ],
   "@id": "http://dp.la/primarysourceset/frenchindianwar/item/87037c8c0dc514bfd19bddbce9ff2ce7",
   "@type": "CreativeWork",
   "isPartOf": "http://dp.la/primarysourceset/frenchindinanwar",
@@ -7,37 +16,31 @@
   "author": {
     "@type": "Person",
     "author": [
-    {
-      "@type": "Person",
-      "name": "Ella Howard",
-      "affiliation": {
-        "@type": "Organization",
-        "name": "Armstrong State University",
-        "location": {
-          "@type": "Place",
-          "name": "Savannah, Georgia"
+      {
+        "@type": "Person",
+        "name": "Ella Howard",
+        "affiliation": {
+          "@type": "Organization",
+          "name": "Armstrong State University",
+          "location": {
+            "@type": "Place",
+            "name": "Savannah, Georgia"
+          }
+        }
+      },
+      {
+        "@type": "Person",
+        "name": "James Walsh",
+        "affiliation": {
+          "@type": "Organization",
+          "name": "Scott County High School",
+          "location": {
+            "@type": "Place",
+            "name": "Kentucky"
+          }
         }
       }
-    },
-    {
-      "@type": "Person",
-      "name": "James Walsh",
-      "affiliation": {
-        "@type": "Organization",
-        "name": "Scott County High School",
-        "location": {
-          "@type": "Place",
-          "name": "Kentucky"
-        }
-      }
-    }
-  ],
-  "dplaer:question": [
-    "Choose five days from <a href='http://dp.la/primarysourceset/source/ee4949c9e4647ecf1a2358f616f96a52'>British soldier Luke Gridley's diary.</a> From his description, what do we learn about soldiers' experience of the war?",
-    "Use the <a href='http://dp.la/primarysourceset/source/5ddde164906d8eb172e4f3e8e1acef81'>letter to William Pitt</a> and the <a href='54d4bb2c2364cd32096e713d83696d8f'>British history of the war</a> to learn about the British perspective on the war. What do the sources tell us about England's reason for fighting. Are the sources biased?",
-    "Use the <a href='http://dp.la/primarysourceset/source/8af90d3a1a85936681a7d8bd156f6a3'>account of speeches and treaties</a> to learn about the Native American perspective on the war. Why did they fight? What did they hope to win?",
-    "Use the <a href='http://dp.la/primarysourceset/source/87037c8c0dc514bfd19bddbce9ff2ce7'>letter at the end of George Washington's diary</a> and the <a href='14e1f06f68b9f954a1936424d29673ea'>map</a> to learn about the French perspective on the war. Why did they fight? What did they hope to win?",
-    "Analyze the <a href='http://dp.la/priarysourceset/source/684ba704a6cafcab5203490eac01aaa1'>medal commemorating the capture of Montreal</a>. What symbols appear on the medal? What do they represent? Do we use similar symbols today?"
-  ],
-  "dplaer:activity": "Divide the class into three groups: Native Americans, French, and British. Have each group read the primary sources relevant to their assigned role, and discuss their perspective on the war. What did they stand to gain? Why did they fight? Moderate a debate between the three groups based on the positions they hold. Have the class vote on the winner of the debate. Then lead a discussion on the actual outcomes of the war. Did the \"correct\" side win?"
+    ],
+    "text": " ##Questions:\n * Choose five days from <a href='http://dp.la/primarysourceset/source/ee4949c9e4647ecf1a2358f616f96a52'>British soldier Luke Gridley's diary.</a> From his description, what do we learn about soldiers' experience of the war?\n * Use the <a href='http://dp.la/primarysourceset/source/5ddde164906d8eb172e4f3e8e1acef81'>letter to William Pitt</a> and the <a href='54d4bb2c2364cd32096e713d83696d8f'>British history of the war</a> to learn about the British perspective on the war. What do the sources tell us about England's reason for fighting. Are the sources biased?\n * Use the <a href='http://dp.la/primarysourceset/source/8af90d3a1a85936681a7d8bd156f6a3'>account of speeches and treaties</a> to learn about the Native American perspective on the war. Why did they fight? What did they hope to win?\n * Use the <a href='http://dp.la/primarysourceset/source/87037c8c0dc514bfd19bddbce9ff2ce7'>letter at the end of George Washington's diary</a> and the <a href='14e1f06f68b9f954a1936424d29673ea'>map</a> to learn about the French perspective on the war. Why did they fight? What did they hope to win?\n\n * Analyze the <a href='http://dp.la/priarysourceset/source/684ba704a6cafcab5203490eac01aaa1'>medal commemorating the capture of Montreal</a>. What symbols appear on the medal? What do they represent? Do we use similar symbols today?\n##Activity:\n Divide the class into three groups: Native Americans, French, and British. Have each group read the primary sources relevant to their assigned role, and discuss their perspective on the war. What did they stand to gain? Why did they fight? Moderate a debate between the three groups based on the positions they hold. Have the class vote on the winner of the debate. Then lead a discussion on the actual outcomes of the war. Did the \"correct\" side win?"
+  }
 }


### PR DESCRIPTION
I was charged with
  1. Replace `PrimarySourceSet:dplaer:timePeriod` with something from the period metadata schema
  2. Replace `PrimarySource:dplaer:aggregation` with something else - possibly `schema:hasPart`?
  3. Replace `TeachingGuide:dplaer:question` and `TeachingGuide:dplaer:activity` with a single field (`schema:text` or something better, like “body”). Expect that the field format will be markdown.  
  4. Possibly replace `PrimarySource:text`, and `PrimarySourceSet:text` with something better, like “body”.  Expect that their field format will be markdown.

Resolving each:
  1. Using `dct:temporal`, with the implication that the value is a `dct:PeriodOfTime`. I owe the Perio.do folks an email, and will get their opinion on applying that class to their `skos:Concept`s
  2. Using `dct:references`, which keeps the semantics here loose.
  3. This revision keeps `schema:text` (and therefore also `schema:Text`), but introduces the markdown datatype. The implication is that `:Markdown` is a subclass of `schema:Text`.
  4. It's okay to leave these as `schema:Text` unless we think we will be storing markdown in them. If we do think that, we can do the type coercion seen on `TeachingGuide.text`.

I've also loosened up the typing throughout, so `PrimarySource`s are just `MediaObject`s, and `TeachingGuide`s are just `CreativeWork`s. I think this is fine, and completes the process of internal namespace from the picture. We can always think about supporting a broader educational resources ontology that addresses these issues specifically if such a thing reveals itself.