### PR TITLE
add rake task to create sample admin account

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ copy, if you're using the local VM.  If you're using `automation`, and you want
 it to "use local source," in other words, use this working copy as the source of
 deployments, please be aware that the working copy's configuration files will be
 copied into the `automation` VM, by design.
+
+
+Sample data
+-----------
+
+To create a sample admin account for development and testing:
+
+    rake primary_source_sets:samples:create_admin
+
+This account will have username: 'sample@dp.la' and password: 'password'.

--- a/lib/tasks/primary_source_sets.rake
+++ b/lib/tasks/primary_source_sets.rake
@@ -1,0 +1,11 @@
+namespace :primary_source_sets do
+  namespace :samples do
+
+    desc 'Create a sample admin account'
+    task :create_admin => :environment do
+      Admin.new({ email: 'sample@dp.la',
+                  password: 'password',
+                  password_confirmation: 'password' }).save
+    end
+  end
+end


### PR DESCRIPTION
This introduces a rake task that creates a sample admin account for use in testing and development.