### PR TITLE
Revert "get favicon from frontend-assets"

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
     <%= branding_stylesheets %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
-    <%= favicon_link_tag %>
     <%= yield :head_script %>
   </head>
   <body>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,4 +12,5 @@ Rails.application.config.assets.precompile += %w( form.js )
 # Precompile assets from gems
 Rails.application.config.assets.precompile += %w( dpla-colors.css dpla-fonts.css )
 Rails.application.config.assets.precompile += %w( *.png *.jpg *.jpeg *.gif *.ico )
+Rails.application.config.assets.precompile += %w( *.png *.jpg *.jpeg *.gif *.ico )
 Rails.application.config.assets.precompile += %w( *.eot *.svg *.ttf *.woff )


### PR DESCRIPTION
Reverts dpla/primary-source-sets#45
Turns out this is un-necessary b/c `primary-source-sets` is already showing a favicon courtesy of the frontend when deployed on staging and production.