### PR TITLE
edit data entry fields and forms

### DIFF
--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -21,7 +21,7 @@
   </p>
  
   <p>
-    <strong><%= f.label :description %></strong><br/>
+    <strong><%= f.label 'SEO description' %></strong><br/>
     <em>Example: "This collection uses primary sources to explore the French and Indian War."</em><br/>
     <%= f.text_area :description %>
   </p>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -13,7 +13,7 @@
     <td><%= inline_markdown(@source_set.name) %></td>
   </tr>
   <tr>
-    <td><strong>Description </strong></td>
+    <td><strong>SEO description </strong></td>
     <td><%= @source_set.description %></td>
   </tr>
   <tr>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -21,7 +21,7 @@
   </p>
 
   <p>
-    <strong><%= f.label :name %></strong><br/>
+    <strong><%= f.label :caption %></strong><br/>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
@@ -39,7 +39,7 @@
   </p>
 
   <p>
-    <strong><%= f.label :textual_content %></strong><br/>
+    <strong><%= f.label 'Description / transcription' %></strong><br/>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
     <%= f.text_area :textual_content %>
   </p>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -18,7 +18,7 @@
     <td><%= link_to @source.aggregation_uri, @source.aggregation_uri %></td>
   </tr>
   <tr>
-    <td><strong>Name </strong></td>
+    <td><strong>Caption </strong></td>
     <td><%= inline_markdown(@source.name) %></td>
   </tr>
   <tr>
@@ -30,7 +30,7 @@
     <td><%= markdown(@source.credits) %></td>
   </tr>
   <tr>
-    <td><strong>Textual content </strong></td>
+    <td><strong>Description / transcription </strong></td>
     <td><%= markdown(@source.textual_content) %></td>
   </tr>
 </table>

--- a/db/migrate/20150929184236_sources_text_limits2.rb
+++ b/db/migrate/20150929184236_sources_text_limits2.rb
@@ -1,0 +1,5 @@
+class SourcesTextLimits2 < ActiveRecord::Migration
+  def change
+    change_column :sources, :textual_content, :text, limit: 16777215
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150923195451) do
+ActiveRecord::Schema.define(version: 20151001141212) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -31,8 +31,15 @@ ActiveRecord::Schema.define(version: 20150923195451) do
   add_index "admins", ["email"], name: "index_admins_on_email", unique: true
   add_index "admins", ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
 
+  create_table "attachments", force: true do |t|
+    t.integer "source_id"
+    t.integer "asset_id"
+    t.integer "asset_type"
+  end
+
+  add_index "attachments", ["source_id"], name: "index_attachments_on_source_id"
+
   create_table "audios", force: true do |t|
-    t.integer  "source_id"
     t.string   "mime_type"
     t.string   "file_base"
     t.datetime "created_at", null: false
@@ -63,7 +70,6 @@ ActiveRecord::Schema.define(version: 20150923195451) do
   add_index "authors_source_sets", ["source_set_id"], name: "index_authors_source_sets_on_source_set_id"
 
   create_table "documents", force: true do |t|
-    t.integer  "source_id"
     t.string   "mime_type"
     t.string   "file_base"
     t.datetime "created_at", null: false
@@ -96,16 +102,14 @@ ActiveRecord::Schema.define(version: 20150923195451) do
   add_index "guides", ["source_set_id"], name: "index_guides_on_source_set_id"
 
   create_table "images", force: true do |t|
-    t.integer  "attachable_id"
-    t.string   "attachable_type"
     t.string   "mime_type"
     t.string   "file_base"
     t.string   "size"
     t.integer  "height"
     t.integer  "width"
     t.string   "alt_text"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "source_sets", force: true do |t|
@@ -123,9 +127,9 @@ ActiveRecord::Schema.define(version: 20150923195451) do
     t.integer  "source_set_id"
     t.string   "name"
     t.string   "aggregation"
-    t.text     "textual_content", limit: 65535
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.text     "textual_content", limit: 16777215
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.text     "citation",        limit: 65535
     t.text     "credits",         limit: 65535
   end
@@ -133,7 +137,6 @@ ActiveRecord::Schema.define(version: 20150923195451) do
   add_index "sources", ["source_set_id"], name: "index_sources_on_source_set_id"
 
   create_table "videos", force: true do |t|
-    t.integer  "source_id"
     t.string   "mime_type"
     t.string   "file_base"
     t.datetime "created_at", null: false


### PR DESCRIPTION
This introduces some small edits to data entry fields and forms based on feedback from FA.  It addresses [#8055](https://issues.dp.la/issues/8055).

Field change:
* Increase the text limit for `guide.textual_content` from 65535 (MySQL TEXT) to 16777215 (MySQL MEDIUMTEXT)

Form changes:
* Change form label for `source_set.description` to "SEO description".
* Change form label for `source.name` to "Caption".
* Change form label for `source.textual_content` to "Description / transcription".

This also deletes a table definition from `db/schema.rb` that was mistakenly introduced in a previous PR.