### PR TITLE
add destroy depenedency to assets-attachments reltionship

### DIFF
--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,5 +1,5 @@
 class Audio < ActiveRecord::Base
-  has_many :attachments, as: :asset
+  has_many :attachments, as: :asset, dependent: :destroy
   has_many :sources, through: :attachments
   validates :file_base, presence: :true
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,5 @@
 class Document < ActiveRecord::Base
-  has_many :attachments, as: :asset
+  has_many :attachments, as: :asset, dependent: :destroy
   has_many :sources, through: :attachments
   validates :file_name, presence: :true
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,5 @@
 class Image < ActiveRecord::Base
-  has_many :attachments, as: :asset
+  has_many :attachments, as: :asset, dependent: :destroy
   has_many :sources, through: :attachments
   validates :file_name, presence: :true
   validates :height, numericality: { only_integer: true }, allow_blank: true

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,5 +1,5 @@
 class Video < ActiveRecord::Base
-  has_many :attachments, as: :asset
+  has_many :attachments, as: :asset, dependent: :destroy
   has_many :sources, through: :attachments
   validates :file_base, presence: :true
 end


### PR DESCRIPTION
This adds a destroy dependency to the assets-attachments relationship so that when an asset is deleted, its rows in the attachments table are also deleted.