### PR TITLE
Disable context menu on lightbox links to big images

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,3 +12,10 @@
 //
 //= require jquery
 //= require jquery_ujs
+
+// Disable context menu (right-click) on lightbox links to big images
+$(function() {
+    $('.lightboxlink').bind("contextmenu", function(e) {
+        return false;
+    });
+});

--- a/app/views/sources/_image.html.erb
+++ b/app/views/sources/_image.html.erb
@@ -2,7 +2,8 @@
   <div class='media-outer-container image'>
     <div class='media-inner-container'>
 
-      <a data-lightbox="image-1"
+      <a class="lightboxlink"
+         data-lightbox="image-1"
          data-title="<%= @source.main_asset.alt_text %>"
          href="<%= base_src + @source.main_asset.file_name %>">
 


### PR DESCRIPTION
This gets rid of the context menu (right click menu) of Lightbox's links to big images.  We had previously removed the ability to right-click and "download image as" but this gets rid of the menu with the options to open the link in another window or "save link as."
