### PR TITLE
add markdown fields

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,37 @@ module ApplicationHelper
       .html_safe
   end
 
+  ##
+  # @param String text A markdown formatted String
+  # @return String An HTML representation of the markdown string given in 'text'
+  # without enclosing <p> tags.
+  # @raise TypeError if @param is not a String
+  def inline_markdown(text)
+    strip_p_tags(markdown(text))
+  end
+
   def source_name(source)
     source.name.present? ? source.name : source.aggregation
+  end
+
+  private
+
+  ##
+  # This strips enclosing <p> tags from an HTML formatted String.
+  #
+  # @param String html An HTML formatted String
+  # @return String An HTML fomratted String
+  #
+  # This is intended for HTML-formatted Strings that were rendered from markdown
+  # with the Redcarpet gem.  Redcarpet automatically encloses all markdown-
+  # formatted Strings in <p> tags, which need to be stripped for inline
+  # elements.
+  # As a sanity check, if a String has internal <p> tags, the enclosing <p> tags
+  # are not stripped.
+  def strip_p_tags(html)
+    match = Regexp.new('^<p>(.*)<\/p>$').match(html)
+    return html unless match.present?
+    return html if match[1].include?("<p>") || match[1].include?("</p>")
+    match[1].html_safe
   end
 end

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -4,7 +4,7 @@
     <div id="error_explanation">
       <h2>
         <%= pluralize(@author.errors.count, "error") %> prohibited
-        this set from being saved:
+        this author from being saved:
       </h2>
       <ul>
         <% @author.errors.full_messages.each do |msg| %>

--- a/app/views/authors/edit.html.erb
+++ b/app/views/authors/edit.html.erb
@@ -5,6 +5,6 @@
   |
   <%= link_to "Delete", author_path(@author),
             method: :delete,
-            data: { confirm: "Are you sure you want to delete #{@author.name}?" } %></p>
+            data: { confirm: "Are you sure you want to delete this author?" } %></p>
  
 <%= render "form" %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -21,13 +21,13 @@
 <h2>Sets</h2>
 <ul>
 <% @author.source_sets.each do |source_set| %>
-  <li><%= link_to source_set.name, source_set_path(source_set) %></li>
+  <li><%= link_to inline_markdown(source_set.name), source_set_path(source_set) %></li>
 <% end %>
 </ul>
 
 <h2>Teaching guides</h2>
 <ul>
   <% @author.guides.each do |guide| %>
-    <li><%= link_to guide.name, guide_path(guide) %></li>
+    <li><%= link_to inline_markdown(guide.name), guide_path(guide) %></li>
   <% end %>
 </ul>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -4,7 +4,7 @@
     <div id="error_explanation">
       <h2>
         <%= pluralize(@guide.errors.count, "error") %> prohibited
-        this set from being saved:
+        this guide from being saved:
       </h2>
       <ul>
         <% @guide.errors.full_messages.each do |msg| %>
@@ -16,6 +16,7 @@
 
   <p>
     <strong><%= f.label "Name (required)" %></strong><br/>
+    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
 

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -5,9 +5,9 @@
   |
   <%= link_to "Delete", 
                guide_path(@guide), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{@guide.name}?" } %>
+               data: { confirm: "Are you sure you want to delete this guide?" } %>
 </p>
 
-<p>This guide belongs to <%= link_to @guide.source_set.name, source_set_path(@guide.source_set) %></p>
+<p>This guide belongs to <%= link_to inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set) %></p>
 
 <%= render "form" %>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,5 +1,5 @@
-<p><%= link_to "Back to #{@source_set.name}", source_set_path(@source_set) %></p>
+<p><%= link_to "Back to set", source_set_path(@source_set) %></p>
 
-<h1>New teaching guide for <%= @source_set.name %></h1>
+<h1>New teaching guide for <%= inline_markdown(@source_set.name) %></h1>
 
 <%= render "form" %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,21 +1,21 @@
-<h1>Teaching guide: <%= @guide.name %></h1>
+<h1>Teaching guide: <%= inline_markdown(@guide.name) %></h1>
 
 <p>
   <%= link_to "Edit", edit_guide_path(@guide) %>
   |
   <%= link_to "Delete", 
                guide_path(@guide), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{@guide.name}?" } %>
+               data: { confirm: "Are you sure you want to delete this guide?" } %>
 </p>
 
 <table>
   <tr>
     <td><strong>Set </strong></td>
-    <td><%= link_to @guide.source_set.name, source_set_path(@guide.source_set)%></td>
+    <td><%= link_to inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set)%></td>
   </tr>
   <tr>
     <td><strong>Name </strong></td>
-    <td><%= @guide.name %></td>
+    <td><%= inline_markdown(@guide.name) %></td>
   </tr>
   <tr>
     <td><strong>Questions </strong></td>
@@ -28,7 +28,7 @@
   <% @guide.authors.each do |author| %>
     <tr>
       <td><strong>Author </strong></td>
-      <td><%= author.name %></td>
+      <td><%= link_to author.name, author_path(author) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -16,6 +16,7 @@
  
   <p>
     <strong><%= f.label "Name (required)" %></strong><br/>
+    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
  

--- a/app/views/source_sets/edit.html.erb
+++ b/app/views/source_sets/edit.html.erb
@@ -5,7 +5,7 @@
   |
   <%= link_to "Delete", source_set_path(@source_set),
             method: :delete,
-            data: { confirm: "Are you sure you want to delete #{@source_set.name}?" } %>
+            data: { confirm: "Are you sure you want to delete this set?" } %>
 </p>
  
 <%= render "form" %>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -5,7 +5,7 @@
 <table>
 <% @source_sets.each do |set| %>
   <tr>
-    <td><%= set.name %></td>
+    <td><%= inline_markdown(set.name) %></td>
     <td><%= link_to "View", source_set_path(set) %></td>
     <td><%= link_to "Edit", edit_source_set_path(set) %></td>
     <td><%= link_to "Delete", source_set_path(set),

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -1,16 +1,16 @@
-<h1>Set: <%= @source_set.name %></h1>
+<h1>Set: <%= inline_markdown(@source_set.name) %></h1>
 
 <p>
   <%= link_to "Edit", edit_source_set_path(@source_set) %>
   |
   <%= link_to "Delete", source_set_path(@source_set), method: :delete,
-                 data: { confirm: "Are you sure you want to delete #{@source_set.name}?" } %>
+                 data: { confirm: "Are you sure you want to delete this set?" } %>
 </p>
 
 <table>
   <tr>
     <td><strong>Name </strong></td>
-    <td><%= @source_set.name %></td>
+    <td><%= inline_markdown(@source_set.name) %></td>
   </tr>
   <tr>
     <td><strong>Description </strong></td>
@@ -43,7 +43,7 @@
 <table>
 <% @source_set.sources.each do |source| %>
   <tr>
-    <td><%= source_name(source) %></td>
+    <td><%= inline_markdown(source_name(source)) %></td>
     <td><%= link_to "View", source_path(source) %></td>
     <td><%= link_to "Edit", edit_source_path(source) %></td>
     <td><%= link_to "Delete", source_path(source),
@@ -60,7 +60,7 @@
 <table>
 <% @source_set.guides.each do |guide| %>
   <tr>
-    <td><%= guide.name %></td>
+    <td><%= inline_markdown(guide.name) %></td>
     <td><%= link_to "View", guide_path(guide) %></td>
     <td><%= link_to "Edit", edit_guide_path(guide) %></td>
     <td><%= link_to "Delete", guide_path(guide),

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -22,6 +22,7 @@
 
   <p>
     <strong><%= f.label :name %></strong><br/>
+    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
 

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -3,11 +3,11 @@
 <p>
   <%= link_to "View", source_path(@source) %>
   |
-  <%= link_to "Delete", 
+  <%= link_to "Delete",
                source_path(@source), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{@source.name}?" } %>
+               data: { confirm: "Are you sure you want to delete this source?" } %>
 </p>
 
-<p>This source belongs to <%= link_to @source.source_set.name, source_set_path(@source.source_set) %></p>
+<p>This source belongs to <%= link_to inline_markdown(@source.source_set.name), source_set_path(@source.source_set) %></p>
 
 <%= render "form" %>

--- a/app/views/sources/new.html.erb
+++ b/app/views/sources/new.html.erb
@@ -1,5 +1,5 @@
-<p><%= link_to "Back to #{@source_set.name}", source_set_path(@source_set) %></p>
+<p><%= link_to "Back to set", source_set_path(@source_set) %></p>
 
-<h1>New source for <%= @source_set.name %></h1>
+<h1>New source for <%= inline_markdown(@source_set.name) %></h1>
 
 <%= render "form" %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,17 +1,17 @@
-<h1>Source: <%= source_name(@source) %></h1>
+<h1>Source: <%= inline_markdown(source_name(@source)) %></h1>
 
 <p>
   <%= link_to "Edit", edit_source_path(@source) %>
   |
   <%= link_to "Delete", 
                source_path(@source), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{source_name(@source)}?" } %>
+               data: { confirm: "Are you sure you want to delete this source?" } %>
 </p>
 
 <table>
   <tr>
     <td><strong>Set </strong></td>
-    <td><%= link_to @source.source_set.name, source_set_path(@source.source_set)%></td>
+    <td><%= link_to inline_markdown(@source.source_set.name), source_set_path(@source.source_set)%></td>
   </tr>
   <tr>
     <td><strong>DPLA item URI </strong></td>
@@ -19,7 +19,7 @@
   </tr>
   <tr>
     <td><strong>Name </strong></td>
-    <td><%= @source.name %></td>
+    <td><%= inline_markdown(@source.name) %></td>
   </tr>
   <tr>
     <td><strong>Media type </strong></td>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,4 +14,18 @@ describe ApplicationHelper, type: :helper do
        expect{ helper.markdown(invalid_input) }.to raise_error(TypeError)
      end
    end
+
+   describe '#inline_markdown' do
+
+    it 'strips enclosing <p> tags' do
+      text = '**Moomin!**'
+      expect(helper.inline_markdown(text)).to eq("<strong>Moomin!</strong>")
+    end
+
+    it 'leaves enclosing <p> tags if there are internal <p> tags' do
+      text = '<p>Moomin!</p><p>Snorkmaiden</p>'
+      expect(helper.inline_markdown(text))
+        .to eq("<p>Moomin!</p><p>Snorkmaiden</p>\n")
+    end
+  end
 end


### PR DESCRIPTION
This introduces markdown formatting to three new fields: `source_set.name`, `source.name`, and `guide.name`.

These three markdown fields differ from the previous markdown fields in that they need to be rendered as inline HTML elements.  Since `Redcarpet` by default encloses all markdown in `<p>` tags, I made a new helper method, `inline_markdown`.  Most of the changes to the views are simply using this new method to render `source_set.name`, `source.name`, and `guide.name`.

In addition, I added instructional text to the `source_set`, `guide`, and `source` input forms, and fixed a few typos.

This addresses [#7985](https://issues.dp.la/issues/7985)