### PR TITLE
style source_sets#show

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -2,6 +2,85 @@
   word-wrap: break-word;
 }
 
+.primary-source-sets aside {
+  margin-left: 1em;
+  margin-bottom: 1em;
+}
+
+.primary-source-sets .moduleSection {
+  margin-bottom: 2em;
+}
+
+/* SourceSet */
+
+.set .title-outer-container {
+  background-color: #6592A6;
+}
+
+.set .title-inner-container {
+  color: white;
+  padding: 1.5em;
+}
+
+.set h1 {
+  color: white;
+  margin: 0;
+}
+
+.set .subheading {
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.set .overview {
+  clear: left;
+}
+
+.set .resources-outer-container {
+  background-color: #EDEDED;
+  border-top: 8px solid #6592A6;
+  padding: 1em;
+}
+
+.set .source-list-container {
+  margin-bottom: 2em;
+}
+
+.set .source-list-container .module {
+  background-color: #DBE5E9;
+  border: none;
+}
+
+.set .thumbnail-container  {
+  height: 160px;
+  width: 100%;
+}
+
+.set .thumbnail-container {
+  text-align: center;
+  margin-bottom: 1.5em;
+}
+
+.set .align-helper {
+  display: inline-block;
+  height: 100%;
+  vertical-align: middle;
+}
+
+.set .thumbnail-container img {
+  margin: 0px auto;
+  display: inline-block;
+  vertical-align: middle;
+  max-height: 160px;
+  max-width: 160px;
+  /*max-width: 160px;*/
+}
+
+.set .source-name-container {
+  text-align: center;
+}
+
+
 /* Source */
 
 .source .media-outer-container {
@@ -28,15 +107,6 @@
   clear: left;
   padding-top: 2em;
   margin-bottom: 3em;
-}
-
-.source aside {
-  margin-left: 1em;
-  margin-bottom: 1em;
-}
-
-.source .moduleSection {
-  margin-bottom: 2em;
 }
 
 iframe {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,6 +58,18 @@ module ApplicationHelper
       defined? DplaFrontendAssets
   end
 
+  ##
+  # Get all the authors for an object with related authors
+  # @param Guide or SourceSet
+  # @return Array
+  def authors(authored)
+    return unless authored.present?
+    authored.authors.map do |author|
+      author.affiliation.present? ? author.name + ', ' + author.affiliation :
+        author.name
+    end
+  end
+
   private
 
   ##

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -51,4 +51,12 @@ class Source < ActiveRecord::Base
       true if a.class.name == 'Image' && a.size != 'large'
     end.first
   end
+
+  def thumbnail
+    thumbnails.first
+  end
+
+  def small_image
+    small_images.first
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <%= render partial: 'shared/jump_links' %>
     <div class='container'>
       <%= render partial: 'shared/header' %>
-      <div class='layout'>
+      <div class='layout primary-source-sets'>
         <%= render partial: 'shared/search_panel' %>
         <%= render partial: 'shared/admin_menu' if admin_signed_in? %>
         <%= yield %>

--- a/app/views/source_sets/_source_list.html.erb
+++ b/app/views/source_sets/_source_list.html.erb
@@ -1,0 +1,26 @@
+<% if @source_set.sources.present? %>
+  <div class='source-list-container'>
+    <% @source_set.sources.each_slice(3) do |sources_row| %>
+      <div class='moduleContainer threeCol'>
+        <% sources_row.each_with_index do |source, i| %>
+          <section class='module'>
+            <div class='source-container'>
+              <div class='thumbnail-container'>
+                <% if source.thumbnail.present? %>
+                  <span class='align-helper'></span>
+                  <%= image_tag base_src + source.thumbnail.file_name,
+                                alt: source.thumbnail.alt_text.present? ? 
+                                       source.thumbnail.alt_text : source.name %>
+                <% end %>
+              </div>
+              <div class='source-name-container'>
+                <%= link_to inline_markdown(source_name(source)),
+                            source_path(source) %>
+              </div>
+            </div>
+          </section>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -2,42 +2,73 @@
 <%= render partial: 'shared/analytics' %>
 <% end %>
 
-<h1>Set: <%= inline_markdown(@source_set.name) %></h1>
+<div class='set'>
 
-<p>
-  <%= link_to "Edit", edit_source_set_path(@source_set) %>
-  |
-  <%= link_to "Delete", source_set_path(@source_set), method: :delete,
-                 data: { confirm: "Are you sure you want to delete this set?" } %>
-</p>
+  <article>
+    <div class='title-outer-container'>
+      <div class='title-inner-container'>
+        <h1><%= inline_markdown(@source_set.name) %></h1>
+        <span class='subheading'>Primary Source Set</span>
+      </div>
+    </div>
+
+    <p>
+      <%= link_to "Edit", edit_source_set_path(@source_set) %>
+      |
+      <%= link_to "Delete", source_set_path(@source_set), method: :delete,
+                     data: { confirm: "Are you sure you want to delete this set?" } %>
+    </p>
+  </article>
+
+  <aside>
+    <div class='module yellow line'>
+      <div class='moduleSection'>
+        <h2>Teaching guide</h2>
+        <p>
+          <% if @source_set.guides.present? %>
+            <%= link_to inline_markdown(@source_set.guides.first.name),
+                        guide_path(@source_set.guides.first) %> by 
+            <%= authors(@source_set.guides.first).join(' and ') %>.
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </aside>
+
+  <div class='overview'>
+    <% if @source_set.authors.present? %>
+      <p>By <%= authors(@source_set).join(' and ') %>.</p>
+    <% end %>
+    <%= markdown(@source_set.overview) %>
+  </div>
+
+  <%= render 'source_list' %>
+
+  <% if @source_set.resources.present? %>
+    <div class='resources-outer-container'>
+      <div class='resrouces-inner-container'>
+        <h2>Additional resources for research</h2>
+        <%= markdown(@source_set.resources) %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class='contact-outer-container'>
+    <p>Send feedback about this primary source set or our other educational resources to <%= mail_to 'education@dp.la', 'education@dp.la' %>.</p>
+  </div>
+</div>
+
+<h2>Admin info</h2>
 
 <table>
-  <tr>
-    <td><strong>Name </strong></td>
-    <td><%= inline_markdown(@source_set.name) %></td>
-  </tr>
   <tr>
     <td><strong>SEO description </strong></td>
     <td><%= @source_set.description %></td>
   </tr>
   <tr>
-    <td><strong>Overview </strong></td>
-    <td><%= markdown(@source_set.overview) %></td>
-  </tr>
-  <tr>
-    <td><strong>Resources </strong></td>
-    <td><%= markdown(@source_set.resources) %></td>
-  </tr>
-  <tr>
     <td><strong>Published </strong></td>
     <td><%= @source_set.published %></td>
   </tr>
-  <% @source_set.authors.each do |author| %>
-    <tr>
-      <td><strong>Author </strong></td>
-      <td><%= link_to author.name, author_path(author) %></td>
-    </tr>
-  <% end %>
   <tr>
     <td><strong>Featured image </strong></td>
     <td>
@@ -48,36 +79,6 @@
   </tr>
 </table>
 
-<h2>Sources</h2>
-
 <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
 
-<table>
-<% @source_set.sources.order('created_at ASC').each do |source| %>
-  <tr>
-    <td><%= inline_markdown(source_name(source)) %></td>
-    <td><%= link_to "View", source_path(source) %></td>
-    <td><%= link_to "Edit", edit_source_path(source) %></td>
-    <td><%= link_to "Delete", source_path(source),
-                    method: :delete,
-                    data: { confirm: "Are you sure you want to delete #{source_name(source)}?" } %></td>
-  </tr>
-<% end %>
-</table>
-
-<h2>Teaching guides</h2>
-
 <p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
-
-<table>
-<% @source_set.guides.each do |guide| %>
-  <tr>
-    <td><%= inline_markdown(guide.name) %></td>
-    <td><%= link_to "View", guide_path(guide) %></td>
-    <td><%= link_to "Edit", edit_guide_path(guide) %></td>
-    <td><%= link_to "Delete", guide_path(guide),
-                    method: :delete,
-                    data: { confirm: "Are you sure you want to delete #{guide.name}?" } %></td>
-  </tr>
-<% end %>
-</table>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -6,17 +6,16 @@
 <%= render partial: 'shared/analytics' %>
 <% end %>
 
-<h1><%= inline_markdown(source_name(@source)) %></h1>
-
-<p>
-  <%= link_to "Edit", edit_source_path(@source) %>
-  |
-  <%= link_to "Delete", 
-               source_path(@source), method: :delete,
-               data: { confirm: "Are you sure you want to delete this source?" } %>
-</p>
-
 <div class='source'>
+  <h1><%= inline_markdown(source_name(@source)) %></h1>
+
+  <p>
+    <%= link_to "Edit", edit_source_path(@source) %>
+    |
+    <%= link_to "Delete", 
+                 source_path(@source), method: :delete,
+                 data: { confirm: "Are you sure you want to delete this source?" } %>
+  </p>
 
   <%= render_media_asset %>
 
@@ -37,6 +36,7 @@
   <div class='textual-content'>
     <%= markdown(@source.textual_content) %>
   </div>
+</div>
 
 <h2>Admin info</h2>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,4 +71,13 @@ describe ApplicationHelper, type: :helper do
       expect(helper.base_src).to eq 'something-example.com/'
     end
   end
+
+  describe '#authors' do
+    it 'returns Array of authors with affilations' do
+      guide = create(:guide_factory)
+      guide.authors << [create(:author_factory, name: 'x', affiliation: 'y'),
+                        create(:author_factory, name: 'z', affiliation: nil)]
+      expect(helper.authors(guide)).to include('x, y', 'z')
+    end
+  end
 end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -100,5 +100,17 @@ describe Source, type: :model do
         expect(source.main_asset).to eq large_image
       end
     end
+
+    describe '#thumbnail' do
+      it 'returns the first attached thumbnail' do
+        expect(source.thumbnail).to eq thumbnail
+      end
+    end
+
+    describe '#small_image' do
+      it 'returns the first attached small image' do
+        expect(source.small_image).to eq small_image
+      end
+    end
   end
 end


### PR DESCRIPTION
This introduces CSS styling for `source_sets#show`.  It includes one helper method for concatenating multiple authors and their affiliations.  It also includes two new methods in the `Source` model to ease access to image assets of specified sizes.  Finally, it corrects a small HTML error in `sources#show`.  