### PR TITLE
remove a/v edit views

### DIFF
--- a/app/views/audios/edit.html.erb
+++ b/app/views/audios/edit.html.erb
@@ -1,9 +1,0 @@
-<h1>Edit audio</h1>
-
-<p>
-  <%= link_to "View", audio_path(@audio) %>
-  |
-  <%= link_to "Delete", 
-               audio_path(@audio), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{@audio.file_base}?" } %>
-</p>

--- a/app/views/audios/index.html.erb
+++ b/app/views/audios/index.html.erb
@@ -7,7 +7,6 @@
   <tr>
     <td><%= audio.file_base %></td>
     <td><%= link_to "View", audio_path(audio) %></td>
-    <td><%= link_to "Edit", edit_audio_path(audio) %></td>
     <td><%= link_to "Delete", audio_path(audio),
                     method: :delete,
                     data: { confirm: "Are you sure you want to delete #{audio.file_base}?" } %></td>

--- a/app/views/audios/show.html.erb
+++ b/app/views/audios/show.html.erb
@@ -1,8 +1,6 @@
 <h1>Audio: <%= @audio.file_base %></h1>
 
 <p>
-  <%= link_to "Edit", edit_audio_path(@audio) %>
-  |
   <%= link_to "Delete", 
                audio_path(@audio), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@audio.file_base}?" } %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -48,7 +48,6 @@
       <td><strong>Main media asset (<%= @source.main_asset.class.name %>)</strong></td>
       <td><%= @source.main_asset.file_base %></td>
       <td><%= link_to "View", polymorphic_path(@source.main_asset) %></td>
-      <td><%= link_to "Edit", edit_polymorphic_path(@source.main_asset) %></td>
       <td><%= link_to "Delete", polymorphic_path(@source.main_asset),
                       method: :delete,
                       data: { confirm: "Are you sure you want to delete #{@source.main_asset.file_base}?" } %></td>

--- a/app/views/videos/edit.html.erb
+++ b/app/views/videos/edit.html.erb
@@ -1,9 +1,0 @@
-<h1>Edit video</h1>
-
-<p>
-  <%= link_to "View", video_path(@video) %>
-  |
-  <%= link_to "Delete", 
-               video_path(@video), method: :delete,
-               data: { confirm: "Are you sure you want to delete #{@video.file_base}?" } %>
-</p>

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -7,7 +7,6 @@
   <tr>
     <td><%= video.file_base %></td>
     <td><%= link_to "View", video_path(video) %></td>
-    <td><%= link_to "Edit", edit_video_path(video) %></td>
     <td><%= link_to "Delete", video_path(video),
                     method: :delete,
                     data: { confirm: "Are you sure you want to delete #{video.file_base}?" } %></td>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -1,8 +1,6 @@
 <h1>Video: <%= @video.file_base %></h1>
 
 <p>
-  <%= link_to "Edit", edit_video_path(@video) %>
-  |
   <%= link_to "Delete", 
                video_path(@video), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@video.file_base}?" } %>

--- a/spec/controllers/audios_controller_spec.rb
+++ b/spec/controllers/audios_controller_spec.rb
@@ -6,7 +6,7 @@ describe AudiosController, type: :controller do
   let(:attributes) { attributes_for(:audio_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_audio_factory) }
 
-  it_behaves_like 'admin-only route', :index, :show, :new, :edit, :create
+  it_behaves_like 'admin-only route', :index, :show, :new, :create
 
   context 'admin logged in' do
     login_admin

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -6,7 +6,7 @@ describe VideosController, type: :controller do
   let(:attributes) { attributes_for(:video_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_video_factory) }
 
-  it_behaves_like 'admin-only route', :index, :show, :new, :edit, :create
+  it_behaves_like 'admin-only route', :index, :show, :new, :create
 
   context 'admin logged in' do
     login_admin


### PR DESCRIPTION
This removes `audio` and `video` `edit` views and link to those views.  It addresses ticket [#8071](https://issues.dp.la/issues/8071).