### PR TITLE
Fix/guide source routes

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -2,11 +2,15 @@
 # Handles HTTP requests for guides
 #
 # @see Guide
-class GuidesController < ApplicationController
-  before_filter :load_source_set
+class GuidesController < ApplicationController 
+  before_filter :load_source_set, only: [:index, :new, :create]
+
+  def index
+    redirect_to @source_set
+  end
 
   def show
-    @guide = @source_set.guides.find(params[:id])
+    @guide = Guide.friendly.find(params[:id])
   end
 
   def new
@@ -14,34 +18,34 @@ class GuidesController < ApplicationController
   end
 
   def edit
-    @guide = @source_set.guides.find(params[:id])
+    @guide = Guide.friendly.find(params[:id])
   end
 
   def create
     @guide = @source_set.guides.new(guide_params)
 
     if @guide.save
-      redirect_to [@source_set, @guide]
+      redirect_to @guide
     else
       render 'new'
     end
   end
 
   def update
-    @guide = @source_set.guides.find(params[:id])
+    @guide = Guide.friendly.find(params[:id])
 
     if @guide.update(guide_params)
-      redirect_to [@source_set, @guide]
+      redirect_to @guide
     else
       render 'edit'
     end
   end
 
   def destroy
-    @guide = @source_set.guides.find(params[:id])
+    @guide = Guide.friendly.find(params[:id])
     @guide.destroy
 
-    redirect_to @source_set
+    redirect_to @guide.source_set
   end
 
   private
@@ -53,6 +57,9 @@ class GuidesController < ApplicationController
                                   author_ids: [])
   end
 
+  ##
+  # Find the source set through the HTTP route.
+  # This method is only for use those actions nested under source_set.
   def load_source_set
     @source_set = SourceSet.friendly.find(params[:source_set_id])
   end

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -3,10 +3,14 @@
 #
 # @see Source
 class SourcesController < ApplicationController
-  before_filter :load_source_set
+  before_filter :load_source_set, only: [:index, :new, :create]
+
+  def index
+    redirect_to @source_set
+  end
 
   def show
-    @source = @source_set.sources.find(params[:id])
+    @source = Source.find(params[:id])
   end
 
   def new
@@ -14,34 +18,34 @@ class SourcesController < ApplicationController
   end
 
   def edit
-    @source = @source_set.sources.find(params[:id])
+    @source = Source.find(params[:id])
   end
 
   def create
     @source = @source_set.sources.new(source_params)
 
     if @source.save
-      redirect_to [@source_set, @source]
+      redirect_to @source
     else
       render 'new'
     end
   end
 
   def update
-    @source = @source_set.sources.find(params[:id])
+    @source = Source.find(params[:id])
 
     if @source.update(source_params)
-      redirect_to [@source_set, @source]
+      redirect_to @source
     else
       render 'edit'
     end
   end
 
   def destroy
-    @source = @source_set.sources.find(params[:id])
+    @source = Source.find(params[:id])
     @source.destroy
 
-    redirect_to @source_set
+    redirect_to @source.source_set
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,8 @@ module ApplicationHelper
     Redcarpet::Markdown.new(Redcarpet::Render::HTML, options).render(text)
       .html_safe
   end
+
+  def source_name(source)
+    source.name.present? ? source.name : source.aggregation
+  end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,5 +1,15 @@
 class Guide < ActiveRecord::Base
+  extend FriendlyId
   belongs_to :source_set
   has_and_belongs_to_many :authors
   validates :name, presence: true
+  ##
+  # FriendlyId generates a human-readable slug to be used in the URL, in place
+  # of the ID.  The slug is automatically generated from the name field.
+  #
+  # Example:
+  #   Guide.create({ name: "Little My" }).slug = "little-my"
+  #   URL:  http://example.com/primary-source-sets/guides/little-my
+  #   To find this object: Guide.friendly.find("little-my")
+  friendly_id :name, use: :slugged
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -28,6 +28,6 @@
 <h2>Teaching guides</h2>
 <ul>
   <% @author.guides.each do |guide| %>
-    <li><%= link_to guide.name, source_set_guide_path(guide.source_set, guide) %></li>
+    <li><%= link_to guide.name, guide_path(guide) %></li>
   <% end %>
 </ul>

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,13 +1,13 @@
 <h1>Edit teaching guide</h1>
 
 <p>
-  <%= link_to "View", source_set_guide_path(@source_set, @guide) %>
+  <%= link_to "View", guide_path(@guide) %>
   |
   <%= link_to "Delete", 
-               source_set_guide_path(@source_set, @guide), method: :delete,
+               guide_path(@guide), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@guide.name}?" } %>
 </p>
 
-<p>This guide belongs to <%= link_to @source_set.name, source_set_path(@source_set) %></p>
+<p>This guide belongs to <%= link_to @guide.source_set.name, source_set_path(@guide.source_set) %></p>
 
 <%= render "form" %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,17 +1,17 @@
 <h1>Teaching guide: <%= @guide.name %></h1>
 
 <p>
-  <%= link_to "Edit", edit_source_set_guide_path(@source_set, @guide) %>
+  <%= link_to "Edit", edit_guide_path(@guide) %>
   |
   <%= link_to "Delete", 
-               source_set_guide_path(@source_set, @guide), method: :delete,
+               guide_path(@guide), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@guide.name}?" } %>
 </p>
 
 <table>
   <tr>
     <td><strong>Set </strong></td>
-    <td><%= link_to @source_set.name, source_set_path(@source_set)%></td>
+    <td><%= link_to @guide.source_set.name, source_set_path(@guide.source_set)%></td>
   </tr>
   <tr>
     <td><strong>Name </strong></td>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -43,12 +43,12 @@
 <table>
 <% @source_set.sources.each do |source| %>
   <tr>
-    <td><%= source_name = source.name.present? ? source.name : source.aggregation %></td>
-    <td><%= link_to "View", source_set_source_path(@source_set, source) %></td>
-    <td><%= link_to "Edit", edit_source_set_source_path(@source_set, source) %></td>
-    <td><%= link_to "Delete", source_set_source_path(@source_set, source),
+    <td><%= source_name(source) %></td>
+    <td><%= link_to "View", source_path(source) %></td>
+    <td><%= link_to "Edit", edit_source_path(source) %></td>
+    <td><%= link_to "Delete", source_path(source),
                     method: :delete,
-                    data: { confirm: "Are you sure you want to delete #{source_name}?" } %></td>
+                    data: { confirm: "Are you sure you want to delete #{source_name(source)}?" } %></td>
   </tr>
 <% end %>
 </table>
@@ -61,9 +61,9 @@
 <% @source_set.guides.each do |guide| %>
   <tr>
     <td><%= guide.name %></td>
-    <td><%= link_to "View", source_set_guide_path(@source_set, guide) %></td>
-    <td><%= link_to "Edit", edit_source_set_guide_path(@source_set, guide) %></td>
-    <td><%= link_to "Delete", source_set_guide_path(@source_set, guide),
+    <td><%= link_to "View", guide_path(guide) %></td>
+    <td><%= link_to "Edit", edit_guide_path(guide) %></td>
+    <td><%= link_to "Delete", guide_path(guide),
                     method: :delete,
                     data: { confirm: "Are you sure you want to delete #{guide.name}?" } %></td>
   </tr>

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -1,13 +1,13 @@
 <h1>Edit source</h1>
 
 <p>
-  <%= link_to "View", source_set_source_path(@source, @source_set) %>
+  <%= link_to "View", source_path(@source) %>
   |
   <%= link_to "Delete", 
-               source_set_source_path(@source_set, @source), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{@source_name}?" } %>
+               source_path(@source), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@source.name}?" } %>
 </p>
 
-<p>This source belongs to <%= link_to @source_set.name, source_set_path(@source_set) %></p>
+<p>This source belongs to <%= link_to @source.source_set.name, source_set_path(@source.source_set) %></p>
 
 <%= render "form" %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,18 +1,17 @@
-<% source_name = @source.name.present? ? @source.name : @source.aggregation %>
-<h1>Source: <%= source_name %></h1>
+<h1>Source: <%= source_name(@source) %></h1>
 
 <p>
-  <%= link_to "Edit", edit_source_set_source_path(@source_set, @source) %>
+  <%= link_to "Edit", edit_source_path(@source) %>
   |
   <%= link_to "Delete", 
-               source_set_source_path(@source_set, @source), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{@source_name}?" } %>
+               source_path(@source), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{source_name(@source)}?" } %>
 </p>
 
 <table>
   <tr>
     <td><strong>Set </strong></td>
-    <td><%= link_to @source_set.name, source_set_path(@source_set)%></td>
+    <td><%= link_to @source.source_set.name, source_set_path(@source.source_set)%></td>
   </tr>
   <tr>
     <td><strong>DPLA item URI </strong></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   devise_for :admins
   resources :sets, controller: 'source_sets', as: 'source_sets' do
-    resources :sources, only: [:new, :create, :edit, :update, :show, :destroy]
-    resources :guides, only: [:new, :create, :edit, :update, :show, :destroy]
+    resources :sources, shallow: :true
+    resources :guides, shallow: :true
   end
   resources :authors
 

--- a/db/migrate/20150914012241_guides_slug.rb
+++ b/db/migrate/20150914012241_guides_slug.rb
@@ -1,0 +1,7 @@
+class GuidesSlug < ActiveRecord::Migration
+  def change
+    change_table :guides do |t|
+      t.string :slug, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904204928) do
+ActiveRecord::Schema.define(version: 20150914012241) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20150904204928) do
     t.text     "activity",      limit: 65535
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
+    t.string   "slug"
   end
 
   add_index "guides", ["source_set_id"], name: "index_guides_on_source_set_id"

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -13,20 +13,23 @@ describe GuidesController, type: :controller do
   context 'admin logged in' do
     login_admin
 
+    describe '#index' do
+
+      it 'redirects to source_set#show' do
+        get :index, source_set_id: source_set.id
+        expect(response).to redirect_to(source_set)
+      end
+    end
+
     describe '#show' do
 
       it 'sets @guide variable' do
-        get :show, id: guide.id, source_set_id: source_set.id
+        get :show, id: guide.id
         expect(assigns(:guide)).to eq(guide)
       end
 
-      it 'sets @source_set variable' do
-        get :show, id: guide.id, source_set_id: source_set.id
-        expect(assigns(:source_set)).to eq(source_set)
-      end
-
       it 'renders the :show view' do
-        get :show, id: guide.id, source_set_id: source_set.id
+        get :show, id: guide.id
         expect(response).to render_template :show
       end
     end
@@ -47,7 +50,7 @@ describe GuidesController, type: :controller do
         post :create,
              source_set_id: source_set.id,
              guide: attributes_for(:guide_factory)
-        expect(response).to redirect_to [source_set, Guide.last]
+        expect(response).to redirect_to Guide.last
       end
 
       context 'with invalid attributes' do
@@ -76,7 +79,6 @@ describe GuidesController, type: :controller do
         guide
         patch :update,
               id: guide.id,
-              source_set_id: source_set.id,
               guide: { name: 'New name' }
         guide.reload
         expect(guide.name).to eq('New name')
@@ -85,9 +87,8 @@ describe GuidesController, type: :controller do
       it 'redirects to the updated guide' do
         patch :update,
               id: guide.id,
-              source_set_id: source_set.id,
               guide: { name: 'New name' }
-        expect(response).to redirect_to [source_set, guide]
+        expect(response).to redirect_to guide
       end
 
       context 'with invalid attributes' do
@@ -97,7 +98,6 @@ describe GuidesController, type: :controller do
           valid_name = guide.name
           patch :update,
                 id: guide.id,
-                source_set_id: source_set.id,
                 guide: attributes_for(:invalid_guide_factory)
           guide.reload
           expect(guide.name).to eq(valid_name)
@@ -106,7 +106,6 @@ describe GuidesController, type: :controller do
         it 're-renders :edit view' do
           patch :update,
                 id: guide.id,
-                source_set_id: source_set.id,
                 guide: attributes_for(:invalid_guide_factory)
           expect(:response).to render_template :edit
         end
@@ -118,13 +117,13 @@ describe GuidesController, type: :controller do
       it 'deletes the guide' do
         guide
         expect do
-          delete :destroy, id: guide.id, source_set_id: source_set.id
+          delete :destroy, id: guide.id
         end.to change(source_set.guides, :count).by(-1)
       end
 
       it 'redirects to :index view' do
         guide
-        delete :destroy, id: guide.id, source_set_id: source_set.id
+        delete :destroy, id: guide.id
         expect(response).to redirect_to source_set_path(source_set)
       end
     end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -13,20 +13,23 @@ describe SourcesController, type: :controller do
   context 'admin logged in' do
     login_admin
 
+    describe '#index' do
+
+      it 'redirects to source_set#show' do
+        get :index, source_set_id: source_set.id
+        expect(response).to redirect_to(source_set)
+      end
+    end
+
     describe '#show' do
 
       it 'sets @source variable' do
-        get :show, id: source.id, source_set_id: source_set.id
+        get :show, id: source.id
         expect(assigns(:source)).to eq(source)
       end
 
-      it 'sets @source_set variable' do
-        get :show, id: source.id, source_set_id: source_set.id
-        expect(assigns(:source_set)).to eq(source_set)
-      end
-
       it 'renders the :show view' do
-        get :show, id: source.id, source_set_id: source_set.id
+        get :show, id: source.id
         expect(response).to render_template :show
       end
     end
@@ -47,7 +50,7 @@ describe SourcesController, type: :controller do
         post :create,
              source_set_id: source_set.id,
              source: attributes_for(:source_factory)
-        expect(response).to redirect_to [source_set, Source.last]
+        expect(response).to redirect_to Source.last
       end
 
       context 'with invalid attributes' do
@@ -76,7 +79,6 @@ describe SourcesController, type: :controller do
         source
         patch :update,
               id: source.id,
-              source_set_id: source_set.id,
               source: { name: 'New name' }
         source.reload
         expect(source.name).to eq('New name')
@@ -85,9 +87,8 @@ describe SourcesController, type: :controller do
       it 'redirects to the updated source' do
         patch :update,
               id: source.id,
-              source_set_id: source_set.id,
               source: { name: 'New name' }
-        expect(response).to redirect_to [source_set, source]
+        expect(response).to redirect_to source
       end
 
       context 'with invalid attributes' do
@@ -97,7 +98,6 @@ describe SourcesController, type: :controller do
           valid_aggregation = source.aggregation
           patch :update,
                 id: source.id,
-                source_set_id: source_set.id,
                 source: attributes_for(:invalid_source_factory)
           source.reload
           expect(source.aggregation).to eq(valid_aggregation)
@@ -106,7 +106,6 @@ describe SourcesController, type: :controller do
         it 're-renders :edit view' do
           patch :update,
                 id: source.id,
-                source_set_id: source_set.id,
                 source: attributes_for(:invalid_source_factory)
           expect(:response).to render_template :edit
         end
@@ -118,13 +117,13 @@ describe SourcesController, type: :controller do
       it 'deletes the source' do
         source
         expect do
-          delete :destroy, id: source.id, source_set_id: source_set.id
+          delete :destroy, id: source.id
         end.to change(source_set.sources, :count).by(-1)
       end
 
       it 'redirects to :index view' do
         source
-        delete :destroy, id: source.id, source_set_id: source_set.id
+        delete :destroy, id: source.id
         expect(response).to redirect_to source_set_path(source_set)
       end
     end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -15,4 +15,8 @@ describe Guide, type: :model do
   it 'is invalid without name' do
     expect(Guide.new(name: nil)).not_to be_valid
   end
+
+  it 'has a slug' do
+    expect(Guide.create(name: 'Little My').slug).to eq 'little-my'
+  end
 end


### PR DESCRIPTION
This fixes `guide` and `source` routes so that they are shallowly nested under `source_set`.  The `shallow` option nests only `:index`, `:new`, and `:create` under `source_set`.  

Shallow nesting makes the routes simpler. For example, without shallow nesting, a route for a source might be `primary-source-sets/sets/french-and-indian-war/sources/52`.  With shallow nesting, the route would be `primary-soruce-sets/sources/52`, but the source's relationship to its parent set is maintained.

Shallow nesting will also make development for images and assets easier.

Shallow nesting changes the way you need to assert route helper methods, such as `redirect_to` and `guide_path` which accounts for a large portion of the changes in this PR.

This PR also adds a friendly id (ie slug) for guides.  Since shallowly-nested `guide` routes will no longer contain the name of their parent primary source set, for SEO purposes it will be good to have descriptive, human-readable slugs instead of IDs in the `guide` URLs.

This PR also adds an `index` route action to `guide` and `source`.  Previously, there were no `index` route actions; now, there are, and they redirect to the parent `source_set`.  It is a small improvement for usability and adhering to expected patterns.

Finally, this adds a helper method `source_name`, a minor refactor to help DRY out the views.