### PR TITLE
order sources and sets by created_at

### DIFF
--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -3,7 +3,7 @@
 <p><%= link_to "Create new set", new_source_set_path %></p>
 
 <table>
-<% @source_sets.each do |set| %>
+<% @source_sets.order('created_at ASC').each do |set| %>
   <tr>
     <td><%= inline_markdown(set.name) %></td>
     <td><%= link_to "View", source_set_path(set) %></td>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -49,7 +49,7 @@
 <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
 
 <table>
-<% @source_set.sources.each do |source| %>
+<% @source_set.sources.order('created_at ASC').each do |source| %>
   <tr>
     <td><%= inline_markdown(source_name(source)) %></td>
     <td><%= link_to "View", source_path(source) %></td>

--- a/spec/views/source_sets/index.html.erb_spec.rb
+++ b/spec/views/source_sets/index.html.erb_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 describe 'source_sets/index.html.erb', type: :view do
 
   before do
-    assign(:source_sets, [create(:source_set_factory, name: 'Moomin'),
-                          create(:source_set_factory, name: 'Snorkmaiden')])
+    create(:source_set_factory, name: 'Moomin')
+    create(:source_set_factory, name: 'Snorkmaiden')
+    assign(:source_sets, SourceSet.all)
   end
 
   it 'renders each source set' do


### PR DESCRIPTION
On `sets#show` order `sources` by their created date (earliest created should appear first).
On `sets#index`, order `sets` by their created date (earliest created should appear first).
This addresses [ticket #8078](https://issues.dp.la/issues/8078)