### PR TITLE
authorization with devise gem

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'turbolinks', '~> 2.5.3'
 gem 'config', '~> 1.0.0'
 gem 'redcarpet', '~> 3.3'
 gem 'friendly_id', '~> 5.1.0'
+gem 'devise', '3.4.1'
 
 group :test, :development do
   gem 'rspec-core', '~> 3.3.2'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :authenticate_admin!
 end

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -3,6 +3,7 @@
 #
 # @see Author
 class AuthorsController < ApplicationController
+
   def index
     @authors = Author.all
   end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,3 @@
+class Admin < ActiveRecord::Base
+  devise :database_authenticatable, :trackable, :validatable
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,12 +8,16 @@
 </head>
 <body>
 
-  <div id="admin-menu">
-    <%= link_to "Sets", source_sets_path %>
-    |
-    <%= link_to "Authors", authors_path %>
-    </ul>
-  </div>
+  <% if admin_signed_in? %>
+    <div id="admin-menu">
+      <%= link_to "Sets", source_sets_path %>
+      |
+      <%= link_to "Authors", authors_path %>
+      |
+      <%= link_to "Log out", destroy_admin_session_path, method: :delete %>
+      </ul>
+    </div>
+  <% end %>
 
 <%= yield %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,259 @@
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # config.secret_key = 'ee3de154b37d881c3f2f9c48ab23eb1b9b0f6063a541f5c5ea6498d0fa424c2b5bcea479eff315dd4a92e1c36167ee7a5c77636a78da4613cd0137c359da3e98'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = Settings.devise.mailer_sender
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [ :email ]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [ :email ]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [ :email ]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+  # using other encryptors, it sets how many times you want the password re-encrypted.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # encryptor), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 10
+
+  # Setup a pepper to generate the encrypted password.
+  # config.pepper = '8e41edc09e6a111a29bea3fca36538df733638fc3f4073177445b3554270ee59523f5ddb9d4a7ee80291eb0a5d508f5b2dba77b360ab80d30bcc291e1d5b7e11'
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [ :email ]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 8..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  # config.email_regexp = /\A[^@]+@[^@]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # If true, expires auth token on session timeout.
+  # config.expire_auth_token_on_timeout = false
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [ :email ]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [ :email ]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another encryption algorithm besides bcrypt (default). You can use
+  # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,
+  # :authlogic_sha512 (then you should set stretches above to 20 for default behavior)
+  # and :restful_authentication_sha1 (then you should set stretches to 10, and copy
+  # REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using omniauth, Devise cannot automatically set Omniauth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,60 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :admins
   resources :sets, controller: 'source_sets', as: 'source_sets' do
     resources :sources, only: [:new, :create, :edit, :update, :show, :destroy]
     resources :guides, only: [:new, :create, :edit, :update, :show, :destroy]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,13 @@
 # Information in this file will be PUBLIC (this file is tracked in git)
 # Declarations in config/settings.local.yml override declarations in this file
 
+devise: 
+  mailer_sender: email@example.org
+
 frontend:
   # With trailing slash
-  url: http://dp.la/
+  url: http://example.com
+
+host: 'localhost'
+
 relative_url_root: /primary-source-sets

--- a/db/migrate/20150904204928_devise_create_admins.rb
+++ b/db/migrate/20150904204928_devise_create_admins.rb
@@ -1,0 +1,42 @@
+class DeviseCreateAdmins < ActiveRecord::Migration
+  def change
+    create_table(:admins) do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps
+    end
+
+    add_index :admins, :email,                unique: true
+    add_index :admins, :reset_password_token, unique: true
+    # add_index :admins, :confirmation_token,   unique: true
+    # add_index :admins, :unlock_token,         unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904191008) do
+ActiveRecord::Schema.define(version: 20150904204928) do
+
+  create_table "admins", force: true do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "admins", ["email"], name: "index_admins_on_email", unique: true
+  add_index "admins", ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
 
   create_table "authors", force: true do |t|
     t.string   "name"

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -1,111 +1,119 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe AuthorsController, type: :controller do
 
-  let(:author) { FactoryGirl. create(:author_factory) }
+  let(:author) { FactoryGirl.create(:author_factory) }
 
-  describe '#index' do
-
-    it 'set @authors variable' do
-      get :index
-      expect(assigns(:authors)).to eq([author])
-    end
-
-    it 'renders the :index view' do
-      get :index
-      expect(response).to render_template :index
-    end
+  it_behaves_like 'admin-only route', :index, :show, :edit, :new do
+    let (:resource) { FactoryGirl.create(:author_factory) }
   end
 
-  describe '#show' do
+  context 'admin logged in' do
+    login_admin
 
-    it 'sets @author variable' do
-      get :show, id: author.id
-      expect(assigns(:author)).to eq(author)
+    describe '#index' do
+
+      it 'set @authors variable' do
+        get :index
+        expect(assigns(:authors)).to eq([author])
+      end
+
+      it 'renders the :index view' do
+        get :index
+        expect(response).to render_template :index
+      end
     end
 
-    it 'renders the :show view' do
-      get :show, id: author.id
-      expect(response).to render_template :show
-    end
-  end
+    describe '#show' do
 
-  describe '#create' do
+      it 'sets @author variable' do
+        get :show, id: author.id
+        expect(assigns(:author)).to eq(author)
+      end
 
-    it 'creates a new author' do
-      expect do
-        post :create, author: attributes_for(:author_factory)
-      end.to change(Author, :count).by(1)
-    end
-
-    it 'redirects to the new author' do
-      post :create, author: attributes_for(:author_factory)
-      expect(response).to redirect_to Author.last
+      it 'renders the :show view' do
+        get :show, id: author.id
+        expect(response).to render_template :show
+      end
     end
 
-    context 'with invalid attributes' do
+    describe '#create' do
 
-      it 'does not save new author' do
+      it 'creates a new author' do
         expect do
+          post :create, author: attributes_for(:author_factory)
+        end.to change(Author, :count).by(1)
+      end
+
+      it 'redirects to the new author' do
+        post :create, author: attributes_for(:author_factory)
+        expect(response).to redirect_to Author.last
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not save new author' do
+          expect do
+            post :create, author: attributes_for(:invalid_author_factory)
+          end.to_not change(Author, :count)
+        end
+
+        it 're-renders :new view' do
           post :create, author: attributes_for(:invalid_author_factory)
-        end.to_not change(Author, :count)
-      end
-
-      it 're-renders :new view' do
-        post :create, author: attributes_for(:invalid_author_factory)
-        expect(response).to render_template :new
+          expect(response).to render_template :new
+        end
       end
     end
-  end
 
-  describe '#update' do
+    describe '#update' do
 
-    it 'updates the author' do
-      author
-      patch :update, id: author.id, author: { name: 'New name' }
-      author.reload
-      expect(author.name).to eq('New name')
-    end
-
-    it 'redirects to the updated author' do
-      patch :update, id: author.id, author: { name: 'New name' }
-      expect(response).to redirect_to author
-    end
-
-    context 'with invalid attributes' do
-
-      it 'does not update the author' do
+      it 'updates the author' do
         author
-        valid_name = author.name
-        patch :update,
-              id: author.id,
-              author: attributes_for(:invalid_author_factory)
+        patch :update, id: author.id, author: { name: 'New name' }
         author.reload
-        expect(author.name).to eq(valid_name)
+        expect(author.name).to eq('New name')
       end
 
-      it 're-renders :edit view' do
-        patch :update,
-              id: author.id,
-              author: attributes_for(:invalid_author_factory)
-        expect(:response).to render_template :edit
+      it 'redirects to the updated author' do
+        patch :update, id: author.id, author: { name: 'New name' }
+        expect(response).to redirect_to author
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not update the author' do
+          author
+          valid_name = author.name
+          patch :update,
+                id: author.id,
+                author: attributes_for(:invalid_author_factory)
+          author.reload
+          expect(author.name).to eq(valid_name)
+        end
+
+        it 're-renders :edit view' do
+          patch :update,
+                id: author.id,
+                author: attributes_for(:invalid_author_factory)
+          expect(:response).to render_template :edit
+        end
       end
     end
-  end
 
-  describe '#destroy' do
+    describe '#destroy' do
 
-    it 'deletes the author' do
-      author
-      expect do
+      it 'deletes the author' do
+        author
+        expect do
+          delete :destroy, id: author.id
+        end.to change(Author, :count).by(-1)
+      end
+
+      it 'redirects to :index view' do
+        author
         delete :destroy, id: author.id
-      end.to change(Author, :count).by(-1)
-    end
-
-    it 'redirects to :index view' do
-      author
-      delete :destroy, id: author.id
-      expect(response).to redirect_to authors_url
+        expect(response).to redirect_to authors_url
+      end
     end
   end
 end

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -1,123 +1,132 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe GuidesController, type: :controller do
 
   let(:guide) { FactoryGirl.create(:guide_factory) }
   let(:source_set) { guide.source_set }
 
-  describe '#show' do
-
-    it 'sets @guide variable' do
-      get :show, id: guide.id, source_set_id: source_set.id
-      expect(assigns(:guide)).to eq(guide)
-    end
-
-    it 'sets @source_set variable' do
-      get :show, id: guide.id, source_set_id: source_set.id
-      expect(assigns(:source_set)).to eq(source_set)
-    end
-
-    it 'renders the :show view' do
-      get :show, id: guide.id, source_set_id: source_set.id
-      expect(response).to render_template :show
-    end
+  it_behaves_like 'admin-only route', :show, :new, :edit do
+    let(:resource) { FactoryGirl.create(:guide_factory) }
+    let(:request_params) { { source_set_id: resource.source_set.id } }
   end
 
-  describe '#create' do
+  context 'admin logged in' do
+    login_admin
 
-    it 'creates a new guide' do
-      source_set
-      expect do
-        post :create,
-             source_set_id: source_set.id,
-             guide: attributes_for(:guide_factory)
-      end.to change(source_set.guides, :count).by(1)
+    describe '#show' do
+
+      it 'sets @guide variable' do
+        get :show, id: guide.id, source_set_id: source_set.id
+        expect(assigns(:guide)).to eq(guide)
+      end
+
+      it 'sets @source_set variable' do
+        get :show, id: guide.id, source_set_id: source_set.id
+        expect(assigns(:source_set)).to eq(source_set)
+      end
+
+      it 'renders the :show view' do
+        get :show, id: guide.id, source_set_id: source_set.id
+        expect(response).to render_template :show
+      end
     end
 
-    it 'redirects to the new guide' do
-      source_set
-      post :create,
-           source_set_id: source_set.id,
-           guide: attributes_for(:guide_factory)
-      expect(response).to redirect_to [source_set, Guide.last]
-    end
+    describe '#create' do
 
-    context 'with invalid attributes' do
-
-      it 'does not save new guide' do
+      it 'creates a new guide' do
         source_set
         expect do
           post :create,
                source_set_id: source_set.id,
-               guide: attributes_for(:invalid_guide_factory)
-        end.to_not change(source_set.guides, :count)
+               guide: attributes_for(:guide_factory)
+        end.to change(source_set.guides, :count).by(1)
       end
 
-      it 're-renders :new view' do
+      it 'redirects to the new guide' do
+        source_set
         post :create,
              source_set_id: source_set.id,
-             guide: attributes_for(:invalid_guide_factory)
-        expect(response).to render_template :new
+             guide: attributes_for(:guide_factory)
+        expect(response).to redirect_to [source_set, Guide.last]
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not save new guide' do
+          source_set
+          expect do
+            post :create,
+                 source_set_id: source_set.id,
+                 guide: attributes_for(:invalid_guide_factory)
+          end.to_not change(source_set.guides, :count)
+        end
+
+        it 're-renders :new view' do
+          post :create,
+               source_set_id: source_set.id,
+               guide: attributes_for(:invalid_guide_factory)
+          expect(response).to render_template :new
+        end
       end
     end
-  end
 
-  describe '#update' do
+    describe '#update' do
 
-    it 'updates the guide' do
-      guide
-      patch :update,
-            id: guide.id,
-            source_set_id: source_set.id,
-            guide: { name: 'New name' }
-      guide.reload
-      expect(guide.name).to eq('New name')
-    end
-
-    it 'redirects to the updated guide' do
-      patch :update,
-            id: guide.id,
-            source_set_id: source_set.id,
-            guide: { name: 'New name' }
-      expect(response).to redirect_to [source_set, guide]
-    end
-
-    context 'with invalid attributes' do
-
-      it 'does not update the guide' do
+      it 'updates the guide' do
         guide
-        valid_name = guide.name
         patch :update,
               id: guide.id,
               source_set_id: source_set.id,
-              guide: attributes_for(:invalid_guide_factory)
+              guide: { name: 'New name' }
         guide.reload
-        expect(guide.name).to eq(valid_name)
+        expect(guide.name).to eq('New name')
       end
 
-      it 're-renders :edit view' do
+      it 'redirects to the updated guide' do
         patch :update,
               id: guide.id,
               source_set_id: source_set.id,
-              guide: attributes_for(:invalid_guide_factory)
-        expect(:response).to render_template :edit
+              guide: { name: 'New name' }
+        expect(response).to redirect_to [source_set, guide]
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not update the guide' do
+          guide
+          valid_name = guide.name
+          patch :update,
+                id: guide.id,
+                source_set_id: source_set.id,
+                guide: attributes_for(:invalid_guide_factory)
+          guide.reload
+          expect(guide.name).to eq(valid_name)
+        end
+
+        it 're-renders :edit view' do
+          patch :update,
+                id: guide.id,
+                source_set_id: source_set.id,
+                guide: attributes_for(:invalid_guide_factory)
+          expect(:response).to render_template :edit
+        end
       end
     end
-  end
 
-  describe '#destroy' do
+    describe '#destroy' do
 
-    it 'deletes the guide' do
-      guide
-      expect do
+      it 'deletes the guide' do
+        guide
+        expect do
+          delete :destroy, id: guide.id, source_set_id: source_set.id
+        end.to change(source_set.guides, :count).by(-1)
+      end
+
+      it 'redirects to :index view' do
+        guide
         delete :destroy, id: guide.id, source_set_id: source_set.id
-      end.to change(source_set.guides, :count).by(-1)
-    end
-
-    it 'redirects to :index view' do
-      guide
-      delete :destroy, id: guide.id, source_set_id: source_set.id
-      expect(response).to redirect_to source_set_path(source_set)
+        expect(response).to redirect_to source_set_path(source_set)
+      end
     end
   end
 end

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -1,111 +1,119 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe SourceSetsController, type: :controller do
 
-  let(:source_set) { FactoryGirl. create(:source_set_factory) }
+  let(:source_set) { FactoryGirl.create(:source_set_factory) }
 
-  describe '#index' do
-
-    it 'set @source_sets variable' do
-      get :index
-      expect(assigns(:source_sets)).to eq([source_set])
-    end
-
-    it 'renders the :index view' do
-      get :index
-      expect(response).to render_template :index
-    end
+  it_behaves_like "admin-only route", :index, :show, :new, :edit do
+    let(:resource) { FactoryGirl.create(:source_set_factory) }
   end
 
-  describe '#show' do
+  context 'admin logged in' do
+    login_admin
 
-    it 'sets @source_set variable' do
-      get :show, id: source_set.id
-      expect(assigns(:source_set)).to eq(source_set)
+    describe '#index' do
+
+      it 'set @source_sets variable' do
+        get :index
+        expect(assigns(:source_sets)).to eq([source_set])
+      end
+
+      it 'renders the :index view' do
+        get :index
+        expect(response).to render_template :index
+      end
     end
 
-    it 'renders the :show view' do
-      get :show, id: source_set.id
-      expect(response).to render_template :show
-    end
-  end
+    describe '#show' do
 
-  describe '#create' do
+      it 'sets @source_set variable' do
+        get :show, id: source_set.id
+        expect(assigns(:source_set)).to eq(source_set)
+      end
 
-    it 'creates a new source set' do
-      expect do
-        post :create, source_set: attributes_for(:source_set_factory)
-      end.to change(SourceSet, :count).by(1)
-    end
-
-    it 'redirects to the new source set' do
-      post :create, source_set: attributes_for(:source_set_factory)
-      expect(response).to redirect_to SourceSet.last
+      it 'renders the :show view' do
+        get :show, id: source_set.id
+        expect(response).to render_template :show
+      end
     end
 
-    context 'with invalid attributes' do
+    describe '#create' do
 
-      it 'does not save new source set' do
+      it 'creates a new source set' do
         expect do
+          post :create, source_set: attributes_for(:source_set_factory)
+        end.to change(SourceSet, :count).by(1)
+      end
+
+      it 'redirects to the new source set' do
+        post :create, source_set: attributes_for(:source_set_factory)
+        expect(response).to redirect_to SourceSet.last
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not save new source set' do
+          expect do
+            post :create, source_set: attributes_for(:invalid_source_set_factory)
+          end.to_not change(SourceSet, :count)
+        end
+
+        it 're-renders :new view' do
           post :create, source_set: attributes_for(:invalid_source_set_factory)
-        end.to_not change(SourceSet, :count)
-      end
-
-      it 're-renders :new view' do
-        post :create, source_set: attributes_for(:invalid_source_set_factory)
-        expect(response).to render_template :new
+          expect(response).to render_template :new
+        end
       end
     end
-  end
 
-  describe '#update' do
+    describe '#update' do
 
-    it 'updates the source set' do
-      source_set
-      patch :update, id: source_set.id, source_set: { name: 'New name' }
-      source_set.reload
-      expect(source_set.name).to eq('New name')
-    end
-
-    it 'redirects to the updated source set' do
-      patch :update, id: source_set.id, source_set: { name: 'New name' }
-      expect(response).to redirect_to source_set
-    end
-
-    context 'with invalid attributes' do
-
-      it 'does not update the source set' do
+      it 'updates the source set' do
         source_set
-        valid_name = source_set.name
-        patch :update,
-              id: source_set.id,
-              source_set: attributes_for(:invalid_source_set_factory)
+        patch :update, id: source_set.id, source_set: { name: 'New name' }
         source_set.reload
-        expect(source_set.name).to eq(valid_name)
+        expect(source_set.name).to eq('New name')
       end
 
-      it 're-renders :edit view' do
-        patch :update,
-              id: source_set.id,
-              source_set: attributes_for(:invalid_source_set_factory)
-        expect(:response).to render_template :edit
+      it 'redirects to the updated source set' do
+        patch :update, id: source_set.id, source_set: { name: 'New name' }
+        expect(response).to redirect_to source_set
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not update the source set' do
+          source_set
+          valid_name = source_set.name
+          patch :update,
+                id: source_set.id,
+                source_set: attributes_for(:invalid_source_set_factory)
+          source_set.reload
+          expect(source_set.name).to eq(valid_name)
+        end
+
+        it 're-renders :edit view' do
+          patch :update,
+                id: source_set.id,
+                source_set: attributes_for(:invalid_source_set_factory)
+          expect(:response).to render_template :edit
+        end
       end
     end
-  end
 
-  describe '#destroy' do
+    describe '#destroy' do
 
-    it 'deletes the source set' do
-      source_set
-      expect do
+      it 'deletes the source set' do
+        source_set
+        expect do
+          delete :destroy, id: source_set.id
+        end.to change(SourceSet, :count).by(-1)
+      end
+
+      it 'redirects to :index view' do
+        source_set
         delete :destroy, id: source_set.id
-      end.to change(SourceSet, :count).by(-1)
-    end
-
-    it 'redirects to :index view' do
-      source_set
-      delete :destroy, id: source_set.id
-      expect(response).to redirect_to source_sets_url
+        expect(response).to redirect_to source_sets_url
+      end
     end
   end
 end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -1,123 +1,132 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe SourcesController, type: :controller do
 
   let(:source) { FactoryGirl.create(:source_factory) }
   let(:source_set) { source.source_set }
 
-  describe '#show' do
-
-    it 'sets @source variable' do
-      get :show, id: source.id, source_set_id: source_set.id
-      expect(assigns(:source)).to eq(source)
-    end
-
-    it 'sets @source_set variable' do
-      get :show, id: source.id, source_set_id: source_set.id
-      expect(assigns(:source_set)).to eq(source_set)
-    end
-
-    it 'renders the :show view' do
-      get :show, id: source.id, source_set_id: source_set.id
-      expect(response).to render_template :show
-    end
+  it_behaves_like "admin-only route", :show, :new, :edit do
+    let(:resource) { FactoryGirl.create(:source_factory) }
+    let(:request_params) { { source_set_id: resource.source_set.id } }
   end
 
-  describe '#create' do
+  context 'admin logged in' do
+    login_admin
 
-    it 'creates a new source' do
-      source_set
-      expect do
-        post :create,
-             source_set_id: source_set.id,
-             source: attributes_for(:source_factory)
-      end.to change(source_set.sources, :count).by(1)
+    describe '#show' do
+
+      it 'sets @source variable' do
+        get :show, id: source.id, source_set_id: source_set.id
+        expect(assigns(:source)).to eq(source)
+      end
+
+      it 'sets @source_set variable' do
+        get :show, id: source.id, source_set_id: source_set.id
+        expect(assigns(:source_set)).to eq(source_set)
+      end
+
+      it 'renders the :show view' do
+        get :show, id: source.id, source_set_id: source_set.id
+        expect(response).to render_template :show
+      end
     end
 
-    it 'redirects to the new source' do
-      source_set
-      post :create,
-           source_set_id: source_set.id,
-           source: attributes_for(:source_factory)
-      expect(response).to redirect_to [source_set, Source.last]
-    end
+    describe '#create' do
 
-    context 'with invalid attributes' do
-
-      it 'does not save new source' do
+      it 'creates a new source' do
         source_set
         expect do
           post :create,
                source_set_id: source_set.id,
-               source: attributes_for(:invalid_source_factory)
-        end.to_not change(source_set.sources, :count)
+               source: attributes_for(:source_factory)
+        end.to change(source_set.sources, :count).by(1)
       end
 
-      it 're-renders :new view' do
+      it 'redirects to the new source' do
+        source_set
         post :create,
              source_set_id: source_set.id,
-             source: attributes_for(:invalid_source_factory)
-        expect(response).to render_template :new
+             source: attributes_for(:source_factory)
+        expect(response).to redirect_to [source_set, Source.last]
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not save new source' do
+          source_set
+          expect do
+            post :create,
+                 source_set_id: source_set.id,
+                 source: attributes_for(:invalid_source_factory)
+          end.to_not change(source_set.sources, :count)
+        end
+
+        it 're-renders :new view' do
+          post :create,
+               source_set_id: source_set.id,
+               source: attributes_for(:invalid_source_factory)
+          expect(response).to render_template :new
+        end
       end
     end
-  end
 
-  describe '#update' do
+    describe '#update' do
 
-    it 'updates the source' do
-      source
-      patch :update,
-            id: source.id,
-            source_set_id: source_set.id,
-            source: { name: 'New name' }
-      source.reload
-      expect(source.name).to eq('New name')
-    end
-
-    it 'redirects to the updated source' do
-      patch :update,
-            id: source.id,
-            source_set_id: source_set.id,
-            source: { name: 'New name' }
-      expect(response).to redirect_to [source_set, source]
-    end
-
-    context 'with invalid attributes' do
-
-      it 'does not update the source' do
+      it 'updates the source' do
         source
-        valid_aggregation = source.aggregation
         patch :update,
               id: source.id,
               source_set_id: source_set.id,
-              source: attributes_for(:invalid_source_factory)
+              source: { name: 'New name' }
         source.reload
-        expect(source.aggregation).to eq(valid_aggregation)
+        expect(source.name).to eq('New name')
       end
 
-      it 're-renders :edit view' do
+      it 'redirects to the updated source' do
         patch :update,
               id: source.id,
               source_set_id: source_set.id,
-              source: attributes_for(:invalid_source_factory)
-        expect(:response).to render_template :edit
+              source: { name: 'New name' }
+        expect(response).to redirect_to [source_set, source]
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not update the source' do
+          source
+          valid_aggregation = source.aggregation
+          patch :update,
+                id: source.id,
+                source_set_id: source_set.id,
+                source: attributes_for(:invalid_source_factory)
+          source.reload
+          expect(source.aggregation).to eq(valid_aggregation)
+        end
+
+        it 're-renders :edit view' do
+          patch :update,
+                id: source.id,
+                source_set_id: source_set.id,
+                source: attributes_for(:invalid_source_factory)
+          expect(:response).to render_template :edit
+        end
       end
     end
-  end
 
-  describe '#destroy' do
+    describe '#destroy' do
 
-    it 'deletes the source' do
-      source
-      expect do
+      it 'deletes the source' do
+        source
+        expect do
+          delete :destroy, id: source.id, source_set_id: source_set.id
+        end.to change(source_set.sources, :count).by(-1)
+      end
+
+      it 'redirects to :index view' do
+        source
         delete :destroy, id: source.id, source_set_id: source_set.id
-      end.to change(source_set.sources, :count).by(-1)
-    end
-
-    it 'redirects to :index view' do
-      source
-      delete :destroy, id: source.id, source_set_id: source_set.id
-      expect(response).to redirect_to source_set_path(source_set)
+        expect(response).to redirect_to source_set_path(source_set)
+      end
     end
   end
 end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :admin do
+    email 'test@example.org'
+    password 'password'
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe ApplicationHelper, type: :helper do
    

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe Author, type: :model do
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe Guide, type: :model do
 

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe SourceSet, type: :model do
 

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe Source, type: :model do
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,19 @@
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'spec_helper'
+require 'rspec/rails'
+require 'factory_girl_rails'
+
+# Checks for pending migrations before tests are run.
+# If you are not using ActiveRecord, you can remove this line.
+ActiveRecord::Migration.maintain_test_schema!
+
+RSpec.configure do |config|
+  config.infer_spec_type_from_file_location!
+  config.include FactoryGirl::Syntax::Methods
+
+  # use_transactional_fixtures is false to comply with database cleaner configs
+  config.use_transactional_fixtures = false
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
-require 'rspec/rails'
-require 'factory_girl_rails'
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
@@ -10,9 +8,4 @@ RSpec.configure do |config|
   config.color = true
   config.formatter = :progress
   config.mock_with :rspec
-
-  config.include FactoryGirl::Syntax::Methods
-
-  # use_transactional_fixtures is false to comply with database cleaner configs
-  config.use_transactional_fixtures = false
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,13 @@
+## Common functions to be used in controller tests
+module ControllerMacros
+  def login_admin
+    before(:each) do
+      admin = FactoryGirl.create(:admin)
+      sign_in admin
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.extend ControllerMacros, type: :controller
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -19,5 +19,4 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
-
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,5 @@
+require 'rspec/rails'
+
+RSpec.configure do |config|
+  config.include Devise::TestHelpers, type: :controller
+end

--- a/spec/support/shared_examples/admin_only_route.rb
+++ b/spec/support/shared_examples/admin_only_route.rb
@@ -1,0 +1,35 @@
+##
+# This tests GET Controller routes and expects them to redirect to the admin
+# login path.
+
+# @param routes Symbol the actions for this controller that are admin-only.
+#
+# The example can be passed a block that defines resource and/or request_params.
+# resource should be a factory with an id that will be used to construct routes.
+# request_params should be a Hash of params (not including :id).
+#
+# @example:
+#   it_behaves_like 'admin-only route', :index, :show, :edit, :new do
+#     let (:resource) { FactoryGirl.create(:guide_factory) }
+#     let (:request_params) { source_set: resource.source_set.id }
+#   end
+shared_examples 'admin-only route' do |*actions|
+
+  let(:admin_login_path) do
+    # This route is concatenated in this way because the path helpers for
+    # devise are not incorportating the relative url root.
+    "#{root_url}#{Settings.relative_url_root.gsub('/', '')}/admins/sign_in"
+  end
+
+  actions.each do |action|
+
+    it "redirects #{action} to admin login" do
+      params = {}
+      params[:id] = resource.id if defined?(resource)
+      params.merge!(request_params) if defined?(request_params)
+
+      get action, params
+      expect(response).to redirect_to admin_login_path
+    end
+  end
+end


### PR DESCRIPTION
This feature adds basic authorization to the app with the [Devise gem](https://github.com/plataformatec/devise).

Authentication is needed for this app so that admins (ie. DPLA staff) can log in to perform CRUD actions in the database.  After our initial launch in October, non-logged-in users will be able to view sets, sources, and guides; but until launch, only admins should have the ability to access any part of the application.  So for now, I added `before_action :authenticate_admin!` to the `ApplicationController`.  When we launch in October, this will need to change.

I kept most of the default Devise settings, expressed in the database migration, `config/initializers/devise.rb` and `config/locales/devise.en.yml`.  One exception is that I added the DPLA email address in [line 13](`config/initializers/devise.rb`) of `config/initializers/devise.rb`.

The setting for the `Admin` model are very simple.  I am double-checking with Franky, but I think we only need one admin account that DPLA staff members can share, and its easy to make a new account from the command line.  So there is log-in and log-out capability from the app interfaces, but there is NOT ability to make a new account or reset a password.  We can always add these things in later if we decide we need them.

I made some spec settings changes to work with Devise: see `spec/support/devise.rb` and `spec/support/controller_macros.rb` and the new factory, `spec/factories/admins.rb`.  Although there appears to be a lot of changes to the existing specs, it's really just nesting all of the existing tests within a `context` block that logs in the admin.

I was also getting some errors with the rspec that I fixed by adding `.rspec` and `spec/rails_helper.rb`.  These files are auto-generated with you do `rails generate rspec:install`, which up to now I had neglected to do.