### PR TITLE
Refactor Javascript and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 bundler_args: "--without debug"
-script: bundle exec rake ci
+script:
+- bundle exec rake ci
+- bundle exec rake jasmine:ci
 rvm:
 - 2.1.3
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,9 @@ group :test, :development do
   gem 'awesome_print', '~> 1.2.0'
   gem 'codeclimate-test-reporter', '~> 0.4.7', require: false
   gem 'database_cleaner', '~> 1.3.0', require: false
-
   gem 'json-ld', '~>1.1.9'
+  gem 'jasmine', '~> 2.0'
+  gem 'jasmine-jquery-rails', '~> 2.0'
 end
 
 group :development do

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure(2) do |config|
     pss.vm.hostname = 'pss'
     pss.vm.network :private_network, ip: '192.168.50.22'
     pss.vm.network "forwarded_port", guest: 3000, host: 3000  # Rails
+    pss.vm.network "forwarded_port", guest: 3001, host: 3001  # Jasmine
     pss.vm.provider 'virtualbox' do |vb|
       vb.memory = 1024
     end

--- a/app/assets/javascripts/avupload.js
+++ b/app/assets/javascripts/avupload.js
@@ -1,0 +1,22 @@
+/*
+ * Handle a/v file uploads
+ */
+//= require upload
+
+function AVUploadHandler() { UploadHandler.call(this); }
+AVUploadHandler.prototype = Object.create(UploadHandler.prototype);
+
+
+AVUploadHandler.prototype.createAssetRecord = function(key) {
+    // For file basename, get rid of "video/" or "audio/" path part and
+    // file extension.
+    file_base = key.replace(/^[a-z]+\/(.*)\.[a-z0-9]+$/i, "$1");
+    postdata = {};
+    postdata[pss_asset_type] = {file_base: file_base, key: key};
+    this.postAssetRecord(postdata);
+};
+
+
+$(function() {
+    new AVUploadHandler();
+});

--- a/app/assets/javascripts/docupload.js
+++ b/app/assets/javascripts/docupload.js
@@ -1,100 +1,19 @@
-
 /*
- * Handle PDF uploads directly to S3, and create new asset records.
+ * Handle PDF uploads
  */
+//= require upload
 
-/*
- * FIXME:  get rid of redundancy between this file and upload.js
- */
-(function() {
+function DocUploadHandler() { UploadHandler.call(this); }
+DocUploadHandler.prototype = Object.create(UploadHandler.prototype);
 
-    $(document).ready(function() {
 
-        $('form').on('submit', function(e) {
+DocUploadHandler.prototype.createAssetRecord = function(key) {
+    postdata = {};
+    postdata[pss_asset_type] = {file_name: key};
+    this.postAssetRecord(postdata);
+};
 
-            e.preventDefault();
 
-            files = $('input[name=file]').prop('files');
-            if (! files.length) {
-                alert('Please choose a file.');
-                return false;
-            }
-
-            // Fill in Content-Type so S3 doesn't default to
-            // "application/octet-stream".
-            $('input[name=Content-Type]').val(files[0].type)
-
-            var data = new FormData(this);
-            var xhr = new XMLHttpRequest();
-
-            xhr.upload.addEventListener(
-                'progress',
-                function(e) {
-                    updateProgress(e);
-                },
-                false
-            );
-
-            xhr.onreadystatechange = function(e) {
-                handleResponseIfDone(xhr);
-            };
-
-            xhr.open('POST', $('form').attr('action'), true);
-            xhr.send(data);
-
-            return false;
-
-        });
-
-    });
-
-    /*
-     * `onreadystatechange' handler for form submission
-     */
-    function handleResponseIfDone(xhr) {
-        if (xhr.readyState == 4) {
-            if (xhr.status == '201') {
-                key = $('Key', xhr.responseXML).text();
-                createAssetRecord(key);
-            } else {
-                alert('Got an unexpected response: ' + xhr.statusText);
-            }
-        }
-    }
-
-    /*
-     * POST to our API to add an asset for the file that was just uploaded to
-     * S3.  Load the asset's "view" resource if that is successful.
-     */
-    function createAssetRecord(key) {
-
-        postdata = {};
-        postdata[pss_asset_type] = {file_name: key};
-
-        $.ajax({
-            method: 'POST',
-            url: pss_create_asset_path,  // defined in the HTML
-            data: postdata
-        }).done(function(data) {
-            document.location = data.resource;
-        }).fail(function(xhr) {
-            alert('Failed to create asset record: ' + xhr.statusText);
-        });
-    }
-
-    /*
-     * Handle the `progress' event of the XMLHttpRequest.
-     * Update the progress percentage indicator.
-     */
-    function updateProgress(e) {
-        $p = $('#upload-progress');
-        if (e.lengthComputable) {
-            if (! $p.is(':visible')) {
-                $p.show();
-            }
-            var pct = Math.round(e.loaded / e.total * 100);
-            $p.text(pct + '% complete');
-        }
-    }
-
-})();
+$(function() {
+    new DocUploadHandler();
+});

--- a/app/assets/javascripts/imgupload.js
+++ b/app/assets/javascripts/imgupload.js
@@ -1,106 +1,25 @@
-
 /*
- * Handle PDF uploads directly to S3, and create new asset records.
+ * Handle image uploads
  */
+//= require upload
 
-/*
- * FIXME:  get rid of redundancy between this file and upload.js
- */
-(function() {
+function ImageUploadHandler() { UploadHandler.call(this); }
+ImageUploadHandler.prototype = Object.create(UploadHandler.prototype);
 
-    $(document).ready(function() {
 
-        $('form').on('submit', function(e) {
+ImageUploadHandler.prototype.createAssetRecord = function(key) {
+    postdata = {};
+    postdata[pss_asset_type] = {
+        file_name: key,
+        size: $('input[name="image[size]"]:checked').val(),
+        width: $('input[name="image[width]"]').val(),
+        height: $('input[name="image[height]"]').val(),
+        alt_text: $('input[name="image[alt_text]"]').val()
+    };
+    this.postAssetRecord(postdata);
+};
 
-            e.preventDefault();
 
-            files = $('input[name=file]').prop('files');
-            if (! files.length) {
-                alert('Please choose a file.');
-                return false;
-            }
-
-            // Fill in Content-Type so S3 doesn't default to
-            // "application/octet-stream".
-            $('input[name=Content-Type]').val(files[0].type)
-
-            var data = new FormData(this);
-            var xhr = new XMLHttpRequest();
-
-            xhr.upload.addEventListener(
-                'progress',
-                function(e) {
-                    updateProgress(e);
-                },
-                false
-            );
-
-            xhr.onreadystatechange = function(e) {
-                handleResponseIfDone(xhr);
-            };
-
-            xhr.open('POST', $('form').attr('action'), true);
-            xhr.send(data);
-
-            return false;
-
-        });
-
-    });
-
-    /*
-     * `onreadystatechange' handler for form submission
-     */
-    function handleResponseIfDone(xhr) {
-        if (xhr.readyState == 4) {
-            if (xhr.status == '201') {
-                key = $('Key', xhr.responseXML).text();
-                createAssetRecord(key);
-            } else {
-                alert('Got an unexpected response: ' + xhr.statusText);
-            }
-        }
-    }
-
-    /*
-     * POST to our API to add an asset for the file that was just uploaded to
-     * S3.  Load the asset's "view" resource if that is successful.
-     */
-    function createAssetRecord(key) {
-
-        postdata = {};
-        postdata[pss_asset_type] = {
-            file_name: key,
-            size: $('input[name="image[size]"]:checked').val() || '',
-            width: $('input[name="image[width]"]').val(),
-            height: $('input[name="image[height]"]').val(),
-            alt_text: $('input[name="image[alt_text]"]').val()
-        };
-
-        $.ajax({
-            method: 'POST',
-            url: pss_create_asset_path,  // defined in the HTML
-            data: postdata
-        }).done(function(data) {
-            document.location = data.resource;
-        }).fail(function(xhr) {
-            alert('Failed to create asset record: ' + xhr.statusText);
-        });
-    }
-
-    /*
-     * Handle the `progress' event of the XMLHttpRequest.
-     * Update the progress percentage indicator.
-     */
-    function updateProgress(e) {
-        $p = $('#upload-progress');
-        if (e.lengthComputable) {
-            if (! $p.is(':visible')) {
-                $p.show();
-            }
-            var pct = Math.round(e.loaded / e.total * 100);
-            $p.text(pct + '% complete');
-        }
-    }
-
-})();
+$(function() {
+    new ImageUploadHandler();
+});

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -1,96 +1,99 @@
-
 /*
  * Handle media file uploads directly to S3, and create new asset records.
  *
  * Manage the form submission, intercepting the submit event.
  * Provide upload status.  For successful uploads, create the new asset record
  * and send the user to the asset's page.
- *
  */
 
-(function() {
 
-    $(document).ready(function() {
+function UploadHandler() { this.init(); }
+UploadHandler.prototype.init = function() {
+    this.$form = $('#upload-form');
+    this.addOnSubmit();
+};
 
-        $('form').on('submit', function(e) {
 
-            e.preventDefault();
+UploadHandler.prototype.$el = function(selector) {
+    return $(selector, this.$form);
+};
 
-            var data = new FormData(this);
-            var xhr = new XMLHttpRequest();
+UploadHandler.prototype.addOnSubmit = function() {
 
-            xhr.upload.addEventListener(
-                'progress',
-                function(e) {
-                    updateProgress(e);
-                },
-                false
-            );
+    var that = this;
+    this.$form.on('submit', function(e) {
 
-            xhr.onreadystatechange = function(e) {
-                handleResponseIfDone(xhr);
-            };
+        e.preventDefault();
 
-            xhr.open('POST', $('form').attr('action'), true);
-            xhr.send(data);
-
+        files = that.$el('input[name=file]').prop('files');
+        if (! files.length) {
+            alert('Please choose a file.');
             return false;
+        }
 
-        });
+        // Fill in Content-Type so S3 doesn't default to
+        // "application/octet-stream".
+        that.$el('input[name=Content-Type]').val(files[0].type)
+
+        var xhr = new XMLHttpRequest();
+        xhr.upload.addEventListener(
+            'progress',
+            function(e) {
+                that.updateProgress(e);
+            },
+            false
+        );
+        xhr.onreadystatechange = function(e) {
+            that.handleResponseIfDone(xhr);
+        };
+
+        xhr.open('POST', that.$form.attr('action'), true);
+        xhr.send(new FormData(this));
+
+        return false;
 
     });
 
-    /*
-     * `onreadystatechange' handler for form submission
-     */
-    function handleResponseIfDone(xhr) {
-        if (xhr.readyState == 4) {
-            if (xhr.status == '201') {
-                key = $('Key', xhr.responseXML).text();
-                createAssetRecord(key);
-            } else {
-                alert('Got an unexpected response: ' + xhr.statusText);
-            }
+};  // addOnSubmit
+
+
+UploadHandler.prototype.updateProgress = function(e) {
+    $p = $('#upload-progress');
+    if (e.lengthComputable) {
+        if (! $p.is(':visible')) {
+            $p.show();
+        }
+        var pct = Math.round(e.loaded / e.total * 100);
+        $p.text(pct + '% complete');
+    }
+};
+
+
+UploadHandler.prototype.handleResponseIfDone = function(xhr) {
+    if (xhr.readyState == 4) {
+        if (xhr.status == '201') {
+            key = $('Key', xhr.responseXML).text();
+            this.createAssetRecord(key);
+        } else {
+            alert('Got an unexpected response: ' + xhr.statusText);
         }
     }
+};
 
-    /*
-     * POST to our API to add an asset for the file that was just uploaded to
-     * S3.  Load the asset's "view" resource if that is successful.
-     */
-    function createAssetRecord(key) {
 
-        // For file basename, get rid of "video/" or "audio/" path part and
-        // file extension.
-        file_base = key.replace(/^[a-z]+\/(.*)\.[a-z0-9]+$/i, "$1");
+UploadHandler.prototype.createAssetRecord = function(key) {
+    console.log('createAssetRecord must be overridden.');
+};
 
-        postdata = {};
-        postdata[pss_asset_type] = {file_base: file_base, key: key};
 
-        $.ajax({
-            method: 'POST',
-            url: pss_create_asset_path,  // defined in the HTML
-            data: postdata
-        }).done(function(data) {
-            document.location = data.resource;
-        }).fail(function(xhr) {
-            alert('Failed to create asset record: ' + xhr.statusText);
-        });
-    }
-
-    /*
-     * Handle the `progress' event of the XMLHttpRequest.
-     * Update the progress percentage indicator.
-     */
-    function updateProgress(e) {
-        $p = $('#upload-progress');
-        if (e.lengthComputable) {
-            if (! $p.is(':visible')) {
-                $p.show();
-            }
-            var pct = Math.round(e.loaded / e.total * 100);
-            $p.text(pct + '% complete');
-        }
-    }
-
-})();
+UploadHandler.prototype.postAssetRecord = function(postdata) {
+    $.ajax({
+        method: 'POST',
+        url: pss_create_asset_path,  // defined in the HTML
+        data: postdata
+    }).done(function(data) {
+        document.location = data.resource;
+    }).fail(function(xhr) {
+        alert('Failed to create asset record: ' + xhr.statusText);
+    });
+};

--- a/app/views/audios/new.html.erb
+++ b/app/views/audios/new.html.erb
@@ -11,4 +11,4 @@
 
 <%= render "shared/s3form" %>
 
-<%= javascript_include_tag 'upload' %>
+<%= javascript_include_tag 'avupload' %>

--- a/app/views/shared/_s3form.erb
+++ b/app/views/shared/_s3form.erb
@@ -1,4 +1,4 @@
-<%= s3_form @formdef do %>
+<%= s3_form @formdef, id: 'upload-form' do %>
 
   <%= file_field_tag :file,
                      accept: @accepted_types %>

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -11,4 +11,4 @@
 
 <%= render "shared/s3form" %>
 
-<%= javascript_include_tag 'upload' %>
+<%= javascript_include_tag 'avupload' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,7 +4,7 @@
 Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
-Rails.application.config.assets.precompile += %w( upload.js )
+Rails.application.config.assets.precompile += %w( avupload.js )
 Rails.application.config.assets.precompile += %w( docupload.js )
 Rails.application.config.assets.precompile += %w( imgupload.js )
 Rails.application.config.assets.precompile += %w( form.js )

--- a/provisioning/provision.yml
+++ b/provisioning/provision.yml
@@ -18,6 +18,7 @@
         - postgresql-common
         - libpq-dev
         - build-essential
+        - libfontconfig1-dev
 
 - hosts: all
   # do as "vagrant" user

--- a/spec/javascripts/av_upload_handler_spec.js
+++ b/spec/javascripts/av_upload_handler_spec.js
@@ -1,0 +1,28 @@
+
+describe("AVUploadHandler", function() {
+
+    beforeEach(function() {
+        a = new AVUploadHandler();
+        spyOn(a, 'postAssetRecord').and.stub();
+        html = '<script>var pss_asset_type = "video";</script>' +
+               '<form></form>';
+        setFixtures(html);
+    });
+
+    it("Generates AJAX POST data with path prefix and alphabetic extension",
+        function() {
+            good_data = {video: {file_base: 'a', key: 'video/a.a'}};
+            a.createAssetRecord('video/a.a');
+            expect(a.postAssetRecord).toHaveBeenCalledWith(good_data);
+        }
+    );
+
+    it("Generates AJAX POST data with alphnumeric file extension",
+        function() {
+            good_data = {video: {file_base: 'a', key: 'video/a.mp4'}};
+            a.createAssetRecord('video/a.mp4');
+            expect(a.postAssetRecord).toHaveBeenCalledWith(good_data);
+        }
+    );
+
+});

--- a/spec/javascripts/doc_upload_handler_spec.js
+++ b/spec/javascripts/doc_upload_handler_spec.js
@@ -1,0 +1,20 @@
+
+describe("DocUploadHandler", function() {
+
+    beforeEach(function() {
+        duh = new DocUploadHandler();
+        spyOn(duh, 'postAssetRecord').and.stub();
+        html = '<script>var pss_asset_type = "document";</script>' +
+               '<form></form>';
+        setFixtures(html);
+    });
+
+    it("Generates AJAX POST data with the file name",
+        function() {
+            good_data = {document: {file_name: 'a.pdf'}};
+            duh.createAssetRecord('a.pdf');
+            expect(duh.postAssetRecord).toHaveBeenCalledWith(good_data);
+        }
+    );
+
+});

--- a/spec/javascripts/helpers/jasmine-query.js
+++ b/spec/javascripts/helpers/jasmine-query.js
@@ -1,0 +1,832 @@
+/*!
+Jasmine-jQuery: a set of jQuery helpers for Jasmine tests.
+
+Version 2.1.0
+
+https://github.com/velesin/jasmine-jquery
+
+Copyright (c) 2010-2014 Wojciech Zawistowski, Travis Jeffery
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
++function (window, jasmine, $) { "use strict";
+
+  jasmine.spiedEventsKey = function (selector, eventName) {
+    return [$(selector).selector, eventName].toString()
+  }
+
+  jasmine.getFixtures = function () {
+    return jasmine.currentFixtures_ = jasmine.currentFixtures_ || new jasmine.Fixtures()
+  }
+
+  jasmine.getStyleFixtures = function () {
+    return jasmine.currentStyleFixtures_ = jasmine.currentStyleFixtures_ || new jasmine.StyleFixtures()
+  }
+
+  jasmine.Fixtures = function () {
+    this.containerId = 'jasmine-fixtures'
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.Fixtures.prototype.set = function (html) {
+    this.cleanUp()
+    return this.createContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.appendSet= function (html) {
+    this.addToContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.preload = function () {
+    this.read.apply(this, arguments)
+  }
+
+  jasmine.Fixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.appendLoad = function () {
+    this.addToContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.read = function () {
+    var htmlChunks = []
+      , fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      htmlChunks.push(this.getFixtureHtml_(fixtureUrls[urlIndex]))
+    }
+
+    return htmlChunks.join('')
+  }
+
+  jasmine.Fixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.Fixtures.prototype.cleanUp = function () {
+    $('#' + this.containerId).remove()
+  }
+
+  jasmine.Fixtures.prototype.sandbox = function (attributes) {
+    var attributesToSet = attributes || {}
+    return $('<div id="sandbox" />').attr(attributesToSet)
+  }
+
+  jasmine.Fixtures.prototype.createContainer_ = function (html) {
+    var container = $('<div>')
+    .attr('id', this.containerId)
+    .html(html)
+
+    $(document.body).append(container)
+    return container
+  }
+
+  jasmine.Fixtures.prototype.addToContainer_ = function (html){
+    var container = $(document.body).find('#'+this.containerId).append(html)
+
+    if (!container.length) {
+      this.createContainer_(html)
+    }
+  }
+
+  jasmine.Fixtures.prototype.getFixtureHtml_ = function (url) {
+    if (typeof this.fixturesCache_[url] === 'undefined') {
+      this.loadFixtureIntoCache_(url)
+    }
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.makeFixtureUrl_(relativeUrl)
+      , htmlText = ''
+      , request = $.ajax({
+        async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+        cache: false,
+        url: url,
+        dataType: 'html',
+        success: function (data, status, $xhr) {
+          htmlText = $xhr.responseText
+        }
+      }).fail(function ($xhr, status, err) {
+          throw new Error('Fixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      })
+
+      var scripts = $($.parseHTML(htmlText, true)).find('script[src]') || [];
+
+      scripts.each(function(){
+        $.ajax({
+            async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+            cache: false,
+            dataType: 'script',
+            url: $(this).attr('src'),
+            success: function (data, status, $xhr) {
+                htmlText += '<script>' + $xhr.responseText + '</script>'
+            },
+            error: function ($xhr, status, err) {
+                throw new Error('Script could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+            }
+        });
+      })
+
+      self.fixturesCache_[relativeUrl] = htmlText;
+  }
+
+  jasmine.Fixtures.prototype.makeFixtureUrl_ = function (relativeUrl){
+    return this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+  }
+
+  jasmine.Fixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+
+  jasmine.StyleFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesNodes_ = []
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.StyleFixtures.prototype.set = function (css) {
+    this.cleanUp()
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.appendSet = function (css) {
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.preload = function () {
+    this.read_.apply(this, arguments)
+  }
+
+  jasmine.StyleFixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.appendLoad = function () {
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.cleanUp = function () {
+    while(this.fixturesNodes_.length) {
+      this.fixturesNodes_.pop().remove()
+    }
+  }
+
+  jasmine.StyleFixtures.prototype.createStyle_ = function (html) {
+    var styleText = $('<div></div>').html(html).text()
+      , style = $('<style>' + styleText + '</style>')
+
+    this.fixturesNodes_.push(style)
+    $('head').append(style)
+  }
+
+  jasmine.StyleFixtures.prototype.clearCache = jasmine.Fixtures.prototype.clearCache
+  jasmine.StyleFixtures.prototype.read_ = jasmine.Fixtures.prototype.read
+  jasmine.StyleFixtures.prototype.getFixtureHtml_ = jasmine.Fixtures.prototype.getFixtureHtml_
+  jasmine.StyleFixtures.prototype.loadFixtureIntoCache_ = jasmine.Fixtures.prototype.loadFixtureIntoCache_
+  jasmine.StyleFixtures.prototype.makeFixtureUrl_ = jasmine.Fixtures.prototype.makeFixtureUrl_
+  jasmine.StyleFixtures.prototype.proxyCallTo_ = jasmine.Fixtures.prototype.proxyCallTo_
+
+  jasmine.getJSONFixtures = function () {
+    return jasmine.currentJSONFixtures_ = jasmine.currentJSONFixtures_ || new jasmine.JSONFixtures()
+  }
+
+  jasmine.JSONFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures/json'
+  }
+
+  jasmine.JSONFixtures.prototype.load = function () {
+    this.read.apply(this, arguments)
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.read = function () {
+    var fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      this.getFixtureData_(fixtureUrls[urlIndex])
+    }
+
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.JSONFixtures.prototype.getFixtureData_ = function (url) {
+    if (!this.fixturesCache_[url]) this.loadFixtureIntoCache_(url)
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+
+    $.ajax({
+      async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+      cache: false,
+      dataType: 'json',
+      url: url,
+      success: function (data) {
+        self.fixturesCache_[relativeUrl] = data
+      },
+      error: function ($xhr, status, err) {
+        throw new Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      }
+    })
+  }
+
+  jasmine.JSONFixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+  jasmine.jQuery = function () {}
+
+  jasmine.jQuery.browserTagCaseIndependentHtml = function (html) {
+    return $('<div/>').append(html).html()
+  }
+
+  jasmine.jQuery.elementToString = function (element) {
+    return $(element).map(function () { return this.outerHTML; }).toArray().join(', ')
+  }
+
+  var data = {
+      spiedEvents: {}
+    , handlers:    []
+  }
+
+  jasmine.jQuery.events = {
+    spyOn: function (selector, eventName) {
+      var handler = function (e) {
+        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+          args: jasmine.util.argsToArray(arguments),
+          calls: ++calls
+        }
+      }
+
+      $(selector).on(eventName, handler)
+      data.handlers.push(handler)
+
+      return {
+        selector: selector,
+        eventName: eventName,
+        handler: handler,
+        reset: function (){
+          delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        },
+        calls: {
+          count: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0;
+          },
+          any: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                !!data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : false;
+          }
+        }
+      }
+    },
+
+    args: function (selector, eventName) {
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
+
+      if (!actualArgs) {
+        throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
+      }
+
+      return actualArgs
+    },
+
+    wasTriggered: function (selector, eventName) {
+      return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
+    },
+
+    wasTriggeredWith: function (selector, eventName, expectedArgs, util, customEqualityTesters) {
+      var actualArgs = jasmine.jQuery.events.args(selector, eventName).slice(1)
+
+      if (Object.prototype.toString.call(expectedArgs) !== '[object Array]')
+        actualArgs = actualArgs[0]
+
+      return util.equals(actualArgs, expectedArgs, customEqualityTesters)
+    },
+
+    wasPrevented: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isDefaultPrevented()
+    },
+
+    wasStopped: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isPropagationStopped()
+    },
+
+    cleanUp: function () {
+      data.spiedEvents = {}
+      data.handlers    = []
+    }
+  }
+
+  var hasProperty = function (actualValue, expectedValue) {
+    if (expectedValue === undefined)
+      return actualValue !== undefined
+
+    return actualValue === expectedValue
+  }
+
+  beforeEach(function () {
+    jasmine.addMatchers({
+      toHaveClass: function () {
+        return {
+          compare: function (actual, className) {
+            return { pass: $(actual).hasClass(className) }
+          }
+        }
+      },
+
+      toHaveCss: function () {
+        return {
+          compare: function (actual, css) {
+            for (var prop in css){
+              var value = css[prop]
+              // see issue #147 on gh
+              ;if (value === 'auto' && $(actual).get(0).style[prop] === 'auto') continue
+              if ($(actual).css(prop) !== value) return { pass: false }
+            }
+            return { pass: true }
+          }
+        }
+      },
+
+      toBeVisible: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':visible') }
+          }
+        }
+      },
+
+      toBeHidden: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':hidden') }
+          }
+        }
+      },
+
+      toBeSelected: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':selected') }
+          }
+        }
+      },
+
+      toBeChecked: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':checked') }
+          }
+        }
+      },
+
+      toBeEmpty: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':empty') }
+          }
+        }
+      },
+
+      toBeInDOM: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $.contains(document.documentElement, $(actual)[0]) }
+          }
+        }
+      },
+
+      toExist: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).length }
+          }
+        }
+      },
+
+      toHaveLength: function () {
+        return {
+          compare: function (actual, length) {
+            return { pass: $(actual).length === length }
+          }
+        }
+      },
+
+      toHaveAttr: function () {
+        return {
+          compare: function (actual, attributeName, expectedAttributeValue) {
+            return { pass: hasProperty($(actual).attr(attributeName), expectedAttributeValue) }
+          }
+        }
+      },
+
+      toHaveProp: function () {
+        return {
+          compare: function (actual, propertyName, expectedPropertyValue) {
+            return { pass: hasProperty($(actual).prop(propertyName), expectedPropertyValue) }
+          }
+        }
+      },
+
+      toHaveId: function () {
+        return {
+          compare: function (actual, id) {
+            return { pass: $(actual).attr('id') == id }
+          }
+        }
+      },
+
+      toHaveHtml: function () {
+        return {
+          compare: function (actual, html) {
+            return { pass: $(actual).html() == jasmine.jQuery.browserTagCaseIndependentHtml(html) }
+          }
+        }
+      },
+
+      toContainHtml: function () {
+        return {
+          compare: function (actual, html) {
+            var actualHtml = $(actual).html()
+              , expectedHtml = jasmine.jQuery.browserTagCaseIndependentHtml(html)
+
+            return { pass: (actualHtml.indexOf(expectedHtml) >= 0) }
+          }
+        }
+      },
+
+      toHaveText: function () {
+        return {
+          compare: function (actual, text) {
+            var actualText = $(actual).text()
+            var trimmedText = $.trim(actualText)
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(actualText) || text.test(trimmedText) }
+            } else {
+              return { pass: (actualText == text || trimmedText == text) }
+            }
+          }
+        }
+      },
+
+      toContainText: function () {
+        return {
+          compare: function (actual, text) {
+            var trimmedText = $.trim($(actual).text())
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(trimmedText) }
+            } else {
+              return { pass: trimmedText.indexOf(text) != -1 }
+            }
+          }
+        }
+      },
+
+      toHaveValue: function () {
+        return {
+          compare: function (actual, value) {
+            return { pass: $(actual).val() === value }
+          }
+        }
+      },
+
+      toHaveData: function () {
+        return {
+          compare: function (actual, key, expectedValue) {
+            return { pass: hasProperty($(actual).data(key), expectedValue) }
+          }
+        }
+      },
+
+      toContainElement: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).find(selector).length }
+          }
+        }
+      },
+
+      toBeMatchedBy: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).filter(selector).length }
+          }
+        }
+      },
+
+      toBeDisabled: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).is(':disabled') }
+          }
+        }
+      },
+
+      toBeFocused: function (selector) {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual)[0] === $(actual)[0].ownerDocument.activeElement }
+          }
+        }
+      },
+
+      toHandle: function () {
+        return {
+          compare: function (actual, event) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var events = $._data($(actual).get(0), "events")
+
+            if (!events || !event || typeof event !== "string") {
+              return { pass: false }
+            }
+
+            var namespaces = event.split(".")
+              , eventType = namespaces.shift()
+              , sortedNamespaces = namespaces.slice(0).sort()
+              , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)")
+
+            if (events[eventType] && namespaces.length) {
+              for (var i = 0; i < events[eventType].length; i++) {
+                var namespace = events[eventType][i].namespace
+
+                if (namespaceRegExp.test(namespace))
+                  return { pass: true }
+              }
+            } else {
+              return { pass: (events[eventType] && events[eventType].length > 0) }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHandleWith: function () {
+        return {
+          compare: function (actual, eventName, eventHandler) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var normalizedEventName = eventName.split('.')[0]
+              , stack = $._data($(actual).get(0), "events")[normalizedEventName]
+
+            for (var i = 0; i < stack.length; i++) {
+              if (stack[i].handler == eventHandler) return { pass: true }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasTriggered(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + $(actual) + " not to have been triggered on " + selector :
+              "Expected event " + $(actual) + " to have been triggered on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenTriggered: function (){
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasTriggered(selector, eventName) }
+
+            result.message = result.pass ?
+            "Expected event " + eventName + " not to have been triggered on " + selector :
+              "Expected event " + eventName + " to have been triggered on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOnAndWith: function (j$, customEqualityTesters) {
+        return {
+          compare: function (actual, selector, expectedArgs) {
+            var wasTriggered = jasmine.jQuery.events.wasTriggered(selector, actual)
+              , result = { pass: wasTriggered && jasmine.jQuery.events.wasTriggeredWith(selector, actual, expectedArgs, j$, customEqualityTesters) }
+
+              if (wasTriggered) {
+                var actualArgs = jasmine.jQuery.events.args(selector, actual, expectedArgs)[1]
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs) :
+                  "Expected event " + actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs)
+
+              } else {
+                // todo check on this
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered on " + selector :
+                  "Expected event " + actual + " to have been triggered on " + selector
+              }
+
+              return result
+          }
+        }
+      },
+
+      toHaveBeenPreventedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasPrevented(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been prevented on " + selector :
+              "Expected event " + actual + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenPrevented: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasPrevented(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been prevented on " + selector :
+              "Expected event " + eventName + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenStoppedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasStopped(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been stopped on " + selector :
+              "Expected event " + actual + " to have been stopped on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenStopped: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasStopped(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been stopped on " + selector :
+              "Expected event " + eventName + " to have been stopped on " + selector
+
+            return result
+          }
+        }
+      }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function(a, b) {
+     if (a && b) {
+       if (a instanceof $ || jasmine.isDomNode(a)) {
+         var $a = $(a)
+
+         if (b instanceof $)
+           return $a.length == b.length && a.is(b)
+
+         return $a.is(b);
+       }
+
+       if (b instanceof $ || jasmine.isDomNode(b)) {
+         var $b = $(b)
+
+         if (a instanceof $)
+           return a.length == $b.length && $b.is(a)
+
+         return $(b).is(a);
+       }
+     }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function (a, b) {
+     if (a instanceof $ && b instanceof $ && a.size() == b.size())
+        return a.is(b)
+    })
+  })
+
+  afterEach(function () {
+    jasmine.getFixtures().cleanUp()
+    jasmine.getStyleFixtures().cleanUp()
+    jasmine.jQuery.events.cleanUp()
+  })
+
+  window.readFixtures = function () {
+    return jasmine.getFixtures().proxyCallTo_('read', arguments)
+  }
+
+  window.preloadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setFixtures = function (html) {
+    return jasmine.getFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.sandbox = function (attributes) {
+    return jasmine.getFixtures().sandbox(attributes)
+  }
+
+  window.spyOnEvent = function (selector, eventName) {
+    return jasmine.jQuery.events.spyOn(selector, eventName)
+  }
+
+  window.preloadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.loadJSONFixtures = function () {
+    return jasmine.getJSONFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.getJSONFixture = function (url) {
+    return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url]
+  }
+}(window, window.jasmine, window.jQuery);

--- a/spec/javascripts/image_upload_handler_spec.js
+++ b/spec/javascripts/image_upload_handler_spec.js
@@ -1,0 +1,87 @@
+
+describe("ImageUploadHandler", function() {
+
+    beforeEach(function() {
+        iuh = new ImageUploadHandler();
+        spyOn(iuh, 'postAssetRecord').and.stub();
+        html = '<script>var pss_asset_type = "image";</script>' +
+               '<form></form>';
+        setFixtures(html);
+    });
+
+    it("Generates AJAX POST data with the file name",
+        function() {
+            good_data = {
+                image: {
+                    file_name: 'a.jpg',
+                    size: undefined,
+                    width: undefined,
+                    height: undefined,
+                    alt_text: undefined
+                }
+            };
+            iuh.createAssetRecord('a.jpg');
+            expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
+        }
+    );
+
+    it("Generates AJAX POST data with the image size",
+        function() {
+            good_data = {
+                image: {
+                    file_name: 'a.jpg',
+                    size: 'small',
+                    width: undefined,
+                    height: undefined,
+                    alt_text: undefined
+                }
+            };
+            html =
+                '<input name="image[size]" type="radio" value="large">' +
+                '<input name="image[size]" type="radio" value="small" checked>';
+            appendSetFixtures(html);
+            iuh.createAssetRecord('a.jpg');
+            expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
+        }
+    );
+
+    it("Generates AJAX POST data with width and height",
+        function() {
+            good_data = {
+                image: {
+                    file_name: 'a.jpg',
+                    size: undefined,
+                    width: '600',
+                    height: '400',
+                    alt_text: undefined
+                }
+            };
+            html =
+               '<input name="image[width]" type="text" value="600" />' +
+               '<input name="image[height]" type="text" value="400" />';
+            appendSetFixtures(html);
+            iuh.createAssetRecord('a.jpg');
+            expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
+        }
+    );
+
+    it("Generates AJAX POST data with alt text",
+        function() {
+            good_data = {
+                image: {
+                    file_name: 'a.jpg',
+                    size: undefined,
+                    width: undefined,
+                    height: undefined,
+                    alt_text: 'x'
+                }
+            };
+            html =
+               '<input name="image[alt_text]" type="text" value="x" />';
+            appendSetFixtures(html);
+            iuh.createAssetRecord('a.jpg');
+            expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
+        }
+    );
+
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,132 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - dist/**/*.js
+#
+src_files:
+  - assets/jquery.js
+  - assets/jasmine-jquery.js
+  - assets/application.js
+  - assets/upload.js
+  - assets/avupload.js
+  - assets/docupload.js
+  - assets/imgupload.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - stylesheets/*.css
+#
+stylesheets:
+  - stylesheets/*.css
+  - stylesheets/**/*.css
+#  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - helpers/**/*.js
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - **/*[sS]pec.js
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir: app/assets
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,19 @@
+#Use this file to set/override Jasmine configuration options
+#You can remove it if you don't need it.
+#This file is loaded *after* jasmine.yml is interpreted.
+#
+#Example: using a different boot file.
+#Jasmine.configure do |config|
+#   config.boot_dir = '/absolute/path/to/boot_dir'
+#   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+#end
+#
+#Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+#Jasmine.configure do |config|
+#   config.prevent_phantom_js_auto_install = true
+#end
+#
+
+Jasmine.configure do |config|
+   config.server_port = 3001
+end

--- a/spec/javascripts/upload_handler_spec.js
+++ b/spec/javascripts/upload_handler_spec.js
@@ -1,0 +1,19 @@
+
+describe("UploadHandler", function() {
+
+    it("Initializes with #upload-form", function() {
+        var html = '<form id="upload-form"></form>';
+        setFixtures(html);
+        u = new UploadHandler();
+        expect(u.$form).toEqual('form');  // 'form' is jQuery selector
+    });
+
+    it("Returns an element within the form with `.$el'", function() {
+        var html = '<input name="a" />' +
+                   '<form id="upload-form"><input name="b" /></form>';
+        setFixtures(html);
+        u = new UploadHandler();
+        expect(u.$el('input').attr('name')).toEqual('b');
+    });
+
+});


### PR DESCRIPTION
Addresses https://issues.dp.la/issues/8075

* Refactor upload-related Javascript, creating UploadHandler, AVUploadHandler, DocUploadHandler, and ImageUploadHandler functions, reducing redundancy and allowing unit testing.
* Add `id` attribute to upload forms so that they are distinguishable from search forms that were recently added to the layout.
* Add Jasmine tests for Javascript code.
* Update Vagrantfile so that you can view Jasmine tests on http://localhost:3001/