### PR TITLE
Feature/extended crud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sass-rails', '~> 4.0.3'
 gem 'jquery-rails'
 gem 'turbolinks'
 gem 'config', '~> 1.0.0'
+gem 'redcarpet', '~> 3.3'
 
 group :test, :development do
   gem 'rspec-core', '~>3.1'

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,0 +1,54 @@
+##
+# Handles HTTP requests for Authors
+#
+# @see Author
+class AuthorsController < ApplicationController
+  def index
+    @authors = Author.all
+  end
+
+  def show
+    @author = Author.find(params[:id])
+  end
+
+  def new
+    @author = Author.new
+  end
+
+  def edit
+    @author = Author.find(params[:id])
+  end
+
+  def create
+    @author = Author.new(author_params)
+
+    if @author.save
+      redirect_to @author
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @author = Author.find(params[:id])
+
+    if @author.update(author_params)
+      redirect_to @author
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @author = Author.find(params[:id])
+    @author.destroy
+
+    redirect_to authors_path
+  end
+
+  private
+
+  def author_params
+    params.require(:author).permit(:name, :affiliation)
+  end
+end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,0 +1,59 @@
+##
+# Handles HTTP requests for guides
+#
+# @see Guide
+class GuidesController < ApplicationController
+  before_filter :load_source_set
+
+  def show
+    @guide = @source_set.guides.find(params[:id])
+  end
+
+  def new
+    @guide = @source_set.guides.new
+  end
+
+  def edit
+    @guide = @source_set.guides.find(params[:id])
+  end
+
+  def create
+    @guide = @source_set.guides.new(guide_params)
+
+    if @guide.save
+      redirect_to [@source_set, @guide]
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @guide = @source_set.guides.find(params[:id])
+
+    if @guide.update(guide_params)
+      redirect_to [@source_set, @guide]
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @guide = @source_set.guides.find(params[:id])
+    @guide.destroy
+
+    redirect_to @source_set
+  end
+
+  private
+
+  def guide_params
+    params.require(:guide).permit(:name,
+                                  :questions,
+                                  :activity,
+                                  author_ids: [])
+  end
+
+  def load_source_set
+    @source_set = SourceSet.find(params[:source_set_id])
+  end
+end

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -49,7 +49,10 @@ class SourceSetsController < ApplicationController
   private
 
   def source_set_params
-    params.require(:source_set).permit(:name, :description, :overview,
-                                       :resources)
+    params.require(:source_set).permit(:name,
+                                       :description,
+                                       :overview,
+                                       :resources,
+                                       author_ids: [])
   end
 end

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -1,0 +1,57 @@
+##
+# Handles HTTP requests for sources
+#
+# @see Source
+class SourcesController < ApplicationController
+  before_filter :load_source_set
+
+  def show
+    @source = @source_set.sources.find(params[:id])
+  end
+
+  def new
+    @source = @source_set.sources.new
+  end
+
+  def edit
+    @source = @source_set.sources.find(params[:id])
+  end
+
+  def create
+    @source = @source_set.sources.new(source_params)
+
+    if @source.save
+      redirect_to [@source_set, @source]
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @source = @source_set.sources.find(params[:id])
+
+    if @source.update(source_params)
+      redirect_to [@source_set, @source]
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @source = @source_set.sources.find(params[:id])
+    @source.destroy
+
+    redirect_to @source_set
+  end
+
+  private
+
+  def source_params
+    params.require(:source).permit(:name, :aggregation, :media_type,
+                                   :textual_content)
+  end
+
+  def load_source_set
+    @source_set = SourceSet.find(params[:source_set_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+
+  ##
+  # @param String text A markdown formatted String
+  # @return String An HTML representation of the markdown string given in 'text'
+  # @raise TypeError if @param is not a String
+  def markdown(text)
+    options = { autolink: true, footnotes: true }
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML, options).render(text)
+      .html_safe
+  end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,0 +1,5 @@
+class Author < ActiveRecord::Base
+  has_and_belongs_to_many :source_sets
+  has_and_belongs_to_many :guides
+  validates :name, presence: true
+end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,0 +1,5 @@
+class Guide < ActiveRecord::Base
+  belongs_to :source_set
+  has_and_belongs_to_many :authors
+  validates :name, presence: true
+end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,0 +1,8 @@
+class Source < ActiveRecord::Base
+  belongs_to :source_set
+  validates :aggregation, presence: true
+
+  def aggregation_uri
+    Settings.frontend.url + 'item/' + aggregation
+  end
+end

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -1,3 +1,6 @@
 class SourceSet < ActiveRecord::Base
+  has_many :sources, dependent: :destroy
+  has_many :guides, dependent: :destroy
+  has_and_belongs_to_many :authors
   validates :name, presence: true
 end

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_for @author do |f| %>
+ 
+  <% if @author.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@author.errors.count, "error") %> prohibited
+        this set from being saved:
+      </h2>
+      <ul>
+        <% @author.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+ 
+  <p>
+    <strong><%= f.label "Name (required)" %></strong><br/>
+    <%= f.text_field :name %>
+  </p>
+
+  <p>
+    <strong><%= f.label :affiliation %></strong><br/>
+    <%= f.text_field :affiliation %>
+  </p>
+  
+  <p>
+    <%= f.submit %>
+  </p>
+ 
+<% end %>

--- a/app/views/authors/edit.html.erb
+++ b/app/views/authors/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Edit author</h1>
+
+<p>
+  <%= link_to "View", author_path(@author) %>
+  |
+  <%= link_to "Delete", author_path(@author),
+            method: :delete,
+            data: { confirm: "Are you sure you want to delete #{@author.name}?" } %></p>
+ 
+<%= render "form" %>

--- a/app/views/authors/index.html.erb
+++ b/app/views/authors/index.html.erb
@@ -1,0 +1,16 @@
+<h1>Authors</h1>
+
+<p><%= link_to "Create new author", new_author_path %></p>
+
+<table>
+<% @authors.each do |author| %>
+  <tr>
+    <td><%= author.name %></td>
+    <td><%= link_to "View", author_path(author) %></td>
+    <td><%= link_to "Edit", edit_author_path(author) %></td>
+    <td><%= link_to "Delete", author_path(author),
+                    method: :delete,
+                    data: { confirm: "Are you sure you want to delete #{author.name}?" } %></td>
+  </tr>
+<% end %>
+</table>

--- a/app/views/authors/new.html.erb
+++ b/app/views/authors/new.html.erb
@@ -1,0 +1,5 @@
+<p><%= link_to "Back to authors", authors_path %></p>
+
+<h1>New author</h1>
+
+<%= render "form" %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,0 +1,33 @@
+<h1>Author: <%= @author.name %></h1>
+
+<p>
+  <%= link_to "Edit", edit_author_path(@author) %>
+  |
+  <%= link_to "Delete", author_path(@author), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@author.name}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Name </strong></td>
+    <td><%= @author.name %></td>
+  </tr>
+  <tr>
+    <td><strong>Affiliation </strong></td>
+    <td><%= @author.affiliation %></td>
+  </tr>
+</table>
+
+<h2>Sets</h2>
+<ul>
+<% @author.source_sets.each do |source_set| %>
+  <li><%= link_to source_set.name, source_set_path(source_set) %></li>
+<% end %>
+</ul>
+
+<h2>Teaching guides</h2>
+<ul>
+  <% @author.guides.each do |guide| %>
+    <li><%= link_to guide.name, source_set_guide_path(guide.source_set, guide) %></li>
+  <% end %>
+</ul>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,40 +1,34 @@
-<%= form_for @source_set do |f| %>
- 
-  <% if @source_set.errors.any? %>
+<%= form_for [@source_set, @guide] do |f| %>
+
+  <% if @guide.errors.any? %>
     <div id="error_explanation">
       <h2>
-        <%= pluralize(@source_set.errors.count, "error") %> prohibited
+        <%= pluralize(@guide.errors.count, "error") %> prohibited
         this set from being saved:
       </h2>
       <ul>
-        <% @source_set.errors.full_messages.each do |msg| %>
+        <% @guide.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
- 
+
   <p>
     <strong><%= f.label "Name (required)" %></strong><br/>
     <%= f.text_field :name %>
   </p>
- 
+
   <p>
-    <strong><%= f.label :description %></strong><br/>
-    <em>Example: "This collection uses primary sources to explore the French and Indian War."</em><br/>
-    <%= f.text_area :description %>
+    <strong><%= f.label :questions %></strong><br/>
+    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
+    <%= f.text_area :questions %>
   </p>
 
   <p>
-    <strong><%= f.label :overview %></strong><br/>
+    <strong><%= f.label :activity %></strong><br/>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
-    <%= f.text_area :overview %>
-  </p>
-
-  <p>
-    <strong><%= f.label :resources_for_research %></strong><br/>
-    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
-    <%= f.text_area :resources %>
+    <%= f.text_area :activity %>
   </p>
 
   <p>
@@ -43,9 +37,9 @@
       <%= b.label { b.check_box + b.text } %><br />
     <% end %>
   </p>
- 
+
   <p>
     <%= f.submit %>
   </p>
- 
+
 <% end %>

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit teaching guide</h1>
+
+<p>
+  <%= link_to "View", source_set_guide_path(@source_set, @guide) %>
+  |
+  <%= link_to "Delete", 
+               source_set_guide_path(@source_set, @guide), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@guide.name}?" } %>
+</p>
+
+<p>This guide belongs to <%= link_to @source_set.name, source_set_path(@source_set) %></p>
+
+<%= render "form" %>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,0 +1,5 @@
+<p><%= link_to "Back to #{@source_set.name}", source_set_path(@source_set) %></p>
+
+<h1>New teaching guide for <%= @source_set.name %></h1>
+
+<%= render "form" %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,0 +1,34 @@
+<h1>Teaching guide: <%= @guide.name %></h1>
+
+<p>
+  <%= link_to "Edit", edit_source_set_guide_path(@source_set, @guide) %>
+  |
+  <%= link_to "Delete", 
+               source_set_guide_path(@source_set, @guide), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@guide.name}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Set </strong></td>
+    <td><%= link_to @source_set.name, source_set_path(@source_set)%></td>
+  </tr>
+  <tr>
+    <td><strong>Name </strong></td>
+    <td><%= @guide.name %></td>
+  </tr>
+  <tr>
+    <td><strong>Questions </strong></td>
+    <td><%= markdown(@guide.questions) %></td>
+  </tr>
+  <tr>
+    <td><strong>Activity </strong></td>
+    <td><%= markdown(@guide.activity) %></td>
+  </tr>
+  <% @guide.authors.each do |author| %>
+    <tr>
+      <td><strong>Author </strong></td>
+      <td><%= author.name %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,13 @@
 </head>
 <body>
 
+  <div id="admin-menu">
+    <%= link_to "Sets", source_sets_path %>
+    |
+    <%= link_to "Authors", authors_path %>
+    </ul>
+  </div>
+
 <%= yield %>
 
 </body>

--- a/app/views/source_sets/edit.html.erb
+++ b/app/views/source_sets/edit.html.erb
@@ -1,8 +1,11 @@
 <h1>Edit set</h1>
 
-<p><%= link_to "Back to sets", source_sets_path %></p>
-<p><%= link_to "Delete this set", source_set_path(@source_set),
+<p>
+  <%= link_to "View", source_set_path(@source_set) %>
+  |
+  <%= link_to "Delete", source_set_path(@source_set),
             method: :delete,
-            data: { confirm: "Are you sure you want to delete #{@source_set.name}?" } %></p>
+            data: { confirm: "Are you sure you want to delete #{@source_set.name}?" } %>
+</p>
  
 <%= render "form" %>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -5,7 +5,8 @@
 <table>
 <% @source_sets.each do |set| %>
   <tr>
-    <td><%= link_to set.name, source_set_path(set) %></td>
+    <td><%= set.name %></td>
+    <td><%= link_to "View", source_set_path(set) %></td>
     <td><%= link_to "Edit", edit_source_set_path(set) %></td>
     <td><%= link_to "Delete", source_set_path(set),
                     method: :delete,

--- a/app/views/source_sets/new.html.erb
+++ b/app/views/source_sets/new.html.erb
@@ -1,5 +1,3 @@
 <h1>New set</h1>
 
-<p><%= link_to "Back to sets", source_sets_path %></p>
-
 <%= render "form" %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -1,8 +1,11 @@
-<p><%= link_to "Back to sets", source_sets_path %></p>
-<p><%= link_to "Edit this set", edit_source_set_path(@source_set) %></p>
-<p><%= link_to "Delete this set", source_set_path(@source_set),
-            method: :delete,
-            data: { confirm: "Are you sure you want to delete #{@source_set.name}?" } %></p>
+<h1>Set: <%= @source_set.name %></h1>
+
+<p>
+  <%= link_to "Edit", edit_source_set_path(@source_set) %>
+  |
+  <%= link_to "Delete", source_set_path(@source_set), method: :delete,
+                 data: { confirm: "Are you sure you want to delete #{@source_set.name}?" } %>
+</p>
 
 <table>
   <tr>
@@ -15,22 +18,54 @@
   </tr>
   <tr>
     <td><strong>Overview </strong></td>
-    <td><%= @source_set.overview %></td>
+    <td><%= markdown(@source_set.overview) %></td>
   </tr>
   <tr>
     <td><strong>Resources </strong></td>
-    <td><%= @source_set.resources %></td>
+    <td><%= markdown(@source_set.resources) %></td>
   </tr>
   <tr>
     <td><strong>Published </strong></td>
     <td><%= @source_set.published %></td>
   </tr>
+  <% @source_set.authors.each do |author| %>
+    <tr>
+      <td><strong>Author </strong></td>
+      <td><%= link_to author.name, author_path(author) %></td>
+    </tr>
+  <% end %>
+</table>
+
+<h2>Sources</h2>
+
+<p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
+
+<table>
+<% @source_set.sources.each do |source| %>
   <tr>
-    <td><strong>Created date </strong></td>
-    <td><%= @source_set.created_at %></td>
+    <td><%= source_name = source.name.present? ? source.name : source.aggregation %></td>
+    <td><%= link_to "View", source_set_source_path(@source_set, source) %></td>
+    <td><%= link_to "Edit", edit_source_set_source_path(@source_set, source) %></td>
+    <td><%= link_to "Delete", source_set_source_path(@source_set, source),
+                    method: :delete,
+                    data: { confirm: "Are you sure you want to delete #{source_name}?" } %></td>
   </tr>
+<% end %>
+</table>
+
+<h2>Teaching guides</h2>
+
+<p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
+
+<table>
+<% @source_set.guides.each do |guide| %>
   <tr>
-    <td><strong>Modified date </strong></td>
-    <td><%= @source_set.updated_at %></td>
+    <td><%= guide.name %></td>
+    <td><%= link_to "View", source_set_guide_path(@source_set, guide) %></td>
+    <td><%= link_to "Edit", edit_source_set_guide_path(@source_set, guide) %></td>
+    <td><%= link_to "Delete", source_set_guide_path(@source_set, guide),
+                    method: :delete,
+                    data: { confirm: "Are you sure you want to delete #{guide.name}?" } %></td>
   </tr>
+<% end %>
 </table>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -1,0 +1,47 @@
+<%= form_for [@source_set, @source] do |f| %>
+
+  <% if @source.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@source.errors.count, "error") %> prohibited
+        this source from being saved:
+      </h2>
+      <ul>
+        <% @source.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <p>
+    <strong><%= f.label "DPLA id (required)" %></strong><br/>
+    <em>Example: ebc07432a6ba4f864daaddc4ad0a68f9</em><br/>
+    <%= f.text_field :aggregation %>
+  </p>
+
+  <p>
+    <strong><%= f.label :name %></strong><br/>
+    <%= f.text_field :name %>
+  </p>
+
+  <p>
+    <strong><%= f.label :media_type %></strong><br/>
+    <em>Media type refers to the file type of the digital object.  It is not a description of the original object.</em><br/>
+    <%= radio_button("source", "media_type", "image") %>image<br/>
+    <%= radio_button("source", "media_type", "document") %>document<br/>
+    <%= radio_button("source", "media_type", "audio") %>audio<br/>
+    <%= radio_button("source", "media_type", "video") %>video<br/>
+  </p>
+
+  <p>
+    <strong><%= f.label :textual_content %></strong><br/>
+    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
+    <%= f.text_area :textual_content %>
+  </p>
+
+  <p>
+    <%= f.submit %>
+  </p>
+
+<% end %>

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit source</h1>
+
+<p>
+  <%= link_to "View", source_set_source_path(@source, @source_set) %>
+  |
+  <%= link_to "Delete", 
+               source_set_source_path(@source_set, @source), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@source_name}?" } %>
+</p>
+
+<p>This source belongs to <%= link_to @source_set.name, source_set_path(@source_set) %></p>
+
+<%= render "form" %>

--- a/app/views/sources/new.html.erb
+++ b/app/views/sources/new.html.erb
@@ -1,0 +1,5 @@
+<p><%= link_to "Back to #{@source_set.name}", source_set_path(@source_set) %></p>
+
+<h1>New source for <%= @source_set.name %></h1>
+
+<%= render "form" %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,0 +1,33 @@
+<% source_name = @source.name.present? ? @source.name : @source.aggregation %>
+<h1>Source: <%= source_name %></h1>
+
+<p>
+  <%= link_to "Edit", edit_source_set_source_path(@source_set, @source) %>
+  |
+  <%= link_to "Delete", 
+               source_set_source_path(@source_set, @source), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@source_name}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Set </strong></td>
+    <td><%= link_to @source_set.name, source_set_path(@source_set)%></td>
+  </tr>
+  <tr>
+    <td><strong>DPLA item URI </strong></td>
+    <td><%= link_to @source.aggregation_uri, @source.aggregation_uri %></td>
+  </tr>
+  <tr>
+    <td><strong>Name </strong></td>
+    <td><%= @source.name %></td>
+  </tr>
+  <tr>
+    <td><strong>Media type </strong></td>
+    <td><%= @source.media_type %></td>
+  </tr>
+  <tr>
+    <td><strong>Textual content </strong></td>
+    <td><%= markdown(@source.textual_content) %></td>
+  </tr>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  resources :sets, controller: 'source_sets', as: 'source_sets'
+  resources :sets, controller: 'source_sets', as: 'source_sets' do
+    resources :sources, only: [:new, :create, :edit, :update, :show, :destroy]
+    resources :guides, only: [:new, :create, :edit, :update, :show, :destroy]
+  end
+  resources :authors
 
   root 'source_sets#index'
 end

--- a/config/settings.local.yml.example
+++ b/config/settings.local.yml.example
@@ -1,4 +1,8 @@
-#Use this file to define settings related to application configuration
-#Use this file to define settings that are ENVIRONMENT SPECIFIC and/or PRIVATE
-#This file will be ignored by git
-#Declarations in this file override declarations in config/settings.yml
+# Use this file to define settings related to application configuration
+# Use this file to define settings that are UNIVERSAL (not specific to any environment)
+# Information in this file is PRIVATE (this file will be ignored by git)
+# Declarations in this file override declarations in config/settings.yml
+
+frontend:
+  # With trailing slash
+  url: http://dp.la/

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,9 @@
-#Use this file to define settings related to application configuration
-#Use this file to define settings that are UNIVERSAL (not specific to any environment)
-#Information in this file will be PUBLIC (this file is tracked in git)
-#Declarations in config/settings.local.yml override declarations in this file
+# Use this file to define settings related to application configuration
+# Use this file to define settings that are UNIVERSAL (not specific to any environment)
+# Information in this file will be PUBLIC (this file is tracked in git)
+# Declarations in config/settings.local.yml override declarations in this file
 
+frontend:
+  # With trailing slash
+  url: http://dp.la/
 relative_url_root: /primary-source-sets

--- a/db/migrate/20150828152401_create_sources.rb
+++ b/db/migrate/20150828152401_create_sources.rb
@@ -1,0 +1,12 @@
+class CreateSources < ActiveRecord::Migration
+  def change
+    create_table :sources do |t|
+      t.belongs_to :source_set, index: true
+      t.string :name
+      t.string :aggregation
+      t.string :media_type
+      t.text :textual_content
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150828153447_sources_text_limits.rb
+++ b/db/migrate/20150828153447_sources_text_limits.rb
@@ -1,0 +1,5 @@
+class SourcesTextLimits < ActiveRecord::Migration
+  def change
+    change_column :sources, :textual_content, :text, limit: 65535
+  end
+end

--- a/db/migrate/20150828231919_create_guides.rb
+++ b/db/migrate/20150828231919_create_guides.rb
@@ -1,0 +1,11 @@
+class CreateGuides < ActiveRecord::Migration
+  def change
+    create_table :guides do |t|
+      t.belongs_to :source_set, index: true
+      t.string :name
+      t.text :questions
+      t.text :activity
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150829003204_guides_text_limits.rb
+++ b/db/migrate/20150829003204_guides_text_limits.rb
@@ -1,0 +1,6 @@
+class GuidesTextLimits < ActiveRecord::Migration
+  def change
+    change_column :guides, :questions, :text, limit: 65535
+    change_column :guides, :activity, :text, limit: 65535
+  end
+end

--- a/db/migrate/20150829150756_create_authors.rb
+++ b/db/migrate/20150829150756_create_authors.rb
@@ -1,0 +1,9 @@
+class CreateAuthors < ActiveRecord::Migration
+  def change
+    create_table :authors do |t|
+      t.string :name
+      t.string :affiliation
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150829151300_create_source_sets_authors.rb
+++ b/db/migrate/20150829151300_create_source_sets_authors.rb
@@ -1,0 +1,8 @@
+class CreateSourceSetsAuthors < ActiveRecord::Migration
+  def change
+    create_table :authors_source_sets, id: false do |t|
+      t.belongs_to :source_set, index: true
+      t.belongs_to :author, index: true
+    end
+  end
+end

--- a/db/migrate/20150829151317_create_guides_authors.rb
+++ b/db/migrate/20150829151317_create_guides_authors.rb
@@ -1,0 +1,8 @@
+class CreateGuidesAuthors < ActiveRecord::Migration
+  def change
+    create_table :authors_guides, id: false do |t|
+      t.belongs_to :guide, index: true
+      t.belongs_to :author, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150826135207) do
+ActiveRecord::Schema.define(version: 20150829151317) do
+
+  create_table "authors", force: true do |t|
+    t.string   "name"
+    t.string   "affiliation"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  create_table "authors_guides", id: false, force: true do |t|
+    t.integer "guide_id"
+    t.integer "author_id"
+  end
+
+  add_index "authors_guides", ["author_id"], name: "index_authors_guides_on_author_id"
+  add_index "authors_guides", ["guide_id"], name: "index_authors_guides_on_guide_id"
+
+  create_table "authors_source_sets", id: false, force: true do |t|
+    t.integer "source_set_id"
+    t.integer "author_id"
+  end
+
+  add_index "authors_source_sets", ["author_id"], name: "index_authors_source_sets_on_author_id"
+  add_index "authors_source_sets", ["source_set_id"], name: "index_authors_source_sets_on_source_set_id"
+
+  create_table "guides", force: true do |t|
+    t.integer  "source_set_id"
+    t.string   "name"
+    t.text     "questions",     limit: 65535
+    t.text     "activity",      limit: 65535
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+  end
+
+  add_index "guides", ["source_set_id"], name: "index_guides_on_source_set_id"
 
   create_table "source_sets", force: true do |t|
     t.string   "name"
@@ -22,5 +56,17 @@ ActiveRecord::Schema.define(version: 20150826135207) do
     t.datetime "created_at",                                null: false
     t.datetime "updated_at",                                null: false
   end
+
+  create_table "sources", force: true do |t|
+    t.integer  "source_set_id"
+    t.string   "name"
+    t.string   "aggregation"
+    t.string   "media_type"
+    t.text     "textual_content", limit: 65535
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+  end
+
+  add_index "sources", ["source_set_id"], name: "index_sources_on_source_set_id"
 
 end

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+describe AuthorsController, type: :controller do
+
+  let(:author) { FactoryGirl. create(:author_factory) }
+
+  describe '#index' do
+
+    it 'set @authors variable' do
+      get :index
+      expect(assigns(:authors)).to eq([author])
+    end
+
+    it 'renders the :index view' do
+      get :index
+      expect(response).to render_template :index
+    end
+  end
+
+  describe '#show' do
+
+    it 'sets @author variable' do
+      get :show, id: author.id
+      expect(assigns(:author)).to eq(author)
+    end
+
+    it 'renders the :show view' do
+      get :show, id: author.id
+      expect(response).to render_template :show
+    end
+  end
+
+  describe '#create' do
+
+    it 'creates a new author' do
+      expect do
+        post :create, author: attributes_for(:author_factory)
+      end.to change(Author, :count).by(1)
+    end
+
+    it 'redirects to the new author' do
+      post :create, author: attributes_for(:author_factory)
+      expect(response).to redirect_to Author.last
+    end
+
+    context 'with invalid attributes' do
+
+      it 'does not save new author' do
+        expect do
+          post :create, author: attributes_for(:invalid_author_factory)
+        end.to_not change(Author, :count)
+      end
+
+      it 're-renders :new view' do
+        post :create, author: attributes_for(:invalid_author_factory)
+        expect(response).to render_template :new
+      end
+    end
+  end
+
+  describe '#update' do
+
+    it 'updates the author' do
+      author
+      patch :update, id: author.id, author: { name: 'New name' }
+      author.reload
+      expect(author.name).to eq('New name')
+    end
+
+    it 'redirects to the updated author' do
+      patch :update, id: author.id, author: { name: 'New name' }
+      expect(response).to redirect_to author
+    end
+
+    context 'with invalid attributes' do
+
+      it 'does not update the author' do
+        author
+        valid_name = author.name
+        patch :update,
+              id: author.id,
+              author: attributes_for(:invalid_author_factory)
+        author.reload
+        expect(author.name).to eq(valid_name)
+      end
+
+      it 're-renders :edit view' do
+        patch :update,
+              id: author.id,
+              author: attributes_for(:invalid_author_factory)
+        expect(:response).to render_template :edit
+      end
+    end
+  end
+
+  describe '#destroy' do
+
+    it 'deletes the author' do
+      author
+      expect do
+        delete :destroy, id: author.id
+      end.to change(Author, :count).by(-1)
+    end
+
+    it 'redirects to :index view' do
+      author
+      delete :destroy, id: author.id
+      expect(response).to redirect_to authors_url
+    end
+  end
+end

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+describe GuidesController, type: :controller do
+
+  let(:guide) { FactoryGirl.create(:guide_factory) }
+  let(:source_set) { guide.source_set }
+
+  describe '#show' do
+
+    it 'sets @guide variable' do
+      get :show, id: guide.id, source_set_id: source_set.id
+      expect(assigns(:guide)).to eq(guide)
+    end
+
+    it 'sets @source_set variable' do
+      get :show, id: guide.id, source_set_id: source_set.id
+      expect(assigns(:source_set)).to eq(source_set)
+    end
+
+    it 'renders the :show view' do
+      get :show, id: guide.id, source_set_id: source_set.id
+      expect(response).to render_template :show
+    end
+  end
+
+  describe '#create' do
+
+    it 'creates a new guide' do
+      source_set
+      expect do
+        post :create,
+             source_set_id: source_set.id,
+             guide: attributes_for(:guide_factory)
+      end.to change(source_set.guides, :count).by(1)
+    end
+
+    it 'redirects to the new guide' do
+      source_set
+      post :create,
+           source_set_id: source_set.id,
+           guide: attributes_for(:guide_factory)
+      expect(response).to redirect_to [source_set, Guide.last]
+    end
+
+    context 'with invalid attributes' do
+
+      it 'does not save new guide' do
+        source_set
+        expect do
+          post :create,
+               source_set_id: source_set.id,
+               guide: attributes_for(:invalid_guide_factory)
+        end.to_not change(source_set.guides, :count)
+      end
+
+      it 're-renders :new view' do
+        post :create,
+             source_set_id: source_set.id,
+             guide: attributes_for(:invalid_guide_factory)
+        expect(response).to render_template :new
+      end
+    end
+  end
+
+  describe '#update' do
+
+    it 'updates the guide' do
+      guide
+      patch :update,
+            id: guide.id,
+            source_set_id: source_set.id,
+            guide: { name: 'New name' }
+      guide.reload
+      expect(guide.name).to eq('New name')
+    end
+
+    it 'redirects to the updated guide' do
+      patch :update,
+            id: guide.id,
+            source_set_id: source_set.id,
+            guide: { name: 'New name' }
+      expect(response).to redirect_to [source_set, guide]
+    end
+
+    context 'with invalid attributes' do
+
+      it 'does not update the guide' do
+        guide
+        valid_name = guide.name
+        patch :update,
+              id: guide.id,
+              source_set_id: source_set.id,
+              guide: attributes_for(:invalid_guide_factory)
+        guide.reload
+        expect(guide.name).to eq(valid_name)
+      end
+
+      it 're-renders :edit view' do
+        patch :update,
+              id: guide.id,
+              source_set_id: source_set.id,
+              guide: attributes_for(:invalid_guide_factory)
+        expect(:response).to render_template :edit
+      end
+    end
+  end
+
+  describe '#destroy' do
+
+    it 'deletes the guide' do
+      guide
+      expect do
+        delete :destroy, id: guide.id, source_set_id: source_set.id
+      end.to change(source_set.guides, :count).by(-1)
+    end
+
+    it 'redirects to :index view' do
+      guide
+      delete :destroy, id: guide.id, source_set_id: source_set.id
+      expect(response).to redirect_to source_set_url
+    end
+  end
+end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+describe SourcesController, type: :controller do
+
+  let(:source) { FactoryGirl.create(:source_factory) }
+  let(:source_set) { source.source_set }
+
+  describe '#show' do
+
+    it 'sets @source variable' do
+      get :show, id: source.id, source_set_id: source_set.id
+      expect(assigns(:source)).to eq(source)
+    end
+
+    it 'sets @source_set variable' do
+      get :show, id: source.id, source_set_id: source_set.id
+      expect(assigns(:source_set)).to eq(source_set)
+    end
+
+    it 'renders the :show view' do
+      get :show, id: source.id, source_set_id: source_set.id
+      expect(response).to render_template :show
+    end
+  end
+
+  describe '#create' do
+
+    it 'creates a new source' do
+      source_set
+      expect do
+        post :create,
+             source_set_id: source_set.id,
+             source: attributes_for(:source_factory)
+      end.to change(source_set.sources, :count).by(1)
+    end
+
+    it 'redirects to the new source' do
+      source_set
+      post :create,
+           source_set_id: source_set.id,
+           source: attributes_for(:source_factory)
+      expect(response).to redirect_to [source_set, Source.last]
+    end
+
+    context 'with invalid attributes' do
+
+      it 'does not save new source' do
+        source_set
+        expect do
+          post :create,
+               source_set_id: source_set.id,
+               source: attributes_for(:invalid_source_factory)
+        end.to_not change(source_set.sources, :count)
+      end
+
+      it 're-renders :new view' do
+        post :create,
+             source_set_id: source_set.id,
+             source: attributes_for(:invalid_source_factory)
+        expect(response).to render_template :new
+      end
+    end
+  end
+
+  describe '#update' do
+
+    it 'updates the source' do
+      source
+      patch :update,
+            id: source.id,
+            source_set_id: source_set.id,
+            source: { name: 'New name' }
+      source.reload
+      expect(source.name).to eq('New name')
+    end
+
+    it 'redirects to the updated source' do
+      patch :update,
+            id: source.id,
+            source_set_id: source_set.id,
+            source: { name: 'New name' }
+      expect(response).to redirect_to [source_set, source]
+    end
+
+    context 'with invalid attributes' do
+
+      it 'does not update the source' do
+        source
+        valid_aggregation = source.aggregation
+        patch :update,
+              id: source.id,
+              source_set_id: source_set.id,
+              source: attributes_for(:invalid_source_factory)
+        source.reload
+        expect(source.aggregation).to eq(valid_aggregation)
+      end
+
+      it 're-renders :edit view' do
+        patch :update,
+              id: source.id,
+              source_set_id: source_set.id,
+              source: attributes_for(:invalid_source_factory)
+        expect(:response).to render_template :edit
+      end
+    end
+  end
+
+  describe '#destroy' do
+
+    it 'deletes the source' do
+      source
+      expect do
+        delete :destroy, id: source.id, source_set_id: source_set.id
+      end.to change(source_set.sources, :count).by(-1)
+    end
+
+    it 'redirects to :index view' do
+      source
+      delete :destroy, id: source.id, source_set_id: source_set.id
+      expect(response).to redirect_to source_set_url
+    end
+  end
+end

--- a/spec/factories/authors.rb
+++ b/spec/factories/authors.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :author_factory, class: Author do
+    name 'Moominmamma'
+    affiliation 'Moominvalley Public School'
+  end
+
+  factory :invalid_author_factory, class: Author do
+    name nil
+  end
+end

--- a/spec/factories/guides.rb
+++ b/spec/factories/guides.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :guide_factory, class: Guide do
+    name 'Exploring Moominvalley'
+    questions 'The birthday button: so good or no good?'
+    activity 'Discuss the birthday button'
+    association :source_set, factory: :source_set_factory
+  end
+
+  factory :invalid_guide_factory, class: Guide do
+    name nil
+  end
+end

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :source_factory, class: Source do
+    name 'The birthday button'
+    aggregation 'c3702b42c7e3daf5aafe47151184ba33'
+    media_type 'image'
+    textual_content 'The birthday button is a beautiful artifact.'
+    association :source_set, factory: :source_set_factory
+  end
+
+  factory :invalid_source_factory, class: Source do
+    aggregation nil
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe ApplicationHelper, type: :helper do
+   
+   describe '#markdown' do
+
+     it 'renders HTML from a markdown String' do
+       text = '**Moomin!**'
+       expect(helper.markdown(text)).to eq("<p><strong>Moomin!</strong></p>\n")
+     end
+
+     it 'raises a TypeError if input is not a String' do
+       invalid_input = 123
+       expect{ helper.markdown(invalid_input) }.to raise_error(TypeError)
+     end
+   end
+end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Author, type: :model do
+
+  it 'has and belongs to many source_sets' do
+    expect(Author.reflect_on_association(:source_sets).macro.should)
+      .to eq :has_and_belongs_to_many
+  end
+
+  it 'has and belongs to many guides' do
+    expect(Author.reflect_on_association(:guides).macro.should)
+      .to eq :has_and_belongs_to_many
+  end
+
+  it 'is invalid without name' do
+    expect(Author.new(name: nil)).not_to be_valid
+  end
+end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Guide, type: :model do
+
+  it 'belong to a source set' do
+    expect(Guide.reflect_on_association(:source_set).macro.should)
+      .to eq :belongs_to
+  end
+
+  it 'has and belongs to many authors' do
+    expect(Guide.reflect_on_association(:authors).macro.should)
+      .to eq :has_and_belongs_to_many
+  end
+
+  it 'is invalid without name' do
+    expect(Guide.new(name: nil)).not_to be_valid
+  end
+end

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -2,6 +2,21 @@ require 'spec_helper'
 
 describe SourceSet, type: :model do
 
+  it 'has many sources' do
+    expect(SourceSet.reflect_on_association(:sources).macro.should)
+      .to eq :has_many
+  end
+
+  it 'has many guides' do
+    expect(SourceSet.reflect_on_association(:guides).macro.should)
+      .to eq :has_many
+  end
+
+  it 'has and belongs to many authors' do
+    expect(SourceSet.reflect_on_association(:authors).macro.should)
+      .to eq :has_and_belongs_to_many
+  end
+
   it 'is invalid without name' do
     expect(SourceSet.new(name: nil)).not_to be_valid
   end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Source, type: :model do
+
+  it 'belongs to a source set' do
+    expect(Source.reflect_on_association(:source_set).macro.should)
+      .to eq :belongs_to
+  end
+
+  it 'is invalid without aggregation' do
+    expect(Source.new(aggregation: nil)).not_to be_valid
+  end
+end

--- a/spec/views/authors/index.html.erb_spec.rb
+++ b/spec/views/authors/index.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'authors/index.html.erb', type: :view do
+
+  before do
+    assign(:authors, [create(:author_factory, name: 'Moomin'),
+                          create(:author_factory, name: 'Snorkmaiden')])
+  end
+
+  it 'renders each author' do
+    render
+    expect(rendered).to include('Moomin')
+    expect(rendered).to include('Snorkmaiden')
+  end
+end

--- a/spec/views/authors/show.html.erb_spec.rb
+++ b/spec/views/authors/show.html.erb_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'authors/show.html.erb', type: :view do
+  let(:author) { create(:author_factory) }
+  
+  before { assign(:author, author) }
+
+  it 'renders the author' do
+    render
+    expect(rendered).to include(author.name)
+  end
+end

--- a/spec/views/guides/show.html.erb_spec.rb
+++ b/spec/views/guides/show.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'guides/show.html.erb', type: :view do
+
+  let(:guide) { create(:guide_factory) }
+
+  before do
+    assign(:guide, guide)
+    assign(:source_set, guide.source_set)
+  end
+
+  it 'renders the guide' do
+    render
+    expect(rendered).to include(guide.name)
+  end
+end

--- a/spec/views/source_sets/show.html.erb_spec.rb
+++ b/spec/views/source_sets/show.html.erb_spec.rb
@@ -1,10 +1,27 @@
 require 'spec_helper'
 
 describe 'source_sets/show.html.erb', type: :view do
-  before { assign(:source_set, create(:source_set_factory, name: 'Moomin')) }
+
+  let(:source_set) { create(:source_set_factory) }
+  let(:source) { create(:source_factory, source_set: source_set) }
+  let(:guide) { create(:guide_factory, source_set: source_set) }
+
+  before { assign(:source_set, source_set) }
 
   it 'renders the source set' do
     render
-    expect(rendered).to include('Moomin')
+    expect(rendered).to include(source_set.name)
+  end
+
+  it 'shows all its sources' do
+    source
+    render
+    expect(rendered).to include(source.name)
+  end
+
+  it 'shows all its guides' do
+    guide
+    render
+    expect(rendered).to include(guide.name)
   end
 end

--- a/spec/views/sources/show.html.erb_spec.rb
+++ b/spec/views/sources/show.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'sources/show.html.erb', type: :view do
+
+  let(:source) { create(:source_factory) }
+
+  before do
+    assign(:source, source)
+    assign(:source_set, source.source_set)
+  end
+
+  it 'renders the source' do
+    render
+    expect(rendered).to include(source.aggregation)
+  end
+end


### PR DESCRIPTION
This PR introduces CRUD interfaces for `source`, `guide`, and `author`.  

`source` and `guide` are very similar - they both have `belongs_to` relationships to `source_set`, and their routes are both nested under `source_set`.  Neither have their own `index` route or view; instead, they are listed on their parent `source_set#show` view.

`author` has a `has_many_and_belongs_to` relationship with both `source_set` and `guide` and as such, required the creation of additional associations tables.

This PR also introduces the [redcarpet](https://github.com/vmg/redcarpet) gem to render Markdown.  Five of the data entry fields accept Markdown, so it needs to be rendered to the user in the `show` views so that they can verify that their data entry was correct.  Look at the [render markdown](https://github.com/dpla/primary-source-sets/commit/7ab719de95d06ce61d6dd0d07290984ef4925209) commit to see only the changes having to do with rendering Markdown.

The best way to test the views is to play with them in your browser.  Remember to do `bundle install` and  `rake db:migrate`.

If you want to run the automated tests locally, remember to do `bundle install` and `rake db:test:prepare`.