### PR TITLE
Add Google Analytics

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+<%= render partial: 'shared/analytics' %>
+<% end %>
+
 <h1>Teaching guide: <%= inline_markdown(@guide.name) %></h1>
 
 <p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,8 @@
       <%= render partial: 'shared/footer' %>
     </div>
     <%= render partial: 'shared/jump_links' %>
+
+    <%= yield :foot_script %>
   </body>
   <%= javascript_include_tag 'style' %>
 </html>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,0 +1,13 @@
+
+<% if Settings.googleanalytics.tracker %>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '<%= Settings.googleanalytics.tracker %>', 'auto');
+      ga('send', 'pageview');
+
+    </script>
+<% end %>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+<%= render partial: 'shared/analytics' %>
+<% end %>
+
 <h1>Sets</h1>
 
 <p><%= link_to "Create new set", new_source_set_path %></p>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+<%= render partial: 'shared/analytics' %>
+<% end %>
+
 <h1>Set: <%= inline_markdown(@source_set.name) %></h1>
 
 <p>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+<%= render partial: 'shared/analytics' %>
+<% end %>
+
 <h1><%= inline_markdown(source_name(@source)) %></h1>
 
 <p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,3 +69,6 @@ widgets:
     twitter: https://twitter.com/example
     tumblr: http://example.tumblr.com/
     rss: http://example.org/info/feed
+
+googleanalytics:
+  tracker: false


### PR DESCRIPTION
Add Google Analytics tracking code.

It's enabled by setting `googleanalytics.tracker` in `settings.local.yml` to a string value.

I've only added it to the views for `/sources/:id` and `/sets/:id` because I'm not sure which ones are public, versus administrative.

@AudreyAltman, can you tell me what pages should be tracked, or at least help me identify which ones are eventually going to be public?  I'm not clear on this because of the presence of certain links that look like they should only be on admin pages.  It does appear that `/` (`source_sets#index`) would be another candidate.
