### PR TITLE
Fix bug in video notification URL

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -48,7 +48,9 @@ class VideosController < ApplicationController
   ##
   # @see ApplicationController#transcoding_notifications
   def notifications_url
-    Settings.app_base_url + video_notifications_path
+    Settings.app_scheme + Settings.zencoder.notification_user + ':' \
+      + Settings.zencoder.notification_pass + '@' \
+      + Settings.app_host + video_notifications_path
   end
 
   ##


### PR DESCRIPTION
This fixes a bug whereby I'd forgotten to update `VideosController#notifidcations_url` with the necessary concatenation of some new settings variables.
