### PR TITLE
Fix/admin ui

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -12,8 +12,12 @@ class SourcesController < ApplicationController
   def show
     @source = Source.find(params[:id])
     ma = @source.main_asset
-    @file_base_or_name =
-      ma.respond_to?(:file_base) ? ma.file_base : ma.file_name
+    @file_base_or_name = nil
+    
+    if ma.present?
+      @file_base_or_name =
+        ma.respond_to?(:file_base) ? ma.file_base : ma.file_name
+    end
   end
 
   def new

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -25,7 +25,7 @@
   </p>
   
   <p>
-    <%= f.submit %>
+    <%= f.submit 'Submit', class: 'form-submit' %>
   </p>
  
 <% end %>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -40,7 +40,7 @@
   </p>
 
   <p>
-    <%= f.submit %>
+    <%= f.submit 'Submit', class: 'form-submit' %>
   </p>
 
 <% end %>

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -46,7 +46,7 @@
   </p>
  
   <p>
-    <%= f.submit %>
+    <%= f.submit 'Submit', class: 'form-submit' %>
   </p>
  
 <% end %>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -90,7 +90,7 @@
   <% end %>
 
   <p>
-    <%= f.submit %>
+    <%= f.submit 'Submit', class: 'form-submit' %>
   </p>
 
 <% end %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -15,7 +15,7 @@
   </tr>
   <tr>
     <td><strong>DPLA item URI </strong></td>
-    <td><%= link_to frontend_path(@source.aggregation), frontend_path(@source.aggregation) %></td>
+    <td><%= link_to frontend_path('item/' + @source.aggregation), frontend_path(@source.aggregation) %></td>
   </tr>
   <tr>
     <td><strong>Caption </strong></td>


### PR DESCRIPTION
This fixes three bugs with the admin UI interfaces.

1. The `sources#show` view was failing if there were no associated media assets because the controller was trying to call `:file_name` on `nil`.

2. Submit buttons on several forms were not rendering correctly because they did not have a class name (they were rendering like the submit button in the DPLA search box).

3. On the `sources#show` view, link to the DPLA items were missing the `/item` substring.