### PR TITLE
Add audio and video transcoding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'rubocop', '~> 0.32.1', require: false
 # came out in December, 2013, and I'm cautious about a change after this long
 # a time being disruptive. --MB
 gem 's3_browser_uploads', '0.1.2'
+gem 'zencoder', '~>2.5'
 
 group :test, :development do
   gem 'rspec-core', '~> 3.3.2'
@@ -34,4 +35,8 @@ group :test, :development do
   gem 'database_cleaner', '~> 1.3.0', require: false
 
   gem 'json-ld', '~>1.1.9'
+end
+
+group :development do
+  gem 'zencoder-fetcher'
 end

--- a/README.md
+++ b/README.md
@@ -63,6 +63,31 @@ The incoming S3 bucket must also have a "policy" that allows the following
 actions on `arn:aws:s3:::<the bucket name>/*`: `s3:GetObject`, `s3:PutObject`,
 and `s3:DeleteObject`.
 
+### Zencoder development setup
+
+The zencoder-fetcher gem can be used during development to complete each
+upload-and-transcoding operation.  It's necessary when your development
+environment is behind a NAT firewall (the usual case) and Zencoder can't access
+your notification endpoint.
+
+In the shell that you'll be using during development that has access to the
+application (e.g. http://localhost:3000/primary-source-sets/), do this:
+
+The `zencoder-fetcher` gem should be installed with the `:development` group in
+the `Gemfile`.  This will allow its `zencoder-fetcher` command to be run like
+one of your `rake` or `rails` commands.  You could also install it somewhere
+else that has access to your app by running `gem install zencoder-fetcher`.
+
+Then you'll be able to run the command as follows:
+
+```
+zencoder_fetcher -u http://USER:PASSWORD@localhost:3000/primary-source-sets/video_notifications <API KEY>
+```
+
+... Where USER is zencoder.notification_user and PASSWORD is
+zencoder.notification_pass in your `settings.yml`.
+
+Substitute `video_notifications` for `audio_notifications` as necessary.
 
 ### When to use this and other DPLA project VMs
 

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -47,11 +47,6 @@
         if (xhr.readyState == 4) {
             if (xhr.status == '201') {
                 key = $('Key', xhr.responseXML).text();
-
-                // TODO: This is probably the place to start the encoding job.
-                // We could get a job ID and pass that to createAssetRecord
-                // along with `key'.
-
                 createAssetRecord(key);
             } else {
                 alert('Got an unexpected response: ' + xhr.statusText);
@@ -70,9 +65,7 @@
         file_base = key.replace(/^[a-z]+\/(.*)\.[a-z]+$/i, "$1");
 
         postdata = {};
-        // TODO: add encoding job ID?
-        // pss_asset_type defined in the HTML
-        postdata[pss_asset_type] = {file_base: file_base}
+        postdata[pss_asset_type] = {file_base: file_base, key: key}
 
         $.ajax({
             method: 'POST',

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -62,7 +62,7 @@
 
         // For file basename, get rid of "video/" or "audio/" path part and
         // file extension.
-        file_base = key.replace(/^[a-z]+\/(.*)\.[a-z]+$/i, "$1");
+        file_base = key.replace(/^[a-z]+\/(.*)\.[a-z0-9]+$/i, "$1");
 
         postdata = {};
         postdata[pss_asset_type] = {file_base: file_base, key: key}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,3 +19,7 @@ ensure that the app's assets are loading correctly. */
 body { font-family: Arial, Helvetica, sans-serif; }
 h1 { color: red; }
 textarea { background-color: cadetblue; }
+
+video {
+    background-color: #333;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,146 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :authenticate_admin!
+
+  ##
+  # Given information about an uploaded file in our "incoming" S3 bucket,
+  # create an encoding job with Zencoder.
+  #
+  # @return [String]  Zencoder job ID
+  # @raise [Zencoder::HTTPError] if no TCP/IP connection to Zencoder
+  # @raise [RuntimeError]        if HTTP request is unsuccessful
+  def create_transcoding_job(s3_key, file_base, outputs_settings)
+    job_opts = {
+      input: input_location(s3_key),
+      outputs: transcoding_outputs(file_base, outputs_settings),
+      notifications: transcoding_notifications
+    }
+    Zencoder.api_key = Settings.zencoder.api_key
+    logger.info "Creating job with: #{job_opts}"
+    response = Zencoder::Job.create(job_opts)
+    raise "Could not create transcoding job (status #{response.code})" \
+      unless response.code == '201'
+    response.body['id'].to_s
+  end
+
+  ##
+  # Create the initial `meta` field contents for when a model is first saved.
+  #
+  # Add essential properties: the CDN domain where the transcoded files will
+  # be served and the list of file output settings, representing the transcoded
+  # derivatives.
+  #
+  # @see create_media
+  #
+  def initial_media_meta
+    { cloudfront_domain: Settings.aws.cloudfront_domain,
+      output_settings: media_outputs }.to_json
+  end
+
+  def input_location(s3_key)
+    "s3://#{Settings.aws.s3_upload_bucket}/#{s3_key}"
+  end
+
+  ##
+  # @see VideosController#create
+  # @see AudiosController#create
+  #
+  def create_media(model, type)
+    # Create encoding job and store the job ID.
+    model[:transcoding_job] =
+      create_transcoding_job(params[type.to_s][:key], model[:file_base],
+                             Settings["#{type}_outputs"])
+
+    model[:meta] = initial_media_meta
+
+    if model.save
+      render json: { id: model.id,
+                     resource: self.send("#{type}_path", model) },
+             status: :created
+    else
+      # TODO: confirm that this is the right status to return.  Under what
+      # conditions should this be reached?
+      render json: { message: "Could not save #{model.capitalize} record" },
+             status: :internal_server_error
+    end
+  end
+
+  ##
+  # Update the appropriate media model with transcoding job status.
+  #
+  # @see VideoNotificationsController
+  # @see AudioNotificationsController
+  #
+  def create_notification(model_class)
+    job_id = params[:job][:id].to_s
+    state = params[:job][:state]
+    logger.info "#{model_class.to_s} job notification from " \
+                "#{request.remote_ip}: " \
+                "job ID #{job_id}, state: #{state}"
+    record = model_class.find_by_transcoding_job(job_id)
+
+    if !record.nil?
+      meta = JSON.parse(!record[:meta].nil? ? record[:meta] : '{}')
+      meta[:job] = params[:job]
+      meta[:outputs] = params[:outputs]
+      record[:meta] = meta.to_json
+      record.save
+      render nothing: true, status: :created
+    else
+      logger.info "Can not look up job ID #{job_id}"
+      render nothing: true, status: :unprocessable_entity
+    end
+  end
+
+  ##
+  # Return the appropriate Settings array of hashes, i.e. video_outputs or
+  # audio_outputs.
+  #
+  def media_outputs
+    raise "Must be overridden in the particular controller"
+  end
+
+  ##
+  # Return controller URL appropriate to the particular media controller.
+  # @see #transcoding_notifications
+  #
+  def notifications_url
+    raise "Must be overridden in the particular controller"
+  end
+
+  ##
+  # Return a URL for the "notifications" property of the JSON object that gets
+  # sent to Zencoder to tell it where to send its HTTP notification when the
+  # job is finished.
+  #
+  # @see #create_transcoding_job
+  #
+  def transcoding_notifications
+    if Rails.env.production? || Settings.dev_real_zc_notification
+      return [notifications_url]
+    else
+      return ["http://zencoderfetcher/"]
+    end
+  end
+
+  ##
+  # Return an array of hashes for the "outputs" property of the JSON object
+  # that gets sent to Zencoder to tell it what output files to produce.
+  #
+  # @param basename [String] File base name (without path or extension)
+  # @param outputs_settings [Array] of Config::Options
+  # @see #create_transcoding_job
+  #
+  def transcoding_outputs(basename, outputs_settings)
+    out = []
+    outputs_settings.each do |settings|
+      file = {}
+      file[:url] = "s3://#{Settings.aws.s3_destination_bucket}/" \
+                   "#{basename}#{settings.suffix}.#{settings.extension}"
+      file[:size] = settings.size
+      file[:h264_profile] = settings.h264_profile
+      out << file.compact
+    end
+    out
+  end
 end

--- a/app/controllers/audio_notifications_controller.rb
+++ b/app/controllers/audio_notifications_controller.rb
@@ -1,0 +1,19 @@
+##
+# Respond to notifications from Zencoder about job status, updating the
+# appropriate Audio record.
+#
+class AudioNotificationsController < ApplicationController
+  skip_before_filter :verify_authenticity_token
+  skip_before_filter :authenticate_admin!
+  include ZencoderAuthentication
+
+  ##
+  # Accept posted JSON data from Zencoder representing a job. Look up the Audio
+  # with that job ID and update its status.
+  #
+  def create
+    render(nothing: true, status: :bad_request) and return \
+      unless params.include?(:job)
+    create_notification(Audio)
+  end
+end

--- a/app/controllers/audios_controller.rb
+++ b/app/controllers/audios_controller.rb
@@ -20,32 +20,11 @@ class AudiosController < ApplicationController
                          .ogg .au .adp .aac .weba).join(',')
   end
 
-  def edit
-    @audio = Audio.find(params[:id])
-  end
-
   ##
-  # @see VideosController#create
+  # @see ApplicationController#create_media
   def create
     @audio = Audio.new(audio_params)
-
-    if @audio.save
-      render json: { id: @audio.id, resource: audio_path(@audio) },
-             status: :created
-    else
-      render json: { message: 'Internal Server Error' },
-             status: :internal_server_error
-    end
-  end
-
-  def update
-    @audio = Audio.find(params[:id])
-
-    if @audio.update(audio_params)
-      redirect_to @audio
-    else
-      render 'edit'
-    end
+    create_media(@audio, 'audio')
   end
 
   def destroy
@@ -53,6 +32,20 @@ class AudiosController < ApplicationController
     @audio.destroy
 
     redirect_to audios_path
+  end
+
+  ##
+  # @see ApplicationController#transcoding_notifications
+  def notifications_url
+    Settings.app_scheme + Settings.zencoder.notification_user + ':' \
+      + Settings.zencoder.notification_pass + '@' \
+      + Settings.app_host + audio_notifications_path
+  end
+
+  ##
+  # @see ApplicationController#media_outputs
+  def media_outputs
+    Settings.audio_outputs.map { |o| o.to_h }
   end
 
   private

--- a/app/controllers/concerns/zencoder_authentication.rb
+++ b/app/controllers/concerns/zencoder_authentication.rb
@@ -1,0 +1,9 @@
+
+module ZencoderAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    http_basic_authenticate_with name: Settings.zencoder.notification_user,
+                                 password: Settings.zencoder.notification_pass
+  end
+end

--- a/app/controllers/video_notifications_controller.rb
+++ b/app/controllers/video_notifications_controller.rb
@@ -1,0 +1,19 @@
+##
+# Respond to notifications from Zencoder about job status, updating the
+# appropriate Video record.
+#
+class VideoNotificationsController < ApplicationController
+  skip_before_filter :verify_authenticity_token
+  skip_before_filter :authenticate_admin!
+  include ZencoderAuthentication
+
+  ##
+  # Accept posted JSON data from Zencoder representing a job. Look up the Video
+  # with that job ID and update its status.
+  #
+  def create
+    render(nothing: true, status: :bad_request) and return \
+      unless params.include?(:job)
+    create_notification(Video)
+  end
+end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -31,32 +31,11 @@ class VideosController < ApplicationController
                          .webm .qt .movie .dv).join(',')
   end
 
-  def edit
-    @video = Video.find(params[:id])
-  end
-
+  ##
+  # @see ApplicationController#create_media
   def create
     @video = Video.new(video_params)
-
-    if @video.save
-      render json: { id: @video.id, resource: video_path(@video) },
-             status: :created
-    else
-      # TODO: confirm that this is the right status to return.  Under what
-      # conditions should this be reached?
-      render json: { message: 'Internal Server Error' },
-             status: :internal_server_error
-    end
-  end
-
-  def update
-    @video = Video.find(params[:id])
-
-    if @video.update(video_params)
-      redirect_to @video
-    else
-      render 'edit'
-    end
+    create_media(@video, 'video')
   end
 
   def destroy
@@ -64,6 +43,18 @@ class VideosController < ApplicationController
     @video.destroy
 
     redirect_to videos_path
+  end
+
+  ##
+  # @see ApplicationController#transcoding_notifications
+  def notifications_url
+    Settings.app_base_url + video_notifications_path
+  end
+
+  ##
+  # @see ApplicationController#media_outputs
+  def media_outputs
+    Settings.video_outputs.map { |o| o.to_h }
   end
 
   private

--- a/app/helpers/audio_player_helper.rb
+++ b/app/helpers/audio_player_helper.rb
@@ -1,0 +1,24 @@
+module AudioPlayerHelper
+  def audio_player(audio)
+    # Fixed mimetypes determined by file extension
+    mimetype = {
+      'mp3' => 'audio/mpeg',
+      'm4a' => 'audio/mp4',
+      'ogg' => 'audio/ogg'
+    }
+
+    meta = JSON.parse(audio.meta)
+    outputs = meta['output_settings']
+    rv = "<audio preload=\"none\" controls>\n"
+    outputs.each do |out|
+      extension = out['extension']
+      suffix = out.fetch('suffix', '')
+      src = Settings.app_scheme + Settings.aws.cloudfront_domain + '/' \
+        + audio.file_base + suffix + ".#{extension}"
+      rv << "<source src=\"#{src}\" type=\"#{mimetype[extension]}\"/>\n"
+    end
+    rv << "Your browser does not support HTML5 audio.\n"
+    rv << "</audio>\n"
+    rv
+  end
+end

--- a/app/helpers/transcoding_status_helper.rb
+++ b/app/helpers/transcoding_status_helper.rb
@@ -1,0 +1,8 @@
+module TranscodingStatusHelper
+  def transcoding_status(model_instance)
+    meta = JSON.parse(model_instance.meta)
+    s = meta.fetch('job', {}).fetch('state', false)
+    "<div class=\"trans-status\">Transcoding status: " \
+      "#{s ? s : 'pending'}</div>\n"
+  end
+end

--- a/app/helpers/video_player_helper.rb
+++ b/app/helpers/video_player_helper.rb
@@ -1,0 +1,24 @@
+module VideoPlayerHelper
+  def video_player(video)
+    # Fixed mimetypes determined by file extension
+    mimetype = {
+      'mp4' => 'video/mp4',
+      'webm' => 'video/webm',
+      'ogg' => 'video/ogg'
+    }
+
+    meta = JSON.parse(video.meta)
+    outputs = meta['output_settings']
+    rv = "<video preload=\"none\" width=\"640\" height=\"480\" controls>\n"
+    outputs.each do |out|
+      extension = out['extension']
+      suffix = out.fetch('suffix', '')
+      src = Settings.app_scheme + Settings.aws.cloudfront_domain + '/' \
+        + video.file_base + ".#{extension}"
+      rv << "<source src=\"#{src}\" type=\"#{mimetype[extension]}\"/>\n"
+    end
+    rv << "Your browser does not support HTML5 video.\n"
+    rv << "</video>\n"
+    rv
+  end
+end

--- a/app/views/audios/show.html.erb
+++ b/app/views/audios/show.html.erb
@@ -21,3 +21,7 @@
   <li><%= link_to inline_markdown(source_name(source)), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
 <% end %>
 </ul>
+
+<%= raw audio_player(@audio) %>
+
+<%= raw transcoding_status(@audio) %>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -22,3 +22,6 @@
 <% end %>
 </ul>
 
+<%= raw video_player(@video) %>
+
+<%= raw transcoding_status(@video) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   resources :documents
   resources :audios
   resources :videos
+  resources :video_notifications, only: [:create]
+  resources :audio_notifications, only: [:create]
 
   root 'source_sets#index'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,9 @@ frontend:
   # With trailing slash
   url: http://example.com
 
-host: 'localhost'
+app_scheme: 'http://'
+# app_host may include port
+app_host: 'localhost:3000'
 
 relative_url_root: /primary-source-sets
 
@@ -20,3 +22,32 @@ aws:
   secret_access_key: 'CHANGEME'
   s3_upload_bucket: 'CHANGEME'
   s3_destination_bucket: 'CHANGEME'
+  cloudfront_domain: 'CHANGEME'
+
+zencoder:
+  api_key: CHANGEME
+  notification_pass: CHANGEME
+  notification_user: CHANGEME
+
+video_outputs:
+  - {extension: "mp4"}
+  - {extension: "webm"}
+  - {extension: "ogg"}
+  # If we can figure out a good way to have multiple <source> elements for the
+  # same mime type, then it would be nice to serve a smaller mobile version and
+  # a high-quality mp4 version, too.
+  # - {extension: "mp4", h264_profile: "high"}
+  # - {extension: "mp4", suffix: "-mobile", size: "640x480"}
+audio_outputs:
+  - {extension: "mp3"}
+  - {extension: "m4a"}
+  - {extension: "ogg"}
+
+# When RAILS_ENV is 'development' or 'test', this determines whether to request
+# Zencoder to send notifications to an HTTP endpoint
+# (VideoNotificationsController or AudioNotificationsController) or to save it
+# so that we can use the zencoder_fetcher utility to pull the notifications from
+# their API and post them locally.  This is relevant if you're behind a
+# NAT firewall, the assumed situation in development.  The default is false,
+# meaning not to make "real" HTTP requests.
+dev_real_zc_notification: false

--- a/db/migrate/20151004184131_add_meta_to_audios.rb
+++ b/db/migrate/20151004184131_add_meta_to_audios.rb
@@ -1,0 +1,5 @@
+class AddMetaToAudios < ActiveRecord::Migration
+  def change
+    add_column :audios, :meta, :text
+  end
+end

--- a/db/migrate/20151004184152_add_meta_to_videos.rb
+++ b/db/migrate/20151004184152_add_meta_to_videos.rb
@@ -1,0 +1,5 @@
+class AddMetaToVideos < ActiveRecord::Migration
+  def change
+    add_column :videos, :meta, :text
+  end
+end

--- a/db/migrate/20151004185055_add_zencoder_job_to_audios.rb
+++ b/db/migrate/20151004185055_add_zencoder_job_to_audios.rb
@@ -1,0 +1,6 @@
+class AddZencoderJobToAudios < ActiveRecord::Migration
+  def change
+    add_column :audios, :zencoder_job, :integer
+    add_index :audios, :zencoder_job
+  end
+end

--- a/db/migrate/20151004185111_add_zencoder_job_to_videos.rb
+++ b/db/migrate/20151004185111_add_zencoder_job_to_videos.rb
@@ -1,0 +1,6 @@
+class AddZencoderJobToVideos < ActiveRecord::Migration
+  def change
+    add_column :videos, :zencoder_job, :integer
+    add_index :videos, :zencoder_job
+  end
+end

--- a/db/migrate/20151006211214_remove_zencoder_job_from_audios.rb
+++ b/db/migrate/20151006211214_remove_zencoder_job_from_audios.rb
@@ -1,0 +1,5 @@
+class RemoveZencoderJobFromAudios < ActiveRecord::Migration
+  def change
+    remove_column :audios, :zencoder_job, :integer
+  end
+end

--- a/db/migrate/20151006211252_remove_zencoder_job_from_videos.rb
+++ b/db/migrate/20151006211252_remove_zencoder_job_from_videos.rb
@@ -1,0 +1,5 @@
+class RemoveZencoderJobFromVideos < ActiveRecord::Migration
+  def change
+    remove_column :videos, :zencoder_job, :integer
+  end
+end

--- a/db/migrate/20151006211336_add_transcoding_job_to_audios.rb
+++ b/db/migrate/20151006211336_add_transcoding_job_to_audios.rb
@@ -1,0 +1,6 @@
+class AddTranscodingJobToAudios < ActiveRecord::Migration
+  def change
+    add_column :audios, :transcoding_job, :string
+    add_index :audios, :transcoding_job, unique: true
+  end
+end

--- a/db/migrate/20151006211352_add_transcoding_job_to_videos.rb
+++ b/db/migrate/20151006211352_add_transcoding_job_to_videos.rb
@@ -1,0 +1,6 @@
+class AddTranscodingJobToVideos < ActiveRecord::Migration
+  def change
+    add_column :videos, :transcoding_job, :string
+    add_index :videos, :transcoding_job, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,9 +42,13 @@ ActiveRecord::Schema.define(version: 20151008142719) do
 
   create_table "audios", force: true do |t|
     t.string   "file_base"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.text     "meta"
+    t.string   "transcoding_job"
   end
+
+  add_index "audios", ["transcoding_job"], name: "index_audios_on_transcoding_job", unique: true
 
   create_table "authors", force: true do |t|
     t.string   "name"
@@ -139,8 +143,12 @@ ActiveRecord::Schema.define(version: 20151008142719) do
 
   create_table "videos", force: true do |t|
     t.string   "file_base"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.text     "meta"
+    t.string   "transcoding_job"
   end
+
+  add_index "videos", ["transcoding_job"], name: "index_videos_on_transcoding_job", unique: true
 
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,201 @@
+require 'rails_helper'
+
+RSpec.configure do |c|
+  c.infer_base_class_for_anonymous_controllers = false
+end
+
+describe ApplicationController, type: :controller do
+
+  describe '#create_transcoding_job' do
+    let(:response) { double }
+    let(:response_body) { { 'id' => 123 } }
+
+    before do
+      allow(Zencoder::Job).to receive(:create).and_return(response)
+      allow(response).to receive(:body).and_return(response_body)
+    end
+
+    it 'calls Zencoder::Job with the correct options' do
+      allow(subject).to receive(:input_location).and_return('loc')
+      allow(subject).to receive(:transcoding_outputs).and_return(['o'])
+      allow(subject).to receive(:transcoding_notifications).and_return(['n'])
+      allow(response).to receive(:code).and_return('201')
+      opts = { input: 'loc', outputs: ['o'], notifications: ['n'] }
+      expect(Zencoder::Job).to receive(:create).with(opts).and_return(response)
+      subject.create_transcoding_job('a', 'b', {})
+    end
+
+    it 'logs the job creation' do
+      allow(response).to receive(:code).and_return('201')
+      msg = "Creating job with: {:input=>\"s3://" \
+            "#{Settings.aws.s3_upload_bucket}/a\", :outputs=>[], " \
+            ":notifications=>[\"http://zencoderfetcher/\"]}"
+      expect(Rails.logger).to receive(:info).with(msg)
+      subject.create_transcoding_job('a', 'b', {})
+    end
+
+    it 'returns a String job ID' do
+      allow(response).to receive(:code).and_return('201')
+      expect(subject.create_transcoding_job('a', 'b', {})).to eq('123')
+    end
+  end
+
+  describe '#create_notification' do
+    let(:remote_addr) { '192.168.0.2' }
+    let(:outputs) { ['a'] }
+    let(:video) { create(:video_factory) }
+    let(:video_with_nil_meta) { create(:video_with_nil_meta_factory) }
+    let(:params1) do
+      {
+        job: { id: '1', state: 'finished' },
+        outputs: ['a']
+      }
+    end
+    let(:params2) do
+      {
+        job: { id: '2', state: 'finished' }
+      }
+    end
+    let(:params99) do
+      {
+        job: { id: '99', state: 'finished' }
+      }
+    end
+
+    controller VideoNotificationsController do
+      def create
+        create_notification(Video)
+      end
+    end
+
+    include ZencoderAuthHelper
+
+    before do
+      allow(Video).to receive(:find_by_transcoding_job)
+                  .with('1')
+                  .and_return(video)
+      allow(Video).to receive(:find_by_transcoding_job)
+                  .with('2')
+                  .and_return(video_with_nil_meta)
+      allow(Video).to receive(:find_by_transcoding_job)
+                  .with('99')
+                  .and_return(nil)
+      @request.env['REMOTE_ADDR'] = remote_addr
+    end
+
+    context 'with found job ID' do
+      before do
+        zc_basic_auth_login
+      end
+
+      it 'renders "Created" status' do
+        post :create, params1
+        expect(response.status).to eq(201)
+      end
+
+      it 'logs the notification' do
+        allow(subject).to receive(:params).and_return(params1)
+        msg = "Video job notification from #{remote_addr}:" \
+              " job ID 1, state: finished"
+        expect(Rails.logger).to receive(:info).with(msg)
+        post :create, job: params1
+      end
+
+      it 'saves `meta` JSON with "job" from input' do
+        post :create, params1
+        record = Video.find(1)
+        meta = JSON.parse(record.meta)
+        expect(meta['job']['id']).to eq('1')
+      end
+
+      it 'saves `meta` JSON with "outputs" from input' do
+        post :create, params1
+        record = Video.find(1)
+        meta = JSON.parse(record.meta)
+        expect(meta['outputs']).to eq(outputs)
+      end
+    end
+
+    context 'with not-found job ID' do
+      before do
+        allow(subject).to receive(:params).and_return(params99)
+        zc_basic_auth_login
+      end
+
+      it 'logs the failed notification' do
+        msg1 = "Video job notification from #{remote_addr}:" \
+               " job ID 99, state: finished"
+        msg2 = "Can not look up job ID 99"
+        expect(Rails.logger).to receive(:info).with(msg1)
+        expect(Rails.logger).to receive(:info).with(msg2)
+        post :create, job: params99
+      end
+
+      it 'renders "Unprocessable Entity" when media record can not be found' do
+        post :create, params99
+        expect(response.status).to eq(422)
+      end
+    end
+
+    # FIXME:
+    # This needs to be moved to a spec for ZencoderAuthentication concern,
+    # but I'm not sure where to put that.
+    context 'with bad HTTP Basic Auth credentials' do
+      before do
+        zc_bad_basic_auth_login
+      end
+      it 'renders a 401 Unauthorized response' do
+        post :create, params1
+        expect(response.status).to eq(401)
+      end
+    end
+  end  # #create_notifications
+
+  describe '#transcoding_outputs' do
+    let(:aws) { double }
+    let(:config_option) { double }
+    let(:outputs_settings) {
+      [ config_option ]  # Array of Config::Option
+    }
+    before do
+      allow(Settings).to receive(:aws).and_return(aws)
+      allow(aws).to receive(:s3_destination_bucket)
+                .and_return('bucket')
+      allow(config_option).to receive(:extension)
+                          .and_return('mp4')
+      allow(config_option).to receive(:size)
+                          .and_return(nil)
+      allow(config_option).to receive(:h264_profile)
+                          .and_return(nil)
+      allow(config_option).to receive(:suffix)
+                          .and_return(nil)
+    end
+
+    context 'with a file suffix' do
+      before do
+        allow(config_option).to receive(:suffix).and_return('-mobile')
+      end
+      it 'returns the correct array' do
+        expect(subject.transcoding_outputs('name', outputs_settings))
+          .to eq([{url: 's3://bucket/name-mobile.mp4'}])
+      end
+    end
+
+    context 'without a file suffix' do
+      it 'returns the correct array' do
+        expect(subject.transcoding_outputs('name', outputs_settings))
+          .to eq([{url: 's3://bucket/name.mp4'}])
+      end
+    end
+
+    context 'with an H.264 profile parameter' do
+      before do
+        allow(config_option).to receive(:h264_profile).and_return('high')
+      end
+      it 'returns the correct array' do
+        expect(subject.transcoding_outputs('name', outputs_settings))
+          .to eq([{url: 's3://bucket/name.mp4', h264_profile: 'high'}])
+      end
+    end
+  end
+end

--- a/spec/controllers/audios_controller_spec.rb
+++ b/spec/controllers/audios_controller_spec.rb
@@ -6,12 +6,11 @@ describe AudiosController, type: :controller do
   let(:attributes) { attributes_for(:audio_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_audio_factory) }
 
-  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit, :create
 
   context 'admin logged in' do
     login_admin
 
-    it_behaves_like 'basic controller', :index, :show, :create, :update,
-                                        :destroy
+    it_behaves_like 'basic controller', :index, :show
   end
 end

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -6,12 +6,11 @@ describe VideosController, type: :controller do
   let(:attributes) { attributes_for(:video_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_video_factory) }
 
-  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+  it_behaves_like 'admin-only route', :index, :show, :new, :edit, :create
 
   context 'admin logged in' do
     login_admin
 
-    it_behaves_like 'basic controller', :index, :show, :create, :update,
-                                        :destroy
+    it_behaves_like 'basic controller', :show
   end
 end

--- a/spec/factories/audios.rb
+++ b/spec/factories/audios.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :audio_factory, class: Audio do
     file_base 'adventures-of-moomin'
+    meta '{"cloudfront_domain":"x", ' \
+         '"output_settings":[{"extension":"mp3"},{"extension":"m4a"},' \
+         '{"extension":"ogg"}]}'
   end
 
   factory :invalid_audio_factory, class: Audio do

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,9 +1,20 @@
 FactoryGirl.define do
   factory :video_factory, class: Video do
+    id 1
     file_base 'adventures-of-moomin'
+    meta '{"cloudfront_domain":"a", "output_settings":[{"extension":"b"}]}'
+    transcoding_job '1'
+  end
+
+  factory :video_with_nil_meta_factory, class: Video do
+    id 2
+    file_base 'f'
+    meta nil
+    transcoding_job '2'
   end
 
   factory :invalid_video_factory, class: Video do
+    id 3
     file_base nil
   end
 end

--- a/spec/support/zencoder_auth_helper.rb
+++ b/spec/support/zencoder_auth_helper.rb
@@ -1,0 +1,21 @@
+module ZencoderAuthHelper
+
+  def zc_basic_auth_login
+    user = Settings.zencoder.notification_user
+    pw = Settings.zencoder.notification_pass
+    set_auth(user, pw)
+  end
+
+  def zc_bad_basic_auth_login
+    user = 'x'
+    pw = 'y'
+    set_auth(user, pw)
+  end
+
+  private
+
+  def set_auth(user, pw)
+    request.env['HTTP_AUTHORIZATION'] =
+      ActionController::HttpAuthentication::Basic.encode_credentials(user, pw)
+  end
+end

--- a/spec/views/videos/index.html.erb_spec.rb
+++ b/spec/views/videos/index.html.erb_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 describe 'videos/index.html.erb', type: :view do
 
   before do
-    assign(:videos, [create(:video_factory, file_base: 'file1'),
-                     create(:video_factory, file_base: 'file2')])
+    assign(:videos, [create(:video_factory, file_base: 'file1', id: 1,
+                            transcoding_job: '1'),
+                     create(:video_factory, file_base: 'file2', id: 2,
+                            transcoding_job: '2')])
   end
 
   it 'renders each video' do


### PR DESCRIPTION
Add media transcoding using the Brightcove Zencoder service.

To test this, you need a Zencoder API key, which requires a free signup. You can use your account's "integration" key to ensure that only test (non-billable) transcodings are performed.  Check `settings.local` for new fields that have been added.

Known potential issues:
* I'm not sure if the view helpers for the audio and video tags are ideal, because you have to specify `raw` when you call them from views, because they return strings of HTML.  But not that this has to hold things up right now.
* This is tied in to Zencoder.  The file upload in an earlier commit was also tied in to Amazon S3.  At least the `meta` fields and the generically-labeled `transcoding_job` fields of the `audios` and `videos` tables might make it not too hard to migrate if we ever have to.
