### PR TITLE
Fix Content-Type of uploaded images and documents

### DIFF
--- a/app/assets/javascripts/docupload.js
+++ b/app/assets/javascripts/docupload.js
@@ -14,6 +14,16 @@
 
             e.preventDefault();
 
+            files = $('input[name=file]').prop('files');
+            if (! files.length) {
+                alert('Please choose a file.');
+                return false;
+            }
+
+            // Fill in Content-Type so S3 doesn't default to
+            // "application/octet-stream".
+            $('input[name=Content-Type]').val(files[0].type)
+
             var data = new FormData(this);
             var xhr = new XMLHttpRequest();
 

--- a/app/assets/javascripts/imgupload.js
+++ b/app/assets/javascripts/imgupload.js
@@ -14,6 +14,16 @@
 
             e.preventDefault();
 
+            files = $('input[name=file]').prop('files');
+            if (! files.length) {
+                alert('Please choose a file.');
+                return false;
+            }
+
+            // Fill in Content-Type so S3 doesn't default to
+            // "application/octet-stream".
+            $('input[name=Content-Type]').val(files[0].type)
+
             var data = new FormData(this);
             var xhr = new XMLHttpRequest();
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -16,6 +16,8 @@ class DocumentsController < ApplicationController
   def new
     @document = Document.new
     @formdef = PSSBrowserUploads.nonav_form_definition('pdf')
+    @formdef.add_field('Content-Type', '')
+    @formdef.add_condition('Content-Type', 'starts-with' => '')
     @accepted_types = '.pdf'
   end
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -16,6 +16,8 @@ class ImagesController < ApplicationController
   def new
     @image = Image.new
     @formdef = PSSBrowserUploads.nonav_form_definition('image')
+    @formdef.add_field('Content-Type', '')
+    @formdef.add_condition('Content-Type', 'starts-with' => '')
     @accepted_types = %w(.jpg .jpeg .png .gif).join(',')
   end
 

--- a/lib/primary-source-sets/pss_browser_uploads.rb
+++ b/lib/primary-source-sets/pss_browser_uploads.rb
@@ -1,5 +1,8 @@
 module PSSBrowserUploads
 
+  # FIXME:  refactor into a base class and child classes for different kinds
+  # of form definitions, to deduplicate code.
+  #
   class FormDefinition < S3BrowserUploads::FormDefinition
 
     ##
@@ -31,6 +34,8 @@ module PSSBrowserUploads
     })
     @formdef.add_field('key', "#{type}/${filename}")
     @formdef.add_condition('key', 'starts-with' => "#{type}/")
+    @formdef.add_field('Content-Type', '')
+    @formdef.add_condition('Content-Type', 'starts-with' => '')
     @formdef.add_field('success_action_status', '201')
     @formdef
   end
@@ -45,6 +50,8 @@ module PSSBrowserUploads
     })
     @formdef.add_field('key', "${filename}")
     @formdef.add_condition('key', 'starts-with' => "")
+    @formdef.add_field('Content-Type', '')
+    @formdef.add_condition('Content-Type', 'starts-with' => '')
     @formdef.add_field('success_action_status', '201')
     @formdef
   end


### PR DESCRIPTION
Fix upload forms so that the Content-Type field assigned.  Amazon S3 defaults to "application/octet-stream" if it is not, and this causes PDFs to download instead of being displayed in the browser.  It also causes other files to be uploaded as octet-stream, but it's less noticable than with PDFs.

Also improve the frontend upload event-handler code to check that a file has been chosen.
