### PR TITLE
add set slugs with FriendlyId

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'config', '~> 1.0.0'
 gem 'redcarpet', '~> 3.3'
+gem 'friendly_id', '~> 5.1.0'
 
 group :test, :development do
   gem 'rspec-core', '~>3.1'

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -54,6 +54,6 @@ class GuidesController < ApplicationController
   end
 
   def load_source_set
-    @source_set = SourceSet.find(params[:source_set_id])
+    @source_set = SourceSet.friendly.find(params[:source_set_id])
   end
 end

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -8,7 +8,7 @@ class SourceSetsController < ApplicationController
   end
 
   def show
-    @source_set = SourceSet.find(params[:id])
+    @source_set = SourceSet.friendly.find(params[:id])
   end
 
   def new
@@ -16,7 +16,7 @@ class SourceSetsController < ApplicationController
   end
 
   def edit
-    @source_set = SourceSet.find(params[:id])
+    @source_set = SourceSet.friendly.find(params[:id])
   end
 
   def create
@@ -30,7 +30,7 @@ class SourceSetsController < ApplicationController
   end
 
   def update
-    @source_set = SourceSet.find(params[:id])
+    @source_set = SourceSet.friendly.find(params[:id])
 
     if @source_set.update(source_set_params)
       redirect_to @source_set
@@ -40,7 +40,7 @@ class SourceSetsController < ApplicationController
   end
 
   def destroy
-    @source_set = SourceSet.find(params[:id])
+    @source_set = SourceSet.friendly.find(params[:id])
     @source_set.destroy
 
     redirect_to source_sets_path

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -52,6 +52,6 @@ class SourcesController < ApplicationController
   end
 
   def load_source_set
-    @source_set = SourceSet.find(params[:source_set_id])
+    @source_set = SourceSet.friendly.find(params[:source_set_id])
   end
 end

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -1,6 +1,16 @@
 class SourceSet < ActiveRecord::Base
+  extend FriendlyId
   has_many :sources, dependent: :destroy
   has_many :guides, dependent: :destroy
   has_and_belongs_to_many :authors
   validates :name, presence: true
+  ##
+  # FriendlyId generates a human-readable slug to be used in the URL, in place
+  # of the ID.  The slug is automatically generated from the name field.
+  #
+  # Example:
+  #   SourceSet.create({ name: "Little My" }).slug = "little-my"
+  #   URL:  http://example.com/primary-source-sets/sets/little-my
+  #   To find this object: SourceSet.friendly.find("little-my")
+  friendly_id :name, use: :slugged
 end

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20150904190830_create_friendly_id_slugs.rb
+++ b/db/migrate/20150904190830_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20150904191008_source_sets_slug.rb
+++ b/db/migrate/20150904191008_source_sets_slug.rb
@@ -1,0 +1,7 @@
+class SourceSetsSlug < ActiveRecord::Migration
+  def change
+    change_table :source_sets do |t|
+      t.string :slug, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150829151317) do
+ActiveRecord::Schema.define(version: 20150904191008) do
 
   create_table "authors", force: true do |t|
     t.string   "name"
@@ -36,6 +36,19 @@ ActiveRecord::Schema.define(version: 20150829151317) do
   add_index "authors_source_sets", ["author_id"], name: "index_authors_source_sets_on_author_id"
   add_index "authors_source_sets", ["source_set_id"], name: "index_authors_source_sets_on_source_set_id"
 
+  create_table "friendly_id_slugs", force: true do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 50
+    t.string   "scope"
+    t.datetime "created_at"
+  end
+
+  add_index "friendly_id_slugs", ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+
   create_table "guides", force: true do |t|
     t.integer  "source_set_id"
     t.string   "name"
@@ -55,6 +68,7 @@ ActiveRecord::Schema.define(version: 20150829151317) do
     t.text     "resources",   limit: 65535
     t.datetime "created_at",                                null: false
     t.datetime "updated_at",                                null: false
+    t.string   "slug"
   end
 
   create_table "sources", force: true do |t|

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -117,7 +117,7 @@ describe GuidesController, type: :controller do
     it 'redirects to :index view' do
       guide
       delete :destroy, id: guide.id, source_set_id: source_set.id
-      expect(response).to redirect_to source_set_url
+      expect(response).to redirect_to source_set_path(source_set)
     end
   end
 end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -117,7 +117,7 @@ describe SourcesController, type: :controller do
     it 'redirects to :index view' do
       source
       delete :destroy, id: source.id, source_set_id: source_set.id
-      expect(response).to redirect_to source_set_url
+      expect(response).to redirect_to source_set_path(source_set)
     end
   end
 end

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -20,4 +20,8 @@ describe SourceSet, type: :model do
   it 'is invalid without name' do
     expect(SourceSet.new(name: nil)).not_to be_valid
   end
+
+  it 'has a slug' do
+    expect(SourceSet.create(name: 'Little My').slug).to eq 'little-my'
+  end
 end


### PR DESCRIPTION
This adds slugs to SourceSets with the [FriendlyId gem](https://github.com/norman/friendly_id).

The FriendlyId gem allows you to use human-readable ids in URLs, which is good for usability and SEO.  For example, instead of:

`http://dp.la/primary-source-sets/sets/82364`

you would get something like this:

`http://dp.la/primary-source-sets/sets/french-and-indian-war`

In this configuration, the name field for SourceSets is used to automatically generate the slug.