### PR TITLE
Fix Source has_many relationship with Attachment

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,6 +1,6 @@
 class Source < ActiveRecord::Base
   belongs_to :source_set
-  has_many :attachments
+  has_many :attachments, dependent: :destroy
 
   has_many :videos, through: :attachments,
                     source: :asset,


### PR DESCRIPTION
Have a deletion of a Source record cause a deletion of the corresponding Attachment record.