### PR TITLE
Add credits, citation to sources

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -52,7 +52,7 @@ class SourcesController < ApplicationController
 
   def source_params
     params.require(:source).permit(:name, :aggregation, :media_type,
-                                   :textual_content)
+                                   :textual_content, :citation, :credits)
   end
 
   def load_source_set

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -36,6 +36,18 @@
   </p>
 
   <p>
+    <strong><%= f.label :citation %></strong><br/>
+    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
+    <%= f.text_area :citation %>
+  </p>
+
+  <p>
+    <strong><%= f.label :credits %></strong><br/>
+    <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
+    <%= f.text_area :credits %>
+  </p>
+
+  <p>
     <strong><%= f.label :textual_content %></strong><br/>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
     <%= f.text_area :textual_content %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -26,6 +26,14 @@
     <td><%= @source.media_type %></td>
   </tr>
   <tr>
+    <td><strong>Citation </strong></td>
+    <td><%= markdown(@source.citation) %></td>
+  </tr>
+  <tr>
+    <td><strong>Credits </strong></td>
+    <td><%= markdown(@source.credits) %></td>
+  </tr>
+  <tr>
     <td><strong>Textual content </strong></td>
     <td><%= markdown(@source.textual_content) %></td>
   </tr>

--- a/db/migrate/20150911134246_add_citation_credits_to_sources.rb
+++ b/db/migrate/20150911134246_add_citation_credits_to_sources.rb
@@ -1,0 +1,8 @@
+class AddCitationCreditsToSources < ActiveRecord::Migration
+  def change
+    change_table :sources do |t|
+      t.text :citation
+      t.text :credits
+    end
+  end
+end

--- a/db/migrate/20150911134545_sources_citation_credits_text_limits.rb
+++ b/db/migrate/20150911134545_sources_citation_credits_text_limits.rb
@@ -1,0 +1,6 @@
+class SourcesCitationCreditsTextLimits < ActiveRecord::Migration
+  def change
+    change_column :sources, :citation, :text, limit: 65535
+    change_column :sources, :credits, :text, limit: 65535
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,6 +79,19 @@ ActiveRecord::Schema.define(version: 20150914012241) do
 
   add_index "guides", ["source_set_id"], name: "index_guides_on_source_set_id"
 
+  create_table "images", force: true do |t|
+    t.integer  "attachable_id"
+    t.string   "attachable_type"
+    t.string   "mime_type"
+    t.string   "file_base"
+    t.string   "size"
+    t.integer  "height"
+    t.integer  "width"
+    t.string   "alt_text"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
   create_table "source_sets", force: true do |t|
     t.string   "name"
     t.boolean  "published",                 default: false
@@ -98,6 +111,8 @@ ActiveRecord::Schema.define(version: 20150914012241) do
     t.text     "textual_content", limit: 65535
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
+    t.text     "citation",        limit: 65535
+    t.text     "credits",         limit: 65535
   end
 
   add_index "sources", ["source_set_id"], name: "index_sources_on_source_set_id"

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -4,6 +4,8 @@ FactoryGirl.define do
     aggregation 'c3702b42c7e3daf5aafe47151184ba33'
     media_type 'image'
     textual_content 'The birthday button is a beautiful artifact.'
+    citation 'By Tove Jansson'
+    credits 'Courtesy of Finland'
     association :source_set, factory: :source_set_factory
   end
 


### PR DESCRIPTION
This introduces the ability to persists source citations and credit in the database, and enter them via the admin web interface.

It is important to persist these (rather than generating them dynamically through the API) because if an item disappears from the DPLA library, we need to be able to retain citation and credit information.  

This addresses [#7991](https://issues.dp.la/issues/7991)