### PR TITLE
fix featured image attr name

### DIFF
--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -38,7 +38,7 @@
     <td><strong>Featured image </strong></td>
     <td>
       <% if @source_set.featured_image.present? %>
-        <%= link_to @source_set.featured_image.file_base, image_path(@source_set.featured_image) %>
+        <%= link_to @source_set.featured_image.file_name, image_path(@source_set.featured_image) %>
       <% end %>
     </td>
   </tr>


### PR DESCRIPTION
This fixes the attribute name of the featured image on the `source_sets#show` view.  The error was preventing the page from rendering.

This addresses [ticket #8079](https://issues.dp.la/issues/8079).