### PR TITLE
Add image viewer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'rubocop', '~> 0.32.1', require: false
 gem 's3_browser_uploads', '0.1.2'
 gem 'zencoder', '~>2.5'
 gem 'navigasmic', '~>1.0'
+gem 'lightbox2-rails', '~>2.0'
 
 group :test, :development do
   gem 'rspec-core', '~> 3.3.2'

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,5 +19,6 @@
  *= require font_overrides.css
  *= require frontend_overrides.css
  *= require primary_source_sets.css
+ *= require lightbox
  *= require_self
  */

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head_script do %>
+<%= javascript_include_tag 'lightbox' %>
+<% end %>
+
 <h1>Image: <%= @image.file_name %></h1>
 
 <p>
@@ -29,9 +33,11 @@
   </tr>
 </table>
 
-<div>
-  <img src="<%= base_src + @image.file_name %>" alt="<%= @image.alt_text %>"/>
-</div>
+<a data-lightbox="image-1" data-title="<%= @image.alt_text %>"
+   href="<%= base_src + @image.file_name %>">
+   <img src="<%= base_src + @image.file_name %>" alt="<%= @image.alt_text %>"
+        style="max-width: 600px; max-height: 600px;" />
+</a>
 
 <h2>Sources</h2>
 <ul>

--- a/app/views/sources/_image.html.erb
+++ b/app/views/sources/_image.html.erb
@@ -1,7 +1,20 @@
 <article class='image'>
   <div class='media-outer-container image'>
     <div class='media-inner-container'>
-      <!-- render image here -->
+
+      <a data-lightbox="image-1"
+         data-title="<%= @source.main_asset.alt_text %>"
+         href="<%= base_src + @source.main_asset.file_name %>">
+
+        <div style="position: relative;">
+            <div style="position: absolute; top: 0; left: 0; width: 700px; height: 485px; z-index: 2;"></div>
+            <img src="<%= base_src + @source.main_asset.file_name %>"
+                 alt="<%= @source.main_asset.alt_text %>"
+                 style="position: absolute; top: 0; left: 0; z-index: 1; max-width: 700px; max-height: 485px;" />
+        </div>
+
+      </a>
+
     </div>
   </div>
 </article>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head_script do %>
+<%= javascript_include_tag 'lightbox' %>
+<% end %>
+
 <% content_for :foot_script do %>
 <%= render partial: 'shared/analytics' %>
 <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,6 +9,7 @@ Rails.application.config.assets.precompile += %w( docupload.js )
 Rails.application.config.assets.precompile += %w( imgupload.js )
 Rails.application.config.assets.precompile += %w( form.js )
 Rails.application.config.assets.precompile += %w( style.js )
+Rails.application.config.assets.precompile += %w( lightbox.js )
 
 # Precompile assets from gems
 Rails.application.config.assets.precompile += %w( dpla-colors.css dpla-fonts.css )


### PR DESCRIPTION
Add Lightbox2 image viewer

The viewer displays large images in the public `/sources:id` (show source) page and prevents convenient right-click downloads.  It displays images in what I assume will be the admin-only `/images:id` page, without preventing right-click-downloads.
