### PR TITLE
Feature/source style

### DIFF
--- a/app/assets/javascripts/style.js
+++ b/app/assets/javascripts/style.js
@@ -1,0 +1,25 @@
+/*
+ * Handles dynamic styling of the DOM.
+ */
+(function() {
+
+  $(document).ready(function() {
+    setAsideHeight();
+  });
+
+  $(window).resize(function() {
+    setAsideHeight();
+  })
+})();
+
+/*
+ * Extend the height of the aside module to be at least as tall as the rendered
+ * media asset.
+ */
+function setAsideHeight() {
+  var height = $('.source aside .module').outerHeight();
+  var minHeight = $('.source .media-inner-container').height();
+  if (minHeight > height) {
+    $('.source aside .module').outerHeight(minHeight);
+  }
+}

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -1,5 +1,65 @@
+.wrap {
+  word-wrap: break-word;
+}
+
+/* Source */
+
+.source .media-outer-container {
+  padding: 34%;
+  width: 100%;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.source article.audio .media-outer-container {
+  padding: 3em;
+  background-color: #555;
+}
+
+.source .media-inner-container {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.source .textual-content {
+  clear: left;
+  padding-top: 2em;
+  margin-bottom: 3em;
+}
+
+.source aside {
+  margin-left: 1em;
+  margin-bottom: 1em;
+}
+
+.source .moduleSection {
+  margin-bottom: 2em;
+}
+
+iframe {
+  width: 100%;
+  height: 100%;
+}
+
 video {
-    background-color: #333;
+  background-color: #333;
+  margin: 0px auto;
+  display: block;
+  height: 100%;
+  width: 100%;
+  max-width: 1280px;
+  max-height: 720px;
+}
+
+audio {
+  margin: 0px auto;
+  display: block;
+  width: 90%;
+  padding-top: 2em;
+  padding-bottom: 1em;
 }
 
 /* Admin interfaces */

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -10,7 +10,6 @@ class DocumentsController < ApplicationController
 
   def show
     @document = Document.find(params[:id])
-    @base_src = Settings.app_scheme + Settings.aws.cloudfront_domain + '/'
   end
 
   def new

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -10,7 +10,6 @@ class ImagesController < ApplicationController
 
   def show
     @image = Image.find(params[:id])
-    @base_src = Settings.app_scheme + Settings.aws.cloudfront_domain + '/'
   end
 
   def new

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -3,6 +3,8 @@
 #
 # @see Source
 class SourcesController < ApplicationController
+  include VideoPlayerHelper
+  include AudioPlayerHelper
   before_filter :load_source_set, only: [:index, :new, :create]
 
   def index

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,10 @@ module ApplicationHelper
     Settings.wordpress.url.chomp('/') + '/' + path.sub(/^\/+/) { $1 }
   end
 
+  def base_src
+    Settings.app_scheme + Settings.aws.cloudfront_domain + '/'
+  end
+
   ##
   # Get stylesheets from dpla_frontend_assets gem
   def branding_stylesheets

--- a/app/helpers/sources_helper.rb
+++ b/app/helpers/sources_helper.rb
@@ -1,0 +1,16 @@
+module SourcesHelper
+
+  def render_media_asset
+    return unless @source.main_asset.present?
+    case @source.main_asset.class.name
+    when 'Image'
+      render partial: 'image'
+    when 'Document'
+      render partial: 'document'
+    when 'Audio'
+      render partial: 'audio'
+    when 'Video'
+      render partial: 'video'
+    end
+  end
+end

--- a/app/helpers/video_player_helper.rb
+++ b/app/helpers/video_player_helper.rb
@@ -9,7 +9,7 @@ module VideoPlayerHelper
 
     meta = JSON.parse(video.meta)
     outputs = meta['output_settings']
-    rv = "<video preload=\"none\" width=\"640\" height=\"480\" controls>\n"
+    rv = "<video preload=\"none\" controls>\n"
     outputs.each do |out|
       extension = out['extension']
       suffix = out.fetch('suffix', '')

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -10,7 +10,7 @@
   <tr>
     <td><strong>File</strong></td>
     <td>
-      <a href="<%= @base_src + @document.file_name %>"><%= @document.file_name %></a>
+      <a href="<%= base_src + @document.file_name %>"><%= @document.file_name %></a>
     </td>
   </tr>
 </table>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -30,7 +30,7 @@
 </table>
 
 <div>
-  <img src="<%= @base_src + @image.file_name %>" alt="<%= @image.alt_text %>"/>
+  <img src="<%= base_src + @image.file_name %>" alt="<%= @image.alt_text %>"/>
 </div>
 
 <h2>Sources</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <%= render partial: 'shared/jump_links' %>
     <div class='container'>
       <%= render partial: 'shared/header' %>
-      <div class='layout fullWidth'>
+      <div class='layout'>
         <%= render partial: 'shared/search_panel' %>
         <%= render partial: 'shared/admin_menu' if admin_signed_in? %>
         <%= yield %>
@@ -21,4 +21,5 @@
     </div>
     <%= render partial: 'shared/jump_links' %>
   </body>
+  <%= javascript_include_tag 'style' %>
 </html>

--- a/app/views/sources/_audio.html.erb
+++ b/app/views/sources/_audio.html.erb
@@ -1,0 +1,7 @@
+<article class='audio'>
+  <div class='media-outer-container'>
+    <div class='media-inner-container'>
+      <%= raw audio_player(@source.main_asset) %>
+    </div>
+  </div>
+</article>

--- a/app/views/sources/_document.html.erb
+++ b/app/views/sources/_document.html.erb
@@ -1,0 +1,7 @@
+<article class='document'>
+  <div class='media-outer-container'>
+    <div class='media-inner-container'>
+      <iframe src="https://docs.google.com/viewer?url=<%= base_src + @source.main_asset.file_name %>&embedded=true" frameborder="0"></iframe>
+    </div>
+  </div>
+</article>

--- a/app/views/sources/_image.html.erb
+++ b/app/views/sources/_image.html.erb
@@ -1,0 +1,7 @@
+<article class='image'>
+  <div class='media-outer-container image'>
+    <div class='media-inner-container'>
+      <!-- render image here -->
+    </div>
+  </div>
+</article>

--- a/app/views/sources/_video.html.erb
+++ b/app/views/sources/_video.html.erb
@@ -1,0 +1,7 @@
+<article class='video'>
+  <div class='media-outer-container'>
+    <div class='media-inner-container'>
+      <%= raw video_player(@source.main_asset) %>
+    </div>
+  </div>
+</article>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,4 +1,4 @@
-<h1>Source: <%= inline_markdown(source_name(@source)) %></h1>
+<h1><%= inline_markdown(source_name(@source)) %></h1>
 
 <p>
   <%= link_to "Edit", edit_source_path(@source) %>
@@ -7,6 +7,30 @@
                source_path(@source), method: :delete,
                data: { confirm: "Are you sure you want to delete this source?" } %>
 </p>
+
+<div class='source'>
+
+  <%= render_media_asset %>
+
+  <aside>
+    <div class='module blue line'>
+      <div class='moduleSection wrap'>
+        <h2>Citation information</h2>
+        <%= markdown(@source.citation) %>
+        <h2>Credits</h2>
+        <%= markdown(@source.credits) %>
+        <h2>Need more information?</h2>
+        <%= link_to 'View the description of this item in DPLA',
+                    frontend_path(@source.aggregation) %>
+      </div>
+    </div>
+  </aside>
+
+  <div class='textual-content'>
+    <%= markdown(@source.textual_content) %>
+  </div>
+
+<h2>Admin info</h2>
 
 <table>
   <tr>
@@ -18,28 +42,13 @@
     <td><%= link_to frontend_path('item/' + @source.aggregation), frontend_path(@source.aggregation) %></td>
   </tr>
   <tr>
-    <td><strong>Caption </strong></td>
-    <td><%= inline_markdown(@source.name) %></td>
-  </tr>
-  <tr>
-    <td><strong>Citation </strong></td>
-    <td><%= markdown(@source.citation) %></td>
-  </tr>
-  <tr>
-    <td><strong>Credits </strong></td>
-    <td><%= markdown(@source.credits) %></td>
-  </tr>
-  <tr>
-    <td><strong>Description / transcription </strong></td>
-    <td><%= markdown(@source.textual_content) %></td>
-  </tr>
-  <tr>
     <td><strong>Featured? </strong></td>
     <td><%= @source.featured %></td>
   </tr>
 </table>
 
-<h2>Media assets</h2>
+
+<h3>Media assets</h2>
 
 <table>
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,6 +8,7 @@ Rails.application.config.assets.precompile += %w( avupload.js )
 Rails.application.config.assets.precompile += %w( docupload.js )
 Rails.application.config.assets.precompile += %w( imgupload.js )
 Rails.application.config.assets.precompile += %w( form.js )
+Rails.application.config.assets.precompile += %w( style.js )
 
 # Precompile assets from gems
 Rails.application.config.assets.precompile += %w( dpla-colors.css dpla-fonts.css )

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -62,4 +62,13 @@ describe ApplicationHelper, type: :helper do
       expect(helper.branding_stylesheets).to match(/dpla-fonts.css/)
     end
   end
+
+  describe '#base_src' do
+    it 'returns base URI with trailing backslash' do
+      allow(Settings).to receive(:app_scheme).and_return('something-')
+      allow(Settings).to receive_message_chain(:aws, :cloudfront_domain)
+        .and_return('example.com')
+      expect(helper.base_src).to eq 'something-example.com/'
+    end
+  end
 end

--- a/spec/helpers/source_helper_spec.rb
+++ b/spec/helpers/source_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe SourcesHelper, type: :helper do
+
+  describe '#render_media_asset' do
+    it 'renders the correct partial' do
+      source = create(:source_factory)
+      source.videos << create(:video_factory)
+      assign(:source, source)
+      expect(helper).to receive(:render).with({ partial: 'video' })
+      helper.render_media_asset
+    end
+  end
+end

--- a/spec/views/documents/show.html.erb_spec.rb
+++ b/spec/views/documents/show.html.erb_spec.rb
@@ -8,8 +8,7 @@ describe 'documents/show.html.erb', type: :view do
     assign(:document, document)
   end
 
-  # FIXME:  view relies on @base_src variable set in controller
-  xit 'renders the document' do
+  it 'renders the document' do
     render
     expect(rendered).to include(document.file_name)
   end

--- a/spec/views/images/show.html.erb_spec.rb
+++ b/spec/views/images/show.html.erb_spec.rb
@@ -8,8 +8,7 @@ describe 'images/show.html.erb', type: :view do
     assign(:image, image)
   end
 
-  # FIXME:  view relies on @base_src variable set in controller
-  xit 'renders the image' do
+  it 'renders the image' do
     render
     expect(rendered).to include(image.file_name)
   end


### PR DESCRIPTION
This styles the `source#show` view for video, audio, and document assets.  The best way to test will be to view them in your browser window.

In the process of adding the PDF viewer, I found that the `source` views needed access to what was the `@base_src` var in the `audio` and `video` controllers - so I changed it to an `ApplicationHelper` method and edited the specs accordingly.

It includes one JavaScript function for dynamic styling. I couldn't find a way to make this particular style definition work with static CSS.  It's a minor style enhancement that doesn't affect the actual content, so if a browser has JavaScript disabled, the user will get a comparable experience.

The video player now has a responsive height and width, based on the height and width of the browser window, instead of being set at 640px by 480px.  If we find that video quality is degrading when the video player is too large, we can add a `max-height` and `max-width` to the CSS.

Rendering image assets with OpenSeadragon can be done later in `views/sources/_image.html.erb`.

Known issue: The PDF viewer doesn't render if JavaScript is disabled.  We can add a graceful degradation that provides a link to the PDF instead.