### PR TITLE
Feature/alphabetize assets

### DIFF
--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -53,39 +53,39 @@
 
   <p>
     <strong><%= f.label :large_image %></strong><br />
-    <%= f.collection_check_boxes(:image_ids, Image.where(size: 'large'), :id, :file_name) do |b| %>
+    <%= f.collection_check_boxes(:image_ids, Image.where(size: 'large').order('file_name'), :id, :file_name) do |b| %>
       <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
     <% end %>
   </p>
 
   <p>
     <strong><%= f.label :audio %></strong><br />
-    <%= f.collection_check_boxes(:audio_ids, Audio.all, :id, :file_base) do |b| %>
+    <%= f.collection_check_boxes(:audio_ids, Audio.all.order('file_base'), :id, :file_base) do |b| %>
       <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
     <% end %>
   </p>
 
   <p>
     <strong><%= f.label :video %></strong><br />
-    <%= f.collection_check_boxes(:video_ids, Video.all, :id, :file_base) do |b| %>
+    <%= f.collection_check_boxes(:video_ids, Video.all.order('file_base'), :id, :file_base) do |b| %>
       <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
     <% end %>
   </p>
 
   <p>
     <strong><%= f.label :document %></strong><br />
-    <%= f.collection_check_boxes(:document_ids, Document.all, :id, :file_name) do |b| %>
+    <%= f.collection_check_boxes(:document_ids, Document.all.order('file_name'), :id, :file_name) do |b| %>
       <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
     <% end %>
   </p>
 
   <h2><%= f.label :thumbnail %></h2>
-  <%= f.collection_check_boxes(:image_ids, Image.where(size: 'thumbnail'), :id, :file_name) do |b| %>
+  <%= f.collection_check_boxes(:image_ids, Image.where(size: 'thumbnail').order('file_name'), :id, :file_name) do |b| %>
     <%= b.label { b.check_box(class: "thumbnail_check_box") + b.text } %><br />
   <% end %>
 
   <h2><%= f.label :small_image %></h2>
-  <%= f.collection_check_boxes(:image_ids, Image.where(size: 'small'), :id, :file_name) do |b| %>
+  <%= f.collection_check_boxes(:image_ids, Image.where(size: 'small').order('file_name'), :id, :file_name) do |b| %>
     <%= b.label { b.check_box(class: "small_image_check_box") + b.text } %><br />
   <% end %>
 


### PR DESCRIPTION
On `#views/sources/_form.html.erb`, display `assets` in alphabetical order.
This addresses [ticket #8074](https://issues.dp.la/issues/8074)