### PR TITLE
Add Zencoder named credentials

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,11 +12,13 @@ class ApplicationController < ActionController::Base
   # @raise [Zencoder::HTTPError] if no TCP/IP connection to Zencoder
   # @raise [RuntimeError]        if HTTP request is unsuccessful
   def create_transcoding_job(s3_key, file_base, outputs_settings)
+    credentials = Settings.zencoder.s3_credentials_name || nil
     job_opts = {
       input: input_location(s3_key),
       outputs: transcoding_outputs(file_base, outputs_settings),
-      notifications: transcoding_notifications
-    }
+      notifications: transcoding_notifications,
+      credentials: credentials
+    }.compact
     Zencoder.api_key = Settings.zencoder.api_key
     logger.info "Creating job with: #{job_opts}"
     response = Zencoder::Job.create(job_opts)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,11 @@ zencoder:
   api_key: CHANGEME
   notification_pass: CHANGEME
   notification_user: CHANGEME
+  # `false` for s3_credentials_name means to use the Zencoder account's default
+  # credentials, as opposed to specifying a saved set of credentials by name.
+  # Named credentials are useful for having different S3 policies for different
+  # development, staging, and production buckets.
+  s3_credentials_name: false
 
 video_outputs:
   - {extension: "mp4"}


### PR DESCRIPTION
Add handling for Zencoder named credential sets.  These are named sets of Amazon IAM (access management) keys that can be used in order to have separate permissions on development, staging, and production buckets.