### PR TITLE
add form class

### DIFF
--- a/app/assets/javascripts/docupload.js
+++ b/app/assets/javascripts/docupload.js
@@ -10,7 +10,7 @@
 
     $(document).ready(function() {
 
-        $('form').on('submit', function(e) {
+        $('form.upload').on('submit', function(e) {
 
             e.preventDefault();
 
@@ -39,7 +39,7 @@
                 handleResponseIfDone(xhr);
             };
 
-            xhr.open('POST', $('form').attr('action'), true);
+            xhr.open('POST', $('form.upload').attr('action'), true);
             xhr.send(data);
 
             return false;

--- a/app/assets/javascripts/imgupload.js
+++ b/app/assets/javascripts/imgupload.js
@@ -10,7 +10,7 @@
 
     $(document).ready(function() {
 
-        $('form').on('submit', function(e) {
+        $('form.upload').on('submit', function(e) {
 
             e.preventDefault();
 
@@ -39,7 +39,7 @@
                 handleResponseIfDone(xhr);
             };
 
-            xhr.open('POST', $('form').attr('action'), true);
+            xhr.open('POST', $('form.upload').attr('action'), true);
             xhr.send(data);
 
             return false;

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -12,7 +12,7 @@
 
     $(document).ready(function() {
 
-        $('form').on('submit', function(e) {
+        $('form.upload').on('submit', function(e) {
 
             e.preventDefault();
 
@@ -31,7 +31,7 @@
                 handleResponseIfDone(xhr);
             };
 
-            xhr.open('POST', $('form').attr('action'), true);
+            xhr.open('POST', $('form.upload').attr('action'), true);
             xhr.send(data);
 
             return false;

--- a/app/views/shared/_s3form.erb
+++ b/app/views/shared/_s3form.erb
@@ -1,4 +1,4 @@
-<%= s3_form @formdef do %>
+<%= s3_form @formdef, class: 'upload' do %>
 
   <%= file_field_tag :file,
                      accept: @accepted_types %>


### PR DESCRIPTION
This corrects an error introduced in PR #36.  On pages with both the DPLA search box and the asset upload form, the javascript could not differentiate between the two forms, causing both the search and upload actions to fail.  This adds a class name to the asset upload forms, and uses the class name in the jQuery selector to differentiate it from the DPLA search box.

This addresses [issue #8076](https://issues.dp.la/issues/8076).