### PR TITLE
Add build-essentials to provisioned packages

### DIFF
--- a/provisioning/provision.yml
+++ b/provisioning/provision.yml
@@ -17,6 +17,7 @@
         - libsqlite3-dev
         - postgresql-common
         - libpq-dev
+        - build-essential
 
 - hosts: all
   # do as "vagrant" user


### PR DESCRIPTION
Building Ruby could/did(?) fail, because `make` was not installed. This
installs the dependencies for a Ruby build.