### PR TITLE
tighen gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,32 +1,32 @@
 source 'https://rubygems.org'
 
-gem 'rails', '4.1.6'
-gem 'sqlite3'
+gem 'rails', '~> 4.1.6'
+gem 'sqlite3', '~> 1.3.8'
 gem 'pg', '0.18.2'
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '~> 2.7.1'
 gem 'coffee-rails', '~> 4.0.0'
-gem 'therubyracer',  platforms: :ruby
+gem 'therubyracer',  '~> 0.12.2', platforms: :ruby
 gem 'sass-rails', '~> 4.0.3'
-gem 'jquery-rails'
-gem 'turbolinks'
+gem 'jquery-rails', '~> 3.1.3'
+gem 'turbolinks', '~> 2.5.3'
 gem 'config', '~> 1.0.0'
 gem 'redcarpet', '~> 3.3'
 gem 'friendly_id', '~> 5.1.0'
 
 group :test, :development do
-  gem 'rspec-core', '~>3.1'
-  gem 'rspec-rails', '~>3.1'
-  gem 'factory_girl_rails'
-  gem 'pry'
-  gem 'pry-doc'
-  gem 'pry-rails'
-  gem 'awesome_print'
-  gem 'codeclimate-test-reporter', require: false
+  gem 'rspec-core', '~> 3.3.2'
+  gem 'rspec-rails', '~> 3.3.3'
+  gem 'factory_girl_rails', '~> 4.4.0'
+  gem 'pry', '~> 0.10.1'
+  gem 'pry-doc', '~> 0.8.0'
+  gem 'pry-rails', '~> 0.3.4'
+  gem 'awesome_print', '~> 1.2.0'
+  gem 'codeclimate-test-reporter', '~> 0.4.7', require: false
   gem 'database_cleaner', '~> 1.3.0', require: false
 end
 
-gem 'breadcrumbs_on_rails'
-gem 'meta-tags'
-gem 'httparty'
+gem 'breadcrumbs_on_rails', '~> 2.3.0'
+gem 'meta-tags', '~> 2.0.0'
+gem 'httparty', '~> 0.11.0'
 gem 'devise', '3.4.1'
 gem 'unicorn', '4.8.3'


### PR DESCRIPTION
This introduces versions for all gems.  It changes the dependency on `rails` from `4.1.6` to `~> 4.1.6`.  Whenever it does not conflict with the current `Gemfile.lock`, versions of gems match either the `heidrun` or `frontend` app.