### PR TITLE
load view specs and require rails_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ require File.expand_path('../../config/environment', __FILE__)
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
+# Load view files
+Dir["#{File.dirname(__FILE__)}/views/**/*.rb"].each { |f| require f }
+
 RSpec.configure do |config|
   config.color = true
   config.formatter = :progress

--- a/spec/views/authors/index.html.erb_spec.rb
+++ b/spec/views/authors/index.html.erb_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'authors/index.html.erb', type: :view do
 
   before do
     assign(:authors, [create(:author_factory, name: 'Moomin'),
-                          create(:author_factory, name: 'Snorkmaiden')])
+                      create(:author_factory, name: 'Snorkmaiden')])
   end
 
   it 'renders each author' do

--- a/spec/views/authors/show.html.erb_spec.rb
+++ b/spec/views/authors/show.html.erb_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'authors/show.html.erb', type: :view do
   let(:author) { create(:author_factory) }

--- a/spec/views/guides/show.html.erb_spec.rb
+++ b/spec/views/guides/show.html.erb_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'guides/show.html.erb', type: :view do
 

--- a/spec/views/source_sets/index.html.erb_spec.rb
+++ b/spec/views/source_sets/index.html.erb_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'source_sets/index.html.erb', type: :view do
 

--- a/spec/views/source_sets/show.html.erb_spec.rb
+++ b/spec/views/source_sets/show.html.erb_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'source_sets/show.html.erb', type: :view do
 

--- a/spec/views/sources/show.html.erb_spec.rb
+++ b/spec/views/sources/show.html.erb_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'sources/show.html.erb', type: :view do
 


### PR DESCRIPTION
This fixes view specs, which were failing.  We didn't detect that they were failing because they were not loading with the rest of the tests when running `rspec`.

To get the view specs to pass, I changed `require spec_helper` to `require rails_helper`.  This change was made to the rest of the specs in PR#16, but I had overlooked the views specs. 

To get the view specs to load, I added a statement to `spec_helper`.