### PR TITLE
add frontend_path method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,14 @@ module ApplicationHelper
     source.name.present? ? source.name : source.aggregation
   end
 
+  ##
+  # Returns frontend path with correctly joining '/'
+  # @param path String (with or without leading slash)
+  # @return String
+  def frontend_path(path = '')
+    Settings.frontend.url.chomp('/') + '/' + path.sub(/^\/+/) { $1 }
+  end
+
   private
 
   ##

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -51,8 +51,4 @@ class Source < ActiveRecord::Base
       true if a.class.name == 'Image' && a.size != 'large'
     end.first
   end
-
-  def aggregation_uri
-    Settings.frontend.url + 'item/' + aggregation
-  end
 end

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -15,7 +15,7 @@
   </tr>
   <tr>
     <td><strong>DPLA item URI </strong></td>
-    <td><%= link_to @source.aggregation_uri, @source.aggregation_uri %></td>
+    <td><%= link_to frontend_path(@source.aggregation), frontend_path(@source.aggregation) %></td>
   </tr>
   <tr>
     <td><strong>Caption </strong></td>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 describe ApplicationHelper, type: :helper do
    
-   describe '#markdown' do
+  describe '#markdown' do
 
-     it 'renders HTML from a markdown String' do
-       text = '**Moomin!**'
-       expect(helper.markdown(text)).to eq("<p><strong>Moomin!</strong></p>\n")
+    it 'renders HTML from a markdown String' do
+      text = '**Moomin!**'
+      expect(helper.markdown(text)).to eq("<p><strong>Moomin!</strong></p>\n")
+    end
+
+    it 'raises a TypeError if input is not a String' do
+      invalid_input = 123
+      expect{ helper.markdown(invalid_input) }.to raise_error(TypeError)
      end
+  end
 
-     it 'raises a TypeError if input is not a String' do
-       invalid_input = 123
-       expect{ helper.markdown(invalid_input) }.to raise_error(TypeError)
-     end
-   end
-
-   describe '#inline_markdown' do
+  describe '#inline_markdown' do
 
     it 'strips enclosing <p> tags' do
       text = '**Moomin!**'
@@ -26,6 +26,14 @@ describe ApplicationHelper, type: :helper do
       text = '<p>Moomin!</p><p>Snorkmaiden</p>'
       expect(helper.inline_markdown(text))
         .to eq("<p>Moomin!</p><p>Snorkmaiden</p>\n")
+    end
+  end
+
+  describe '#frontend_path' do
+    it 'constructs a URI with correct /s' do
+      allow(Settings).to receive_message_chain(:frontend, :url)
+        .and_return 'http://example.com/'
+      expect(helper.frontend_path('/path')).to eq 'http://example.com/path'
     end
   end
 end


### PR DESCRIPTION
This adds a `frontend_path`, that constructs a link to the frontend.  It checks for the correct `/` between the path base defined in `Settings.frontend.url` and the appended path name.  This is more fool-proof than the previous code, which was unforgiving if both the path base and the appended path name did not have `/`s in the right places.  

It also moves the method out of the `source` model, to a more appropriate location in a `helper`.

This should fix the current problem on staging, where the path is showing up without the adjoining `/` (see [#8062](https://issues.dp.la/issues/8062))