### PR TITLE
Feature/media scaffolding

### DIFF
--- a/app/controllers/audios_controller.rb
+++ b/app/controllers/audios_controller.rb
@@ -1,0 +1,65 @@
+##
+# Handles HTTP requests for Audios
+#
+# @see Audios
+class AudiosController < ApplicationController
+  before_filter :load_source, only: [:index, :new, :create]
+
+  def index
+    redirect_to @source
+  end
+
+  def show
+    @audio = Audio.find(params[:id])
+  end
+
+  def new
+    @audio = @source.build_audio
+  end
+
+  def edit
+    @audio = Audio.find(params[:id])
+  end
+
+  def create
+    @audio = @source.build_audio(audio_params)
+
+    if @audio.save
+      redirect_to @audio
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @audio = Audio.find(params[:id])
+
+    if @audio.update(audio_params)
+      redirect_to @audio
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @audio = Audio.find(params[:id])
+    @audio.destroy
+
+    redirect_to @audio.source
+  end
+
+  private
+
+  def audio_params
+    params.require(:audio).permit(:source_id,
+                                  :mime_type,
+                                  :file_base)
+  end
+
+  ##
+  # Find the source through the HTTP route.
+  # This method is only for use those actions nested under source.
+  def load_source
+    @source = Source.find(params[:source_id])
+  end
+end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,0 +1,65 @@
+##
+# Handles HTTP requests for Documents
+#
+# @see Document
+class DocumentsController < ApplicationController
+  before_filter :load_source, only: [:index, :new, :create]
+
+  def index
+    redirect_to @source
+  end
+
+  def show
+    @document = Document.find(params[:id])
+  end
+
+  def new
+    @document = @source.build_document
+  end
+
+  def edit
+    @document = Document.find(params[:id])
+  end
+
+  def create
+    @document = @source.build_document(document_params)
+
+    if @document.save
+      redirect_to @document
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @document = Document.find(params[:id])
+
+    if @document.update(document_params)
+      redirect_to @document
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @document = Document.find(params[:id])
+    @document.destroy
+
+    redirect_to @document.source
+  end
+
+  private
+
+  def document_params
+    params.require(:document).permit(:source_id,
+                                     :mime_type,
+                                     :file_base)
+  end
+
+  ##
+  # Find the source through the HTTP route.
+  # This method is only for use those actions nested under source.
+  def load_source
+    @source = Source.find(params[:source_id])
+  end
+end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -2,7 +2,7 @@
 # Handles HTTP requests for guides
 #
 # @see Guide
-class GuidesController < ApplicationController 
+class GuidesController < ApplicationController
   before_filter :load_source_set, only: [:index, :new, :create]
 
   def index

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,74 @@
+##
+# Handles HTTP requests for Images
+#
+# @see Image
+class ImagesController < ApplicationController
+  before_filter :load_attachable, only: [:index, :new, :create]
+
+  def index
+    redirect_to @attachable
+  end
+
+  def show
+    @image = Image.find(params[:id])
+  end
+
+  def new
+    @image = @attachable.images.new
+  end
+
+  def edit
+    @image = Image.find(params[:id])
+  end
+
+  def create
+    @image = @attachable.images.new(image_params)
+
+    if @image.save
+      redirect_to @image
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @image = Image.find(params[:id])
+
+    if @image.update(image_params)
+      redirect_to @image
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @image = Image.find(params[:id])
+    @image.destroy
+
+    redirect_to @image.attachable
+  end
+
+  private
+
+  def image_params
+    params.require(:image).permit(:attachable_id,
+                                  :attachable_type,
+                                  :mime_type,
+                                  :file_base,
+                                  :size,
+                                  :height,
+                                  :width,
+                                  :alt_text)
+  end
+
+  ##
+  # Find the attachable through the HTTP route.
+  # This method is only for use those actions nested under source.
+  def load_attachable
+    @attachable = Source.find(params[:source_id]) and return if
+      params.include?(:source_id)
+
+    @attachable = SourceSet.friendly.find(params[:source_set_id]) if
+      params.include?(:source_set_id)
+  end
+end

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -51,8 +51,11 @@ class SourcesController < ApplicationController
   private
 
   def source_params
-    params.require(:source).permit(:name, :aggregation, :media_type,
-                                   :textual_content, :citation, :credits)
+    params.require(:source).permit(:name,
+                                   :aggregation,
+                                   :textual_content,
+                                   :citation,
+                                   :credits)
   end
 
   def load_source_set

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,0 +1,65 @@
+##
+# Handles HTTP requests for Videos
+#
+# @see Video
+class VideosController < ApplicationController
+  before_filter :load_source, only: [:index, :new, :create]
+
+  def index
+    redirect_to @source
+  end
+
+  def show
+    @video = Video.find(params[:id])
+  end
+
+  def new
+    @video = @source.build_video
+  end
+
+  def edit
+    @video = Video.find(params[:id])
+  end
+
+  def create
+    @video = @source.build_video(video_params)
+
+    if @video.save
+      redirect_to @video
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @video = Video.find(params[:id])
+
+    if @video.update(video_params)
+      redirect_to @video
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @video = Video.find(params[:id])
+    @video.destroy
+
+    redirect_to @video.source
+  end
+
+  private
+
+  def video_params
+    params.require(:video).permit(:source_id,
+                                  :mime_type,
+                                  :file_base)
+  end
+
+  ##
+  # Find the source through the HTTP route.
+  # This method is only for use those actions nested under source.
+  def load_source
+    @source = Source.find(params[:source_id])
+  end
+end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,0 +1,6 @@
+class Audio < ActiveRecord::Base
+  belongs_to :source
+  validates :mime_type, presence: :true
+  validates :file_base, presence: :true
+  validates :source_id, single_asset: :true
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,0 +1,6 @@
+class Document < ActiveRecord::Base
+  belongs_to :source
+  validates :mime_type, presence: :true
+  validates :file_base, presence: :true
+  validates :source_id, single_asset: :true
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,20 @@
+class Image < ActiveRecord::Base
+  belongs_to :attachable, polymorphic: true
+  validates :file_base, presence: :true
+  validates :mime_type, presence: :true
+  validates :height, numericality: { only_integer: true }
+  validates :width, numericality: { only_integer: true }
+  # Each attachable object can only have one image of any given size.
+  validates :size, presence: :true,
+                   uniqueness: { scope: [:attachable_id, :attachable_type],
+                                 message: 'already exists for this object' }
+  validates :attachable_id, single_asset: :true
+
+  def source
+    return attachable if attachable.is_a? Source
+  end
+
+  def source_set
+    return attachable if attachable.is_a? SourceSet
+  end
+end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,6 +1,24 @@
 class Source < ActiveRecord::Base
   belongs_to :source_set
+  has_many :images, as: :attachable, dependent: :destroy
+  has_one :document, dependent: :destroy
+  has_one :audio, dependent: :destroy
+  has_one :video, dependent: :destroy
+
+  has_one :large_image, -> { where size: 'large' }, as: :attachable,
+                        class_name: 'Image'
+
+  has_one :thumbnail, -> { where size: 'thumbnail' }, as: :attachable,
+                      class_name: 'Image'
+
   validates :aggregation, presence: true
+
+  def asset
+    return large_image if large_image.present?
+    return document if document.present?
+    return audio if audio.present?
+    return video if video.present?
+  end
 
   def aggregation_uri
     Settings.frontend.url + 'item/' + aggregation

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -3,7 +3,16 @@ class SourceSet < ActiveRecord::Base
   has_many :sources, dependent: :destroy
   has_many :guides, dependent: :destroy
   has_and_belongs_to_many :authors
+  has_many :images, as: :attachable, dependent: :destroy
+
+  has_one :large_image, -> { where size: 'large' }, as: :attachable,
+                        class_name: 'Image'
+
+  has_one :thumbnail, -> { where size: 'thumbnail' }, as: :attachable,
+                      class_name: 'Image'
+
   validates :name, presence: true
+
   ##
   # FriendlyId generates a human-readable slug to be used in the URL, in place
   # of the ID.  The slug is automatically generated from the name field.

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,0 +1,6 @@
+class Video < ActiveRecord::Base
+  belongs_to :source
+  validates :mime_type, presence: :true
+  validates :file_base, presence: :true
+  validates :source_id, single_asset: :true
+end

--- a/app/validators/single_asset_validator.rb
+++ b/app/validators/single_asset_validator.rb
@@ -1,0 +1,32 @@
+##
+# Prohibits an asset from being saved if:
+#   1. It has an associated source AND
+#   2. The associated source already has an asset.
+#
+# Images are only considered assets if they are large.  A source may, for
+# example, have both a thumbnail image and an asset.
+#
+# @param record ActiveRecord::Base the record that is being validated
+# @param attribute Symbol the field for the foreign key of the source.
+# @param value Integer the foreign key of the source
+#
+# @example
+#   validates :attachable_id, single_asset: :true
+class SingleAssetValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    asset_classes = [:large_image, :document, :audio, :video]
+
+    if record.class.name == 'Image'
+      return unless record.attachable_type == 'Source'
+      return unless record.size == 'large'
+      asset_classes.delete(:large_image)
+    else
+      asset_classes.delete(record.class.name.downcase.to_sym)
+    end
+
+    asset_classes.each do |asset|
+      record.errors.add(:base, 'Source already has an asset.') if
+        Source.find(value).send(asset).present?
+    end
+  end
+end

--- a/app/views/audios/_form.html.erb
+++ b/app/views/audios/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_for [@source, @audio] do |f| %>
+
+  <% if @audio.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@audio.errors.count, "error") %> prohibited
+        this audio from being saved:
+      </h2>
+      <ul>
+        <% @audio.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <p>
+    <strong><%= f.label :file_base %></strong><br/>
+    <%= f.text_field :file_base %>
+  </p>
+
+  <p>
+    <strong><%= f.label :mime_type %></strong><br/>
+    <%= f.text_field :mime_type %><br/>
+  </p>
+
+  <p>
+    <%= f.submit %>
+  </p>
+
+<% end %>

--- a/app/views/audios/edit.html.erb
+++ b/app/views/audios/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit audio</h1>
+
+<p>
+  <%= link_to "View", audio_path(@audio) %>
+  |
+  <%= link_to "Delete", 
+               audio_path(@audio), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@audio.file_base}?" } %>
+</p>
+
+<p>This audio belongs to <%= link_to inline_markdown(source_name(@audio.source)), source_path(@audio.source) %></p>
+
+<%= render "form" %>

--- a/app/views/audios/new.html.erb
+++ b/app/views/audios/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New audio</h1>
+
+<p>This audio will belong to <%= link_to inline_markdown(source_name(@source)), source_path(@source) %>
+
+<%= render "form" %>

--- a/app/views/audios/show.html.erb
+++ b/app/views/audios/show.html.erb
@@ -1,0 +1,20 @@
+<h1>Audio: <%= @audio.file_base %></h1>
+
+<p>
+  <%= link_to "Edit", edit_audio_path(@audio) %>
+  |
+  <%= link_to "Delete", 
+               audio_path(@audio), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@audio.file_base}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Audio belongs to </strong></td>
+    <td><%= link_to inline_markdown(source_name(@audio.source)), source_path(@audio.source)%></td>
+  </tr>
+  <tr>
+    <td><strong>File base </strong></td>
+    <td><%= @audio.file_base %></td>
+  </tr>
+</table>

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_for [@source, @document] do |f| %>
+
+  <% if @document.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@document.errors.count, "error") %> prohibited
+        this document from being saved:
+      </h2>
+      <ul>
+        <% @document.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <p>
+    <strong><%= f.label :file_base %></strong><br/>
+    <%= f.text_field :file_base %>
+  </p>
+
+  <p>
+    <strong><%= f.label :mime_type %></strong><br/>
+    <%= radio_button("document", "mime_type", "application/pdf", style: "display:inline") %>application/pdf<br/>
+  </p>
+
+  <p>
+    <%= f.submit %>
+  </p>
+
+<% end %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit document</h1>
+
+<p>
+  <%= link_to "View", document_path(@document) %>
+  |
+  <%= link_to "Delete", 
+               document_path(@document), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@document.file_base}?" } %>
+</p>
+
+<p>This document belongs to <%= link_to inline_markdown(source_name(@document.source)), source_path(@document.source) %></p>
+
+<%= render "form" %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New document</h1>
+
+<p>This document will belong to <%= link_to inline_markdown(source_name(@source)), source_path(@source) %>
+
+<%= render "form" %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,0 +1,20 @@
+<h1>Document: <%= @document.file_base %></h1>
+
+<p>
+  <%= link_to "Edit", edit_document_path(@document) %>
+  |
+  <%= link_to "Delete", 
+               document_path(@document), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@document.file_base}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Document belongs to </strong></td>
+    <td><%= link_to inline_markdown(source_name(@document.source)), polymorphic_path(@document.source)%></td>
+  </tr>
+  <tr>
+    <td><strong>File base </strong></td>
+    <td><%= @document.file_base %></td>
+  </tr>
+</table>

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -1,0 +1,54 @@
+<%= form_for [@attachable, @image] do |f| %>
+
+  <% if @image.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@image.errors.count, "error") %> prohibited
+        this image from being saved:
+      </h2>
+      <ul>
+        <% @image.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <p>
+    <strong><%= f.label :file_base %></strong><br/>
+    <%= f.text_field :file_base %>
+  </p>
+
+  <p>
+    <strong><%= f.label :mime_type %></strong><br/>
+    <%= radio_button("image", "mime_type", "image/jpeg", style: "display:inline") %>image/jpeg<br/>
+    <%= radio_button("image", "mime_type", "image/png", style: "display:inline") %>image/png<br/>
+    <%= radio_button("image", "mime_type", "image/gif", style: "display:inline") %>image/gif<br/>
+  </p>
+
+  <p>
+    <strong><%= f.label :height %></strong><br/>
+    <%= f.text_field :height %>
+  </p>
+
+  <p>
+    <strong><%= f.label :width %></strong><br/>
+    <%= f.text_field :width %>
+  </p>
+
+  <p>
+    <strong><%= f.label :size %></strong><br/>
+    <%= radio_button("image", "size", "large", style: "display:inline") %>large<br/>
+    <%= radio_button("image", "size", "thumbnail", style: "display:inline") %>thumbnail<br/>
+  </p>
+
+  <p>
+    <strong><%= f.label :alt_text %></strong><br/>
+    <%= f.text_field :alt_text %>
+  </p>
+
+  <p>
+    <%= f.submit %>
+  </p>
+
+<% end %>

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -1,0 +1,16 @@
+<h1>Edit image</h1>
+
+<p>
+  <%= link_to "View", image_path(@image) %>
+  |
+  <%= link_to "Delete", 
+               image_path(@image), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@image.file_base}?" } %>
+</p>
+
+<% attachable_name = @image.attachable.name.present? ? @image.attachable.name :
+  @image.attachable.aggregation %>
+
+<p>This image belongs to <%= link_to attachable_name, polymorphic_path(@image.attachable) %></p>
+
+<%= render "form" %>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,0 +1,8 @@
+<% attachable_name = @attachable.name.present? ? @attachable.name :
+  @attachable.aggregation %>
+
+<h1>New image</h1>
+
+<p>This image will belong to <%= link_to inline_markdown(attachable_name), polymorphic_path(@attachable) %>
+
+<%= render "form" %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,0 +1,43 @@
+<h1>Image: <%= @image.file_base %></h1>
+
+<p>
+  <%= link_to "Edit", edit_image_path(@image) %>
+  |
+  <%= link_to "Delete", 
+               image_path(@image), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@image.file_base}?" } %>
+</p>
+
+<% attachable_name = @image.attachable.name.present? ? @image.attachable.name :
+  @image.attachable.aggregation %>
+
+<table>
+  <tr>
+    <td><strong>Image belongs to </strong></td>
+    <td><%= link_to attachable_name, polymorphic_path(@image.attachable)%></td>
+  </tr>
+  <tr>
+    <td><strong>File base </strong></td>
+    <td><%= @image.file_base %></td>
+  </tr>
+  <tr>
+    <td><strong>Mime type </strong></td>
+    <td><%= @image.mime_type %></td>
+  </tr>
+  <tr>
+    <td><strong>Size </strong></td>
+    <td><%= @image.size %></td>
+  </tr>
+  <tr>
+    <td><strong>Height </strong></td>
+    <td><%= @image.height %></td>
+  </tr>
+  <tr>
+    <td><strong>Width </strong></td>
+    <td><%= @image.width %></td>
+  </tr>
+  <tr>
+    <td><strong>Alt text </strong></td>
+    <td><%= @image.alt_text %></td>
+  </tr>
+</table>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -69,3 +69,34 @@
   </tr>
 <% end %>
 </table>
+
+<h2>Images</h2>
+
+<p><%= link_to "Add new image", new_source_set_image_path(@source_set.id) %></p>
+
+<table>
+
+  <% if @source_set.large_image.present? %>
+    <tr>
+      <td><strong>Large image </strong></td>
+      <td><%= @source_set.large_image.file_base %></td>
+      <td><%= link_to "View", image_path(@source_set.large_image) %></td>
+      <td><%= link_to "Edit", edit_image_path(@source_set.large_image) %></td>
+      <td><%= link_to "Delete", image_path(@source_set.large_image),
+                      method: :delete,
+                      data: { confirm: "Are you sure you want to delete #{@source_set.large_image.file_base}?" } %></td>
+    </tr>
+  <% end %>
+
+  <% if @source_set.thumbnail.present? %>
+    <tr>
+      <td><strong>Thumbnail </strong></td>
+      <td><%= @source_set.thumbnail.file_base %></td>
+      <td><%= link_to "View", image_path(@source_set.thumbnail) %></td>
+      <td><%= link_to "Edit", edit_image_path(@source_set.thumbnail) %></td>
+      <td><%= link_to "Delete", image_path(@source_set.thumbnail),
+                      method: :delete,
+                      data: { confirm: "Are you sure you want to delete #{@source_set.thumbnail.file_base}?" } %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -27,15 +27,6 @@
   </p>
 
   <p>
-    <strong><%= f.label :media_type %></strong><br/>
-    <em>Media type refers to the file type of the digital object.  It is not a description of the original object.</em><br/>
-    <%= radio_button("source", "media_type", "image") %>image<br/>
-    <%= radio_button("source", "media_type", "document") %>document<br/>
-    <%= radio_button("source", "media_type", "audio") %>audio<br/>
-    <%= radio_button("source", "media_type", "video") %>video<br/>
-  </p>
-
-  <p>
     <strong><%= f.label :citation %></strong><br/>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
     <%= f.text_area :citation %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -22,10 +22,6 @@
     <td><%= inline_markdown(@source.name) %></td>
   </tr>
   <tr>
-    <td><strong>Media type </strong></td>
-    <td><%= @source.media_type %></td>
-  </tr>
-  <tr>
     <td><strong>Citation </strong></td>
     <td><%= markdown(@source.citation) %></td>
   </tr>
@@ -37,4 +33,43 @@
     <td><strong>Textual content </strong></td>
     <td><%= markdown(@source.textual_content) %></td>
   </tr>
+</table>
+
+<h2>Media asset</h2>
+
+<% unless @source.asset.present? && @source.thumbnail.present? %>
+  <p><%= link_to "Add new image", new_source_image_path(@source.id) %></p>
+<% end %>
+
+<% unless @source.asset.present? %>
+  <p><%= link_to "Add new document", new_source_document_path(@source.id) %></p>
+  <p><%= link_to "Add new audio", new_source_audio_path(@source.id) %></p>
+  <p><%= link_to "Add new video", new_source_video_path(@source.id) %></p>
+<% end %>
+
+<table>
+
+  <% if @source.asset.present? %>
+    <tr>
+      <td><strong>Asset </strong></td>
+      <td><%= @source.asset.file_base %></td>
+      <td><%= link_to "View", polymorphic_path(@source.asset) %></td>
+      <td><%= link_to "Edit", edit_polymorphic_path(@source.asset) %></td>
+      <td><%= link_to "Delete", polymorphic_path(@source.asset),
+                      method: :delete,
+                      data: { confirm: "Are you sure you want to delete #{@source.asset.file_base}?" } %></td>
+    </tr>
+  <% end %>
+
+  <% if @source.thumbnail.present? %>
+    <tr>
+      <td><strong>Thumbnail </strong></td>
+      <td><%= @source.thumbnail.file_base %></td>
+      <td><%= link_to "View", image_path(@source.thumbnail) %></td>
+      <td><%= link_to "Edit", edit_image_path(@source.thumbnail) %></td>
+      <td><%= link_to "Delete", image_path(@source.thumbnail),
+                      method: :delete,
+                      data: { confirm: "Are you sure you want to delete #{@source.thumbnail.file_base}?" } %></td>
+    </tr>
+  <% end %>
 </table>

--- a/app/views/videos/_form.html.erb
+++ b/app/views/videos/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_for [@source, @video] do |f| %>
+
+  <% if @video.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@video.errors.count, "error") %> prohibited
+        this video from being saved:
+      </h2>
+      <ul>
+        <% @video.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <p>
+    <strong><%= f.label :file_base %></strong><br/>
+    <%= f.text_field :file_base %>
+  </p>
+
+  <p>
+    <strong><%= f.label :mime_type %></strong><br/>
+    <%= f.text_field :mime_type %><br/>
+  </p>
+
+  <p>
+    <%= f.submit %>
+  </p>
+
+<% end %>

--- a/app/views/videos/edit.html.erb
+++ b/app/views/videos/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit video</h1>
+
+<p>
+  <%= link_to "View", video_path(@video) %>
+  |
+  <%= link_to "Delete", 
+               video_path(@video), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@video.file_base}?" } %>
+</p>
+
+<p>This video belongs to <%= link_to inline_markdown(source_name(@video.source)), source_path(@video.source) %></p>
+
+<%= render "form" %>

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New video</h1>
+
+<p>This video will belong to <%= link_to inline_markdown(source_name(@source)), source_path(@source) %>
+
+<%= render "form" %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -1,0 +1,20 @@
+<h1>Video: <%= @video.file_base %></h1>
+
+<p>
+  <%= link_to "Edit", edit_video_path(@video) %>
+  |
+  <%= link_to "Delete", 
+               video_path(@video), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@video.file_base}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Video belongs to </strong></td>
+    <td><%= link_to inline_markdown(source_name(@video.source)), source_path(@video.source)%></td>
+  </tr>
+  <tr>
+    <td><strong>File base </strong></td>
+    <td><%= @video.file_base %></td>
+  </tr>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,14 @@
 Rails.application.routes.draw do
   devise_for :admins
   resources :sets, controller: 'source_sets', as: 'source_sets' do
-    resources :sources, shallow: :true
+    resources :sources, shallow: :true do
+      resources :images, shallow: :true
+      resources :documents, shallow: :true
+      resources :audios, shallow: :true
+      resources :videos, shallow: :true
+    end
     resources :guides, shallow: :true
+    resources :images, shallow: true
   end
   resources :authors
 

--- a/db/migrate/20150912145227_create_images.rb
+++ b/db/migrate/20150912145227_create_images.rb
@@ -1,0 +1,15 @@
+class CreateImages < ActiveRecord::Migration
+  def change
+    create_table :images do |t|
+      t.integer :attachable_id
+      t.string :attachable_type
+      t.string :mime_type
+      t.string :file_base
+      t.string :size
+      t.integer :height
+      t.integer :width
+      t.string :alt_text
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150916161243_create_documents.rb
+++ b/db/migrate/20150916161243_create_documents.rb
@@ -1,0 +1,10 @@
+class CreateDocuments < ActiveRecord::Migration
+  def change
+    create_table :documents do |t|
+      t.integer :source_id
+      t.string :mime_type
+      t.string :file_base
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150918025501_create_audios.rb
+++ b/db/migrate/20150918025501_create_audios.rb
@@ -1,0 +1,10 @@
+class CreateAudios < ActiveRecord::Migration
+  def change
+    create_table :audios do |t|
+      t.integer :source_id
+      t.string :mime_type
+      t.string :file_base
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150918025532_create_videos.rb
+++ b/db/migrate/20150918025532_create_videos.rb
@@ -1,0 +1,10 @@
+class CreateVideos < ActiveRecord::Migration
+  def change
+    create_table :videos do |t|
+      t.integer :source_id
+      t.string :mime_type
+      t.string :file_base
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150923195451_source_remove_media_type.rb
+++ b/db/migrate/20150923195451_source_remove_media_type.rb
@@ -1,0 +1,5 @@
+class SourceRemoveMediaType < ActiveRecord::Migration
+  def change
+    remove_column :sources, :media_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150914012241) do
+ActiveRecord::Schema.define(version: 20150923195451) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(version: 20150914012241) do
 
   add_index "admins", ["email"], name: "index_admins_on_email", unique: true
   add_index "admins", ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+
+  create_table "audios", force: true do |t|
+    t.integer  "source_id"
+    t.string   "mime_type"
+    t.string   "file_base"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "authors", force: true do |t|
     t.string   "name"
@@ -53,6 +61,14 @@ ActiveRecord::Schema.define(version: 20150914012241) do
 
   add_index "authors_source_sets", ["author_id"], name: "index_authors_source_sets_on_author_id"
   add_index "authors_source_sets", ["source_set_id"], name: "index_authors_source_sets_on_source_set_id"
+
+  create_table "documents", force: true do |t|
+    t.integer  "source_id"
+    t.string   "mime_type"
+    t.string   "file_base"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "friendly_id_slugs", force: true do |t|
     t.string   "slug",                      null: false
@@ -107,7 +123,6 @@ ActiveRecord::Schema.define(version: 20150914012241) do
     t.integer  "source_set_id"
     t.string   "name"
     t.string   "aggregation"
-    t.string   "media_type"
     t.text     "textual_content", limit: 65535
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
@@ -116,5 +131,13 @@ ActiveRecord::Schema.define(version: 20150914012241) do
   end
 
   add_index "sources", ["source_set_id"], name: "index_sources_on_source_set_id"
+
+  create_table "videos", force: true do |t|
+    t.integer  "source_id"
+    t.string   "mime_type"
+    t.string   "file_base"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/controllers/audios_controller_spec.rb
+++ b/spec/controllers/audios_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe AudiosController, type: :controller do
+
+  let(:resource) { create(:audio_factory) }
+  let(:attributes) { attributes_for(:audio_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_audio_factory) }
+  let(:parent) { resource.source }
+
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+
+  context 'admin logged in' do
+    login_admin
+
+    it_behaves_like 'basic controller', :show, :update
+    it_behaves_like 'nested controller', :index, :create, :destroy
+  end
+end

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -2,118 +2,16 @@ require 'rails_helper'
 
 describe AuthorsController, type: :controller do
 
-  let(:author) { FactoryGirl.create(:author_factory) }
+  let(:resource) { create(:author_factory) }
+  let(:attributes) { attributes_for(:author_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_author_factory) }
 
-  it_behaves_like 'admin-only route', :index, :show, :edit, :new do
-    let (:resource) { FactoryGirl.create(:author_factory) }
-  end
+  it_behaves_like 'admin-only route', :index, :show, :edit, :new
 
   context 'admin logged in' do
     login_admin
 
-    describe '#index' do
-
-      it 'set @authors variable' do
-        get :index
-        expect(assigns(:authors)).to eq([author])
-      end
-
-      it 'renders the :index view' do
-        get :index
-        expect(response).to render_template :index
-      end
-    end
-
-    describe '#show' do
-
-      it 'sets @author variable' do
-        get :show, id: author.id
-        expect(assigns(:author)).to eq(author)
-      end
-
-      it 'renders the :show view' do
-        get :show, id: author.id
-        expect(response).to render_template :show
-      end
-    end
-
-    describe '#create' do
-
-      it 'creates a new author' do
-        expect do
-          post :create, author: attributes_for(:author_factory)
-        end.to change(Author, :count).by(1)
-      end
-
-      it 'redirects to the new author' do
-        post :create, author: attributes_for(:author_factory)
-        expect(response).to redirect_to Author.last
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not save new author' do
-          expect do
-            post :create, author: attributes_for(:invalid_author_factory)
-          end.to_not change(Author, :count)
-        end
-
-        it 're-renders :new view' do
-          post :create, author: attributes_for(:invalid_author_factory)
-          expect(response).to render_template :new
-        end
-      end
-    end
-
-    describe '#update' do
-
-      it 'updates the author' do
-        author
-        patch :update, id: author.id, author: { name: 'New name' }
-        author.reload
-        expect(author.name).to eq('New name')
-      end
-
-      it 'redirects to the updated author' do
-        patch :update, id: author.id, author: { name: 'New name' }
-        expect(response).to redirect_to author
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not update the author' do
-          author
-          valid_name = author.name
-          patch :update,
-                id: author.id,
-                author: attributes_for(:invalid_author_factory)
-          author.reload
-          expect(author.name).to eq(valid_name)
-        end
-
-        it 're-renders :edit view' do
-          patch :update,
-                id: author.id,
-                author: attributes_for(:invalid_author_factory)
-          expect(:response).to render_template :edit
-        end
-      end
-    end
-
-    describe '#destroy' do
-
-      it 'deletes the author' do
-        author
-        expect do
-          delete :destroy, id: author.id
-        end.to change(Author, :count).by(-1)
-      end
-
-      it 'redirects to :index view' do
-        author
-        delete :destroy, id: author.id
-        expect(response).to redirect_to authors_url
-      end
-    end
+    it_behaves_like 'basic controller', :index, :show, :create, :update,
+                                        :destroy
   end
 end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe DocumentsController, type: :controller do
+
+  let(:resource) { create(:document_factory) }
+  let(:attributes) { attributes_for(:document_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_document_factory) }
+  let(:parent) { resource.source }
+
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+
+  context 'admin logged in' do
+    login_admin
+
+    it_behaves_like 'basic controller', :show, :update
+    it_behaves_like 'nested controller', :index, :create, :destroy
+  end
+end

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -2,130 +2,17 @@ require 'rails_helper'
 
 describe GuidesController, type: :controller do
 
-  let(:guide) { FactoryGirl.create(:guide_factory) }
-  let(:source_set) { guide.source_set }
+  let(:resource) { create(:guide_factory) }
+  let(:attributes) { attributes_for(:guide_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_guide_factory) }
+  let(:parent) { resource.source_set }
 
-  it_behaves_like 'admin-only route', :show, :new, :edit do
-    let(:resource) { FactoryGirl.create(:guide_factory) }
-    let(:request_params) { { source_set_id: resource.source_set.id } }
-  end
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit
 
   context 'admin logged in' do
     login_admin
 
-    describe '#index' do
-
-      it 'redirects to source_set#show' do
-        get :index, source_set_id: source_set.id
-        expect(response).to redirect_to(source_set)
-      end
-    end
-
-    describe '#show' do
-
-      it 'sets @guide variable' do
-        get :show, id: guide.id
-        expect(assigns(:guide)).to eq(guide)
-      end
-
-      it 'renders the :show view' do
-        get :show, id: guide.id
-        expect(response).to render_template :show
-      end
-    end
-
-    describe '#create' do
-
-      it 'creates a new guide' do
-        source_set
-        expect do
-          post :create,
-               source_set_id: source_set.id,
-               guide: attributes_for(:guide_factory)
-        end.to change(source_set.guides, :count).by(1)
-      end
-
-      it 'redirects to the new guide' do
-        source_set
-        post :create,
-             source_set_id: source_set.id,
-             guide: attributes_for(:guide_factory)
-        expect(response).to redirect_to Guide.last
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not save new guide' do
-          source_set
-          expect do
-            post :create,
-                 source_set_id: source_set.id,
-                 guide: attributes_for(:invalid_guide_factory)
-          end.to_not change(source_set.guides, :count)
-        end
-
-        it 're-renders :new view' do
-          post :create,
-               source_set_id: source_set.id,
-               guide: attributes_for(:invalid_guide_factory)
-          expect(response).to render_template :new
-        end
-      end
-    end
-
-    describe '#update' do
-
-      it 'updates the guide' do
-        guide
-        patch :update,
-              id: guide.id,
-              guide: { name: 'New name' }
-        guide.reload
-        expect(guide.name).to eq('New name')
-      end
-
-      it 'redirects to the updated guide' do
-        patch :update,
-              id: guide.id,
-              guide: { name: 'New name' }
-        expect(response).to redirect_to guide
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not update the guide' do
-          guide
-          valid_name = guide.name
-          patch :update,
-                id: guide.id,
-                guide: attributes_for(:invalid_guide_factory)
-          guide.reload
-          expect(guide.name).to eq(valid_name)
-        end
-
-        it 're-renders :edit view' do
-          patch :update,
-                id: guide.id,
-                guide: attributes_for(:invalid_guide_factory)
-          expect(:response).to render_template :edit
-        end
-      end
-    end
-
-    describe '#destroy' do
-
-      it 'deletes the guide' do
-        guide
-        expect do
-          delete :destroy, id: guide.id
-        end.to change(source_set.guides, :count).by(-1)
-      end
-
-      it 'redirects to :index view' do
-        guide
-        delete :destroy, id: guide.id
-        expect(response).to redirect_to source_set_path(source_set)
-      end
-    end
+    it_behaves_like 'basic controller', :show, :update
+    it_behaves_like 'nested controller', :index, :create, :destroy
   end
 end

--- a/spec/controllers/images_controller_spec.rb
+++ b/spec/controllers/images_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe ImagesController, type: :controller do
+  let(:resource) { create(:image_factory) }
+  let(:attributes) { attributes_for(:image_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_image_factory) }
+  let(:parent) { resource.attachable }
+
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+
+  context 'admin logged in' do
+    login_admin
+
+    it_behaves_like 'basic controller', :show, :update
+    it_behaves_like 'nested controller', :index, :create, :destroy
+
+    context 'attached to source' do
+      let(:parent) { create(:source_factory) }
+      let(:resource) { create(:image_factory, attachable: parent) }
+
+      it_behaves_like 'nested controller', :index, :create, :destroy
+    end
+  end
+end

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -2,118 +2,16 @@ require 'rails_helper'
 
 describe SourceSetsController, type: :controller do
 
-  let(:source_set) { FactoryGirl.create(:source_set_factory) }
+  let(:resource) { create(:source_set_factory) }
+  let(:attributes) { attributes_for(:source_set_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_source_set_factory) }
 
-  it_behaves_like "admin-only route", :index, :show, :new, :edit do
-    let(:resource) { FactoryGirl.create(:source_set_factory) }
-  end
+  it_behaves_like 'admin-only route', :index, :show, :edit, :new
 
   context 'admin logged in' do
     login_admin
 
-    describe '#index' do
-
-      it 'set @source_sets variable' do
-        get :index
-        expect(assigns(:source_sets)).to eq([source_set])
-      end
-
-      it 'renders the :index view' do
-        get :index
-        expect(response).to render_template :index
-      end
-    end
-
-    describe '#show' do
-
-      it 'sets @source_set variable' do
-        get :show, id: source_set.id
-        expect(assigns(:source_set)).to eq(source_set)
-      end
-
-      it 'renders the :show view' do
-        get :show, id: source_set.id
-        expect(response).to render_template :show
-      end
-    end
-
-    describe '#create' do
-
-      it 'creates a new source set' do
-        expect do
-          post :create, source_set: attributes_for(:source_set_factory)
-        end.to change(SourceSet, :count).by(1)
-      end
-
-      it 'redirects to the new source set' do
-        post :create, source_set: attributes_for(:source_set_factory)
-        expect(response).to redirect_to SourceSet.last
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not save new source set' do
-          expect do
-            post :create, source_set: attributes_for(:invalid_source_set_factory)
-          end.to_not change(SourceSet, :count)
-        end
-
-        it 're-renders :new view' do
-          post :create, source_set: attributes_for(:invalid_source_set_factory)
-          expect(response).to render_template :new
-        end
-      end
-    end
-
-    describe '#update' do
-
-      it 'updates the source set' do
-        source_set
-        patch :update, id: source_set.id, source_set: { name: 'New name' }
-        source_set.reload
-        expect(source_set.name).to eq('New name')
-      end
-
-      it 'redirects to the updated source set' do
-        patch :update, id: source_set.id, source_set: { name: 'New name' }
-        expect(response).to redirect_to source_set
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not update the source set' do
-          source_set
-          valid_name = source_set.name
-          patch :update,
-                id: source_set.id,
-                source_set: attributes_for(:invalid_source_set_factory)
-          source_set.reload
-          expect(source_set.name).to eq(valid_name)
-        end
-
-        it 're-renders :edit view' do
-          patch :update,
-                id: source_set.id,
-                source_set: attributes_for(:invalid_source_set_factory)
-          expect(:response).to render_template :edit
-        end
-      end
-    end
-
-    describe '#destroy' do
-
-      it 'deletes the source set' do
-        source_set
-        expect do
-          delete :destroy, id: source_set.id
-        end.to change(SourceSet, :count).by(-1)
-      end
-
-      it 'redirects to :index view' do
-        source_set
-        delete :destroy, id: source_set.id
-        expect(response).to redirect_to source_sets_url
-      end
-    end
+    it_behaves_like 'basic controller', :index, :show, :create, :update,
+                                        :destroy
   end
 end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -2,130 +2,17 @@ require 'rails_helper'
 
 describe SourcesController, type: :controller do
 
-  let(:source) { FactoryGirl.create(:source_factory) }
-  let(:source_set) { source.source_set }
+  let(:resource) { create(:source_factory) }
+  let(:attributes) { attributes_for(:source_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_source_factory) }
+  let(:parent) { resource.source_set }
 
-  it_behaves_like "admin-only route", :show, :new, :edit do
-    let(:resource) { FactoryGirl.create(:source_factory) }
-    let(:request_params) { { source_set_id: resource.source_set.id } }
-  end
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit
 
   context 'admin logged in' do
     login_admin
 
-    describe '#index' do
-
-      it 'redirects to source_set#show' do
-        get :index, source_set_id: source_set.id
-        expect(response).to redirect_to(source_set)
-      end
-    end
-
-    describe '#show' do
-
-      it 'sets @source variable' do
-        get :show, id: source.id
-        expect(assigns(:source)).to eq(source)
-      end
-
-      it 'renders the :show view' do
-        get :show, id: source.id
-        expect(response).to render_template :show
-      end
-    end
-
-    describe '#create' do
-
-      it 'creates a new source' do
-        source_set
-        expect do
-          post :create,
-               source_set_id: source_set.id,
-               source: attributes_for(:source_factory)
-        end.to change(source_set.sources, :count).by(1)
-      end
-
-      it 'redirects to the new source' do
-        source_set
-        post :create,
-             source_set_id: source_set.id,
-             source: attributes_for(:source_factory)
-        expect(response).to redirect_to Source.last
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not save new source' do
-          source_set
-          expect do
-            post :create,
-                 source_set_id: source_set.id,
-                 source: attributes_for(:invalid_source_factory)
-          end.to_not change(source_set.sources, :count)
-        end
-
-        it 're-renders :new view' do
-          post :create,
-               source_set_id: source_set.id,
-               source: attributes_for(:invalid_source_factory)
-          expect(response).to render_template :new
-        end
-      end
-    end
-
-    describe '#update' do
-
-      it 'updates the source' do
-        source
-        patch :update,
-              id: source.id,
-              source: { name: 'New name' }
-        source.reload
-        expect(source.name).to eq('New name')
-      end
-
-      it 'redirects to the updated source' do
-        patch :update,
-              id: source.id,
-              source: { name: 'New name' }
-        expect(response).to redirect_to source
-      end
-
-      context 'with invalid attributes' do
-
-        it 'does not update the source' do
-          source
-          valid_aggregation = source.aggregation
-          patch :update,
-                id: source.id,
-                source: attributes_for(:invalid_source_factory)
-          source.reload
-          expect(source.aggregation).to eq(valid_aggregation)
-        end
-
-        it 're-renders :edit view' do
-          patch :update,
-                id: source.id,
-                source: attributes_for(:invalid_source_factory)
-          expect(:response).to render_template :edit
-        end
-      end
-    end
-
-    describe '#destroy' do
-
-      it 'deletes the source' do
-        source
-        expect do
-          delete :destroy, id: source.id
-        end.to change(source_set.sources, :count).by(-1)
-      end
-
-      it 'redirects to :index view' do
-        source
-        delete :destroy, id: source.id
-        expect(response).to redirect_to source_set_path(source_set)
-      end
-    end
+    it_behaves_like 'basic controller', :show, :update
+    it_behaves_like 'nested controller', :index, :create, :destroy
   end
 end

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe VideosController, type: :controller do
+
+  let(:resource) { create(:video_factory) }
+  let(:attributes) { attributes_for(:video_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_video_factory) }
+  let(:parent) { resource.source }
+
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+
+  context 'admin logged in' do
+    login_admin
+
+    it_behaves_like 'basic controller', :show, :update
+    it_behaves_like 'nested controller', :index, :create, :destroy
+  end
+end

--- a/spec/factories/audios.rb
+++ b/spec/factories/audios.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :audio_factory, class: Audio do
+    file_base 'adventures-of-moomin'
+    mime_type 'audio/mp4'
+    association :source, factory: :source_factory
+  end
+
+  factory :invalid_audio_factory, class: Audio do
+    file_base nil
+  end
+end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :document_factory, class: Document do
+    file_base 'adventures-of-moomin'
+    mime_type 'application/pdf'
+    association :source, factory: :source_factory
+  end
+
+  factory :invalid_document_factory, class: Document do
+    file_base nil
+  end
+end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :image_factory, class: Image do
+    file_base 'picture-of-little-my'
+    mime_type 'image/jpeg'
+    size 'thumbnail'
+    height '150'
+    width '150'
+    alt_text 'picture of Little My'
+    association :attachable, factory: :source_set_factory
+  end
+
+  factory :invalid_image_factory, class: Image do
+    file_base nil
+    mime_type nil
+  end
+end

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :source_factory, class: Source do
     name 'The birthday button'
     aggregation 'c3702b42c7e3daf5aafe47151184ba33'
-    media_type 'image'
     textual_content 'The birthday button is a beautiful artifact.'
     citation 'By Tove Jansson'
     credits 'Courtesy of Finland'

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :video_factory, class: Video do
+    file_base 'adventures-of-moomin'
+    mime_type 'video/mp4'
+    association :source, factory: :source_factory
+  end
+
+  factory :invalid_video_factory, class: Video do
+    file_base nil
+  end
+end

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Audio, type: :model do
+
+  let(:source) { create(:source_factory) }
+
+  let(:attributes) do
+    attributes_for(:audio_factory).merge({ source: source })
+  end
+
+  it_behaves_like 'media asset'
+
+  it 'belongs to source' do
+    expect(described_class.reflect_on_association(:source).macro.should)
+      .to eq :belongs_to
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Document, type: :model do
+
+  let(:source) { create(:source_factory) }
+
+  let(:attributes) do
+    attributes_for(:document_factory).merge({ source: source })
+  end
+
+  it_behaves_like 'media asset'
+
+  it 'belongs to source' do
+    expect(described_class.reflect_on_association(:source).macro.should)
+      .to eq :belongs_to
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe Image, type: :model do
+
+  let(:attributes) { attributes_for(:image_factory) }
+  let(:source) { create(:source_factory) }
+
+  it 'belongs to attachable' do
+    expect(described_class.reflect_on_association(:attachable).macro.should)
+      .to eq :belongs_to
+  end
+
+  it 'is invalid without size' do
+    attributes[:size] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
+
+  it 'allows only one of each size per associated attachable' do
+    described_class.create(attributes)
+    expect(described_class.new(attributes)).not_to be_valid
+  end
+
+  it 'is invalid if height is not an integer' do
+    attributes[:height] = 'abc'
+    expect(described_class.new(attributes)).not_to be_valid
+  end
+
+  it 'is invalid if width is not an integer' do
+    attributes[:width] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
+
+  context 'is a large image attached to source' do
+
+    let(:attributes) do
+      attributes_for(:image_factory).merge({ attachable: source,
+                                             size: 'large' })
+    end
+
+    it_behaves_like 'media asset'
+  end
+
+  context 'is thumbnail attached to source' do
+    context 'source has asset' do
+
+      let(:attributes) do
+        attributes_for(:image_factory).merge({ attachable: source,
+                                               size: 'thumbnail' })
+      end
+
+      it 'is valid' do
+        create(:document_factory, source: source)
+        expect(described_class.new(attributes)).to be_valid
+      end
+    end
+  end
+
+  describe '#source' do
+    it 'returns attachable source' do
+      attributes[:attachable] = source
+      expect(described_class.new(attributes).source).to eq source
+    end
+
+    it 'ignores attachable source_set' do
+      expect(described_class.create(attributes).source).to eq nil
+    end
+  end
+
+  describe '#source_set' do
+    it 'returns attachable source set' do
+      source_set = create(:source_set_factory)
+      attributes[:attachable] = source_set
+      expect(described_class.new(attributes).source_set).to eq source_set
+    end
+
+    it 'ignores attachable source_set' do
+      attributes[:attachable] = source
+      expect(described_class.create(attributes).source_set).to eq nil
+    end
+  end
+end

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe SourceSet, type: :model do
 
+  let(:source_set) { FactoryGirl.create(:source_set_factory) }
+
   it 'has many sources' do
     expect(SourceSet.reflect_on_association(:sources).macro.should)
       .to eq :has_many
@@ -15,6 +17,33 @@ describe SourceSet, type: :model do
   it 'has and belongs to many authors' do
     expect(SourceSet.reflect_on_association(:authors).macro.should)
       .to eq :has_and_belongs_to_many
+  end
+
+  it 'has many images' do
+    expect(SourceSet.reflect_on_association(:images).macro.should)
+      .to eq :has_many
+  end
+
+  it 'has one large image' do
+    expect(SourceSet.reflect_on_association(:large_image).macro.should)
+      .to eq :has_one
+  end
+
+  it 'recognizes a large image' do
+    image = FactoryGirl.create(:image_factory, size: 'large',
+                                               attachable: source_set)
+    expect(source_set.large_image.id).to eq image.id
+  end
+
+  it 'has one thumbnail' do
+    expect(SourceSet.reflect_on_association(:thumbnail).macro.should)
+      .to eq :has_one
+  end
+
+  it 'recognizes a thumbnail image' do
+    image = FactoryGirl.create(:image_factory, size: 'thumbnail',
+                                               attachable: source_set)
+    expect(source_set.thumbnail.id).to eq image.id
   end
 
   it 'is invalid without name' do

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -2,12 +2,77 @@ require 'rails_helper'
 
 describe Source, type: :model do
 
+  let(:source) { create(:source_factory) }
+
   it 'belongs to a source set' do
     expect(Source.reflect_on_association(:source_set).macro.should)
       .to eq :belongs_to
   end
 
+  it 'has one document' do
+    expect(Source.reflect_on_association(:document).macro.should)
+      .to eq :has_one
+  end
+
+  it 'has one audio' do
+    expect(Source.reflect_on_association(:audio).macro.should)
+      .to eq :has_one
+  end
+
+  it 'has one video' do
+    expect(Source.reflect_on_association(:video).macro.should)
+      .to eq :has_one
+  end
+
+  it 'has many images' do
+    expect(Source.reflect_on_association(:images).macro.should)
+      .to eq :has_many
+  end
+
+  it 'has one large image' do
+    expect(Source.reflect_on_association(:large_image).macro.should)
+      .to eq :has_one
+  end
+
+  it 'recognizes a large image' do
+    image = create(:image_factory, size: 'large', attachable: source)
+    expect(source.large_image).to eq image
+  end
+
+  it 'has one thumbnail' do
+    expect(Source.reflect_on_association(:thumbnail).macro.should)
+      .to eq :has_one
+  end
+
+  it 'recognizes a thumbnail image' do
+    image = create(:image_factory, size: 'thumbnail', attachable: source)
+    expect(source.thumbnail).to eq image
+  end
+
+
   it 'is invalid without aggregation' do
     expect(Source.new(aggregation: nil)).not_to be_valid
+  end
+
+  describe '#asset' do
+    it 'recognizes a large image asset' do
+      image = create(:image_factory, size: 'large', attachable: source)
+      expect(source.asset).to eq image
+    end
+
+    it 'recognizes a document asset' do
+      document = create(:document_factory, source: source)
+      expect(source.asset).to eq document
+    end
+
+    it 'recognizes an audio asset' do
+      document = create(:audio_factory, source: source)
+      expect(source.asset).to eq document
+    end
+
+    it 'recognizes a video asset' do
+      document = create(:video_factory, source: source)
+      expect(source.asset).to eq document
+    end
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Video, type: :model do
+
+  let(:source) { create(:source_factory) }
+
+  let(:attributes) do
+    attributes_for(:video_factory).merge({ source: source })
+  end
+
+  it_behaves_like 'media asset'
+
+  it 'belongs to source' do
+    expect(described_class.reflect_on_association(:source).macro.should)
+      .to eq :belongs_to
+  end
+end

--- a/spec/support/shared_examples/admin_only_route.rb
+++ b/spec/support/shared_examples/admin_only_route.rb
@@ -1,35 +1,31 @@
 ##
 # This tests GET Controller routes and expects them to redirect to the admin
-# login path.
-
-# @param routes Symbol the actions for this controller that are admin-only.
+# login path.  Available routes are: :index, :show, :new, and :edit
 #
-# The example can be passed a block that defines resource and/or request_params.
-# resource should be a factory with an id that will be used to construct routes.
-# request_params should be a Hash of params (not including :id).
+# @param actions Symbol the actions for this examples to test.
 #
-# @example:
-#   it_behaves_like 'admin-only route', :index, :show, :edit, :new do
-#     let (:resource) { FactoryGirl.create(:guide_factory) }
-#     let (:request_params) { source_set: resource.source_set.id }
-#   end
+# This assumes the following variable have been defined in the controller spec,
+# or are passed as a block to this example:
+#   :resource
+#   :parent (optional)
+#
 shared_examples 'admin-only route' do |*actions|
 
-  let(:admin_login_path) do
-    # This route is concatenated in this way because the path helpers for
-    # devise are not incorportating the relative url root.
-    "#{root_url}#{Settings.relative_url_root.gsub('/', '')}/admins/sign_in"
+  let(:params) do
+    params = { id: resource.id }
+    if defined?(parent)
+      params.merge!({ "#{parent.class.name.underscore}_id".to_sym =>
+        parent.id })
+    end
+    params
   end
 
   actions.each do |action|
 
     it "redirects #{action} to admin login" do
-      params = {}
-      params[:id] = resource.id if defined?(resource)
-      params.merge!(request_params) if defined?(request_params)
-
       get action, params
-      expect(response).to redirect_to admin_login_path
+      expect(response)
+        .to redirect_to "#{Settings.relative_url_root}#{new_admin_session_path}"
     end
   end
 end

--- a/spec/support/shared_examples/basic_controller.rb
+++ b/spec/support/shared_examples/basic_controller.rb
@@ -1,0 +1,135 @@
+##
+# This has basic controller specs for :index, :show, :create, :update, :destroy
+#
+# @param actions Symbol the actions for this examples to test.
+#
+# This assumes the following variable have been defined in the controller spec,
+# or are passed as a block to this example:
+#   :resource
+#   :attributes (:create and update only)
+#   :invalid_attributes (:create and :update only)
+#
+shared_examples 'basic controller' do |*actions|
+
+  let(:resource_sym) { resource.class.name.underscore.to_sym }
+
+  if actions.include? :index
+    describe '#index' do
+
+      it 'sets resources variable' do
+        get :index
+        expect(assigns(resource.class.name.pluralize.underscore.to_sym))
+          .to eq([resource])
+      end
+
+      it 'renders the :index view' do
+        get :index
+        expect(response).to render_template :index
+      end
+
+    end
+  end
+
+  if actions.include? :show
+    describe '#show' do
+
+      it 'sets resource variable' do
+        get :show, id: resource.id
+        expect(assigns(resource_sym)).to eq(resource)
+      end
+
+      it 'renders the :show view' do
+        get :show, id: resource.id
+        expect(response).to render_template :show
+      end
+    end
+  end
+
+  if actions.include? :create
+    describe '#create' do
+
+      it 'creates a new resource' do
+        expect do
+          post :create, resource_sym => attributes
+        end.to change(resource.class, :count).by(1)
+      end
+
+      it 'redirects to the new resource' do
+        post :create, resource_sym => attributes
+        expect(response).to redirect_to resource.class.last
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not save new resource' do
+          expect do
+            post :create, resource_sym => invalid_attributes
+          end.to change(resource.class, :count).by(0)
+        end
+
+        it 're-renders :new view' do
+          post :create, resource_sym => invalid_attributes
+          expect(response).to render_template :new
+        end
+      end
+    end
+  end
+
+  if actions.include? :update
+    describe '#update' do
+
+      let(:field_sym) { attributes.keys.first }
+
+      it 'updates the resource' do
+        resource
+        patch :update, id: resource.id,
+                       resource_sym => { field_sym => 'new-field-value' }
+        resource.reload
+        expect(resource.send(field_sym)).to eq('new-field-value')
+      end
+
+      it 'redirects to the updated resource' do
+        patch :update, id: resource.id,
+                       resource_sym => { field_sym => 'new-field-value' }
+        expect(response).to redirect_to resource
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not update the resource' do
+          expect do
+            patch :update, id: resource.id,
+                           resource_sym => invalid_attributes
+            resource.reload
+          end.not_to change(resource, invalid_attributes.keys.first)
+        end
+
+        it 're-renders :edit view' do
+          patch :update, id: resource.id,
+                         resource_sym => invalid_attributes
+          expect(:response).to render_template :edit
+        end
+      end
+    end
+  end
+
+  if actions.include? :destroy
+    describe '#destroy' do
+
+      it 'deletes the resource' do
+        resource
+        expect do
+          delete :destroy, id: resource.id
+        end.to change(resource.class, :count).by(-1)
+      end
+
+      it 'redirects to :index' do
+        resource
+        delete :destroy, id: resource.id
+        path = "#{resource.class.name.pluralize.underscore}_path"
+        expect(response)
+          .to redirect_to Rails.application.routes.url_helpers.send(path)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/media_asset.rb
+++ b/spec/support/shared_examples/media_asset.rb
@@ -1,0 +1,49 @@
+shared_examples 'media asset' do
+
+  let(:asset) { described_class.new(attributes) }
+
+  it 'is invalid without file_base' do
+    attributes[:file_base] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
+
+  it 'is invalid without mime_type' do
+    attributes[:mime_type] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
+
+  it 'has an source' do
+    expect(asset.source).to be_a Source
+  end
+
+  describe 'single asset validation' do
+
+    unless described_class.name == 'Image'
+      it 'is invalid if source already has large image asset' do
+        create(:image_factory, attachable: source, size: 'large')
+        expect(described_class.new(attributes)).not_to be_valid
+      end
+    end
+
+    unless described_class.name == 'Document'
+      it 'is invalid if source already has document asset' do
+        create(:document_factory, source: source)
+        expect(described_class.new(attributes)).not_to be_valid
+      end
+    end
+
+    unless described_class.name == 'Audio'
+      it 'is invalid if source already has audio asset' do
+        create(:audio_factory, source: source)
+        expect(described_class.new(attributes)).not_to be_valid
+      end
+    end
+
+    unless described_class.name == 'Video'
+      it 'is invalid if source already has video asset' do
+        create(:video_factory, source: source)
+        expect(described_class.new(attributes)).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/nested_controller.rb
+++ b/spec/support/shared_examples/nested_controller.rb
@@ -1,0 +1,86 @@
+##
+# This has specs for controllers whose routes are nested under a parent route.
+# Available actions to test are :index, create, :destroy
+#
+# @param actions Symbol the actions for this examples to test.
+#
+# This assumes the following variable have been defined in the controller spec,
+# or are passed as a block to this example:
+#   :resource
+#   :parent
+#   :attributes (:create only)
+#   :invalid_attributes (:create only)
+#
+shared_examples 'nested controller' do |*actions|
+
+  let(:resource_sym) { resource.class.name.downcase.to_sym }
+  let(:parent_id_sym) { "#{parent.class.name.underscore}_id".to_sym }
+
+  if actions.include? :index
+    describe '#index' do
+
+      it 'redirects to parent' do
+        get :index, parent_id_sym => parent.id
+        expect(response).to redirect_to parent
+      end
+    end
+  end
+
+  if actions.include? :create
+    describe '#create' do
+
+      before(:each) do
+        parent
+        resource.class.destroy(resource.class.find(resource.id)) if
+          resource.class.where(id: resource.id).present?
+      end
+
+      it 'creates a new resource' do
+        expect do
+          post :create, parent_id_sym => parent.id,
+                        resource_sym => attributes
+        end.to change(resource.class, :count).by(1)
+      end
+
+      it 'redirects to the new resource' do
+        post :create, parent_id_sym => parent.id,
+                      resource_sym => attributes
+        expect(response).to redirect_to resource.class.last
+      end
+
+      context 'with invalid attributes' do
+
+        it 'does not save new resource' do
+          expect do
+            post :create, parent_id_sym => parent.id,
+                          resource_sym => invalid_attributes
+          end.to change(resource.class, :count).by(0)
+        end
+
+        it 're-renders :new view' do
+          post :create, parent_id_sym => parent.id,
+                        resource_sym => invalid_attributes
+          expect(response).to render_template :new
+        end
+      end
+    end
+  end
+
+  if actions.include? :destroy
+    describe '#destroy' do
+
+      it 'deletes the resource' do
+        resource
+        expect do
+          delete :destroy, id: resource.id
+        end.to change(resource.class, :count).by(-1)
+      end
+
+      it 'redirects to parent' do
+        resource
+        delete :destroy, id: resource.id
+        expect(response).to redirect_to parent
+      end
+    end
+  end
+end

--- a/spec/views/audios/show.html.erb_spec.rb
+++ b/spec/views/audios/show.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'audios/show.html.erb', type: :view do
+
+  let(:audio) { create(:audio_factory) }
+
+  before do
+    assign(:audio, audio)
+  end
+
+  it 'renders the audio' do
+    render
+    expect(rendered).to include(audio.file_base)
+  end
+end

--- a/spec/views/authors/show.html.erb_spec.rb
+++ b/spec/views/authors/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'authors/show.html.erb', type: :view do
   let(:author) { create(:author_factory) }
-  
+
   before { assign(:author, author) }
 
   it 'renders the author' do

--- a/spec/views/documents/show.html.erb_spec.rb
+++ b/spec/views/documents/show.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'documents/show.html.erb', type: :view do
+
+  let(:document) { create(:document_factory) }
+
+  before do
+    assign(:document, document)
+  end
+
+  it 'renders the document' do
+    render
+    expect(rendered).to include(document.file_base)
+  end
+end

--- a/spec/views/images/show.html.erb_spec.rb
+++ b/spec/views/images/show.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'images/show.html.erb', type: :view do
+
+  let(:image) { create(:image_factory) }
+
+  before do
+    assign(:image, image)
+  end
+
+  it 'renders the image' do
+    render
+    expect(rendered).to include(image.file_base)
+  end
+end

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'videos/show.html.erb', type: :view do
+
+  let(:video) { create(:video_factory) }
+
+  before do
+    assign(:video, video)
+  end
+
+  it 'renders the video' do
+    render
+    expect(rendered).to include(video.file_base)
+  end
+end


### PR DESCRIPTION
This introduces the basic database tables, models, views, and controllers for media objects, including their relationships to source sets and sources.  It addresses [#8025](https://issues.dp.la/issues/8025) and follows the [ER Diagram](https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Relational+Database+Model).  This does NOT allow admins to upload actual media files, just their related metadata.

Media objects (images, video, audio, and documents) form a conceptual group of "assets".  Assets belong to "attachable" objects (sources or source sets).  "Assets" and "attachables" don't lend themselves to explicit representation in the relational database, nor did it seem helpful to make "asset" and "attachable" classes or mixins in the application.  Instead, "assets" and "attachables" are defined through relationships and accessors in the models.  These conceptual object types are helpful because they allow you to refer generically to, say, a source's `asset` without needed to know whether that `assets` is an image, video, etc.  There is a `shared_examples` [spec for "assets"](https://github.com/dpla/primary-source-sets/blob/980d72f8664f9ee84645b7a07a0c1ce39a82438c/spec/support/shared_examples/media_asset.rb) that describes the expected behavior of an "asset".

This refactors some controller specs, introducing some `shared_examples` to DRY them out.

To run tests locally:  remember to do `rake db:test:prepare`.

To run the server locally:  remember to clean up your database to get rid of any old data that conforms to previous database schema.  I find it easiest to do `bundle exec rake db:drop db:create db:migrate`.