### PR TITLE
get favicon from frontend-assets

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= branding_stylesheets %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
+    <%= favicon_link_tag %>
     <%= yield :head_script %>
   </head>
   <body>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,5 +12,4 @@ Rails.application.config.assets.precompile += %w( form.js )
 # Precompile assets from gems
 Rails.application.config.assets.precompile += %w( dpla-colors.css dpla-fonts.css )
 Rails.application.config.assets.precompile += %w( *.png *.jpg *.jpeg *.gif *.ico )
-Rails.application.config.assets.precompile += %w( *.png *.jpg *.jpeg *.gif *.ico )
 Rails.application.config.assets.precompile += %w( *.eot *.svg *.ttf *.woff )


### PR DESCRIPTION
Add a favicon, taken from frontend-assets.

This is related to [PR#3 on frontend-assets](https://github.com/dpla/frontend-assets/pull/3).

This addresses [task #8070](https://issues.dp.la/issues/8070).