### PR TITLE
temporal, citation, and provenance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,6 @@ group :test, :development do
   gem 'awesome_print', '~> 1.2.0'
   gem 'codeclimate-test-reporter', '~> 0.4.7', require: false
   gem 'database_cleaner', '~> 1.3.0', require: false
+
+  gem 'json-ld', '~>1.1.9'
 end

--- a/etc/PrimarySourceDataModelSample.json
+++ b/etc/PrimarySourceDataModelSample.json
@@ -4,8 +4,7 @@
     {
       "ore": "http://www.openarchives.org/ore/terms/",
       "dct": "http://purl.org/dc/terms/",
-      "text":
-      {
+      "text": {
         "@id": "http://schema.org/text",
         "@type": "http://ns.ontowiki.net/SysOnt/Markdown"
       }
@@ -21,6 +20,11 @@
   "dct:references": {
     "@id": "http://dp.la/item/87037c8c0dc514bfd19bddbce9ff2ce7",
     "@type": "ore:Aggregation"
+  },
+  "dct:citation": "Washington, George. *The journal of Major George Washington.* Chicago: The Newberry Library, 1958. Page 53.",
+  "dct:provenance": {
+    "@type": "dct:ProvenanceStatement",
+    "name": "Courtesy of The Univeristy of Michigan via HathiTrust"
   },
   "text": "Excerpt from Wednesday, October 31st, 1753:\n\"I was comissioned and appointed by the Honourable Robert Dinwidde, Esq; Governor, etc. of Virginia to visit and deliver a Letter to the Commandant of the French Forces on the Hioin, and set out on the indended Journey the same day ; and proceeded with him to Alexandria, where we provided Necessaries ; from thence we went to Winchester, and got Baggage, Horses, etc., and from thence we pursued the new Road to Wills-Creek, where we arrive the 14th of November.\""
 }

--- a/etc/PrimarySourceSetDataModelSample.json
+++ b/etc/PrimarySourceSetDataModelSample.json
@@ -43,7 +43,13 @@
     }
   ],
   "dct:temporal": [
-    { "name": "Colonial America" }
+    { 
+      "@id": "ushist:united-states-era-2",
+      "@type": "dct:PeriodOfTime",
+      "name": "Colonization & Settlement (1585-1763)",
+      "start": "1585",
+      "end": "1763",
+    }
   ],
   "description": "This collection uses primary sources to explore the French and Indian War.",
   "author": [

--- a/etc/PrimarySourceSetDataModelSample.json
+++ b/etc/PrimarySourceSetDataModelSample.json
@@ -5,6 +5,7 @@
       "ccss": "http://www.corestandards.org/",
       "dct": "http://purl.org/dc/terms/",
       "dcmitype": "http://purl.org/dc/dcmitype/",
+      "edm": "http://www.europeana.eu/schemas/edm",
       "text":
       {
         "@id": "http://schema.org/text",
@@ -45,10 +46,10 @@
   "dct:temporal": [
     { 
       "@id": "ushist:united-states-era-2",
-      "@type": "dct:PeriodOfTime",
+      "@type": "edm:TimeSpan",
       "name": "Colonization & Settlement (1585-1763)",
-      "start": "1585",
-      "end": "1763",
+      "edm:begin": "1585",
+      "edm:end": "1763"
     }
   ],
   "description": "This collection uses primary sources to explore the French and Indian War.",

--- a/spec/lint_samples_spec.rb
+++ b/spec/lint_samples_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'sample json-ld' do
+  Dir["etc/*.json"].each do |json_file|
+    describe "#{json_file}" do
+      let(:input) { JSON.load(File.open(json_file)) }
+      let(:graph) { RDF::Graph.new << JSON::LD::API.toRdf(input) }
+
+      it 'is valid json' do
+        expect { input }.not_to raise_error
+      end
+
+      it 'is valid json-ld' do
+        expect(graph).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds citation and provenance metadata to the `Source` class, and adds more detailed temporal metadata.  These changes are motivated by conversations I've had with FA.

Although the citation and provenance metadata is accessible by linking to the ore:Aggregation, we want to include it here so that if the ore:Aggregation disappears, as they sometimes do, we can retain the information here.

FA has decided that for the primary source sets time periods, she is going to use the [US History Content Standards eras](http://www.nchs.ucla.edu/history-standards/us-history-content-standards). Since we now have time periods with start and end dates, I took a stab at representing them using DC's PeriodOfTime class. 

A particular concern is this: As far as I know, the US History Content Standards do not have an RDF expression (maybe worth double-checking).  So, the URL that I used for @id is not any sort of official RDF URI, it's just the web page where the info exists.  Is that a legit way of representing that this time period term comes from a standardized vocabulary?  Is there a better way? 