### PR TITLE
allow public access to some views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  before_action :authenticate_admin!
 
   ##
   # Given information about an uploaded file in our "incoming" S3 bucket,

--- a/app/controllers/audio_notifications_controller.rb
+++ b/app/controllers/audio_notifications_controller.rb
@@ -4,7 +4,6 @@
 #
 class AudioNotificationsController < ApplicationController
   skip_before_filter :verify_authenticity_token
-  skip_before_filter :authenticate_admin!
   include ZencoderAuthentication
 
   ##

--- a/app/controllers/audios_controller.rb
+++ b/app/controllers/audios_controller.rb
@@ -3,6 +3,8 @@
 #
 # @see Audios
 class AudiosController < ApplicationController
+  before_action :authenticate_admin!
+
   def index
     @audios = Audio.all
   end

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -3,6 +3,7 @@
 #
 # @see Author
 class AuthorsController < ApplicationController
+  before_action :authenticate_admin!
 
   def index
     @authors = Author.all

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,6 +3,7 @@
 #
 # @see Document
 class DocumentsController < ApplicationController
+  before_action :authenticate_admin!
 
   def index
     @documents = Document.all

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -4,6 +4,8 @@
 # @see Guide
 class GuidesController < ApplicationController
   before_filter :load_source_set, only: [:index, :new, :create]
+  before_action :authenticate_admin!, only: [:new, :edit, :create, :update,
+                                             :destroy]
   add_breadcrumb 'Primary Source Sets', :root_path
 
   def index

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -3,6 +3,7 @@
 #
 # @see Image
 class ImagesController < ApplicationController
+  before_action :authenticate_admin!
 
   def index
     @images = Image.all

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -4,6 +4,7 @@
 # @see SourceSet
 class SourceSetsController < ApplicationController
   add_breadcrumb 'Primary Source Sets', :root_path
+  before_action :authenticate_admin!, only: [:new, :edit]
 
   def index
     @source_sets = SourceSet.all

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -6,6 +6,7 @@ class SourcesController < ApplicationController
   include VideoPlayerHelper
   include AudioPlayerHelper
   before_filter :load_source_set, only: [:index, :new, :create]
+  before_action :authenticate_admin!, only: [:new, :edit]
   add_breadcrumb 'Primary Source Sets', :root_path
 
   def index

--- a/app/controllers/video_notifications_controller.rb
+++ b/app/controllers/video_notifications_controller.rb
@@ -4,7 +4,6 @@
 #
 class VideoNotificationsController < ApplicationController
   skip_before_filter :verify_authenticity_token
-  skip_before_filter :authenticate_admin!
   include ZencoderAuthentication
 
   ##

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -3,6 +3,7 @@
 #
 # @see Video
 class VideosController < ApplicationController
+  before_action :authenticate_admin!
 
   def index
     @videos = Video.all

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -14,14 +14,6 @@
       </div>
     </div>
 
-    <p>
-      <%= link_to "Edit", edit_guide_path(@guide) %>
-      |
-      <%= link_to "Delete", 
-                   guide_path(@guide), method: :delete,
-                   data: { confirm: "Are you sure you want to delete this guide?" } %>
-    </p>
-
     <div class='textual_content'>
       <div class='overview'>
         <p>This teaching guide helps instructors use a specific primary source set, <%= link_to @guide.source_set.name, source_set_path(@guide.source_set) %>, in the classroom.  It offers discussion questions, classroom activities, and primary source analysis tools. It is intended to spark pedagogical creativity by giving a sample approach to the material. Please feel free to share, reuse, and adapt the resources in this guide for your teaching purposes.</p>
@@ -90,3 +82,15 @@
     <p>Send feedback about this teaching guide or our other educational resources to <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
   </div>
 </div>
+
+<% if admin_signed_in? %>
+  <h2>Admin info</h2>
+
+  <p>
+    <%= link_to "Edit", edit_guide_path(@guide) %>
+    |
+    <%= link_to "Delete", 
+                 guide_path(@guide), method: :delete,
+                 data: { confirm: "Are you sure you want to delete this guide?" } %>
+  </p>
+<% end %>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -34,19 +34,10 @@
 
 </div>
 
-<h2>Admin Info</h2>
+<% if admin_signed_in? %>
 
-<p><%= link_to "Create new set", new_source_set_path %></p>
+  <h2>Admin Info</h2>
 
-<table>
-<% @source_sets.order('created_at ASC').each do |set| %>
-  <tr>
-    <td><%= inline_markdown(set.name) %></td>
-    <td><%= link_to "View", source_set_path(set) %></td>
-    <td><%= link_to "Edit", edit_source_set_path(set) %></td>
-    <td><%= link_to "Delete", source_set_path(set),
-                    method: :delete,
-                    data: { confirm: "Are you sure you want to delete #{set.name}?" } %></td>
-  </tr>
+  <p><%= link_to "Create new set", new_source_set_path %></p>
+
 <% end %>
-</table>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -11,13 +11,6 @@
         <span class='subheading'>Primary Source Set</span>
       </div>
     </div>
-
-    <p>
-      <%= link_to "Edit", edit_source_set_path(@source_set) %>
-      |
-      <%= link_to "Delete", source_set_path(@source_set), method: :delete,
-                     data: { confirm: "Are you sure you want to delete this set?" } %>
-    </p>
   </article>
 
   <aside>
@@ -58,27 +51,36 @@
   </div>
 </div>
 
-<h2>Admin info</h2>
+<% if admin_signed_in? %>
+  <h2>Admin info</h2>
 
-<table>
-  <tr>
-    <td><strong>SEO description </strong></td>
-    <td><%= @source_set.description %></td>
-  </tr>
-  <tr>
-    <td><strong>Published </strong></td>
-    <td><%= @source_set.published %></td>
-  </tr>
-  <tr>
-    <td><strong>Featured image </strong></td>
-    <td>
-      <% if @source_set.featured_image.present? %>
-        <%= link_to @source_set.featured_image.file_name, image_path(@source_set.featured_image) %>
-      <% end %>
-    </td>
-  </tr>
-</table>
+  <p>
+    <%= link_to "Edit", edit_source_set_path(@source_set) %>
+    |
+    <%= link_to "Delete", source_set_path(@source_set), method: :delete,
+                   data: { confirm: "Are you sure you want to delete this set?" } %>
+  </p>
 
-<p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
+  <table>
+    <tr>
+      <td><strong>SEO description </strong></td>
+      <td><%= @source_set.description %></td>
+    </tr>
+    <tr>
+      <td><strong>Published </strong></td>
+      <td><%= @source_set.published %></td>
+    </tr>
+    <tr>
+      <td><strong>Featured image </strong></td>
+      <td>
+        <% if @source_set.featured_image.present? %>
+          <%= link_to @source_set.featured_image.file_name, image_path(@source_set.featured_image) %>
+        <% end %>
+      </td>
+    </tr>
+  </table>
 
-<p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
+  <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
+
+  <p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
+<% end %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -9,14 +9,6 @@
 <div class='source'>
   <h1><%= inline_markdown(source_name(@source)) %></h1>
 
-  <p>
-    <%= link_to "Edit", edit_source_path(@source) %>
-    |
-    <%= link_to "Delete", 
-                 source_path(@source), method: :delete,
-                 data: { confirm: "Are you sure you want to delete this source?" } %>
-  </p>
-
   <%= render_media_asset %>
 
   <aside>
@@ -42,58 +34,68 @@
     <p>Send feedback about this primary source or our other educational resources to <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
   </div>
 
-<h2>Admin info</h2>
+<% if admin_signed_in? %>
+  <h2>Admin info</h2>
 
-<table>
-  <tr>
-    <td><strong>Set </strong></td>
-    <td><%= link_to inline_markdown(@source.source_set.name), source_set_path(@source.source_set)%></td>
-  </tr>
-  <tr>
-    <td><strong>DPLA item URI </strong></td>
-    <td><%= link_to frontend_path('item/' + @source.aggregation), frontend_path(@source.aggregation) %></td>
-  </tr>
-  <tr>
-    <td><strong>Featured? </strong></td>
-    <td><%= @source.featured %></td>
-  </tr>
-</table>
+  <p>
+    <%= link_to "Edit", edit_source_path(@source) %>
+    |
+    <%= link_to "Delete", 
+                 source_path(@source), method: :delete,
+                 data: { confirm: "Are you sure you want to delete this source?" } %>
+  </p>
 
-
-<h3>Media assets</h2>
-
-<table>
-
-  <% if @source.main_asset.present? %>
+  <table>
     <tr>
-      <td><strong>Main media asset (<%= @source.main_asset.class.name %>)</strong></td>
-      <td><%= @file_base_or_name %></td>
-      <td><%= link_to "View", polymorphic_path(@source.main_asset) %></td>
-      <td><%= link_to "Delete", polymorphic_path(@source.main_asset),
-                      method: :delete,
-                      data: { confirm: "Are you sure you want to delete #{@file_base_or_name}?" } %></td>
+      <td><strong>Set </strong></td>
+      <td><%= link_to inline_markdown(@source.source_set.name), source_set_path(@source.source_set)%></td>
     </tr>
-  <% end %>
-
-  <% if @source.thumbnails.present? %>
     <tr>
-      <td><strong>Thumbnail </strong></td>
-      <td><%= @source.thumbnails.first.file_name %></td>
-      <td><%= link_to "View", image_path(@source.thumbnails.first) %></td>
-      <td><%= link_to "Delete", image_path(@source.thumbnails.first),
-                      method: :delete,
-                      data: { confirm: "Are you sure you want to delete #{@source.thumbnails.first.file_name}?" } %></td>
+      <td><strong>DPLA item URI </strong></td>
+      <td><%= link_to frontend_path('item/' + @source.aggregation), frontend_path(@source.aggregation) %></td>
     </tr>
-  <% end %>
-
-  <% if @source.small_images.present? %>
     <tr>
-      <td><strong>Small image </strong></td>
-      <td><%= @source.small_images.first.file_name %></td>
-      <td><%= link_to "View", image_path(@source.small_images.first) %></td>
-      <td><%= link_to "Delete", image_path(@source.small_images.first),
-                      method: :delete,
-                      data: { confirm: "Are you sure you want to delete #{@source.small_images.first.file_name}?" } %></td>
+      <td><strong>Featured? </strong></td>
+      <td><%= @source.featured %></td>
     </tr>
-  <% end %>
-</table>
+  </table>
+
+
+  <h3>Media assets</h2>
+
+  <table>
+
+    <% if @source.main_asset.present? %>
+      <tr>
+        <td><strong>Main media asset (<%= @source.main_asset.class.name %>)</strong></td>
+        <td><%= @file_base_or_name %></td>
+        <td><%= link_to "View", polymorphic_path(@source.main_asset) %></td>
+        <td><%= link_to "Delete", polymorphic_path(@source.main_asset),
+                        method: :delete,
+                        data: { confirm: "Are you sure you want to delete #{@file_base_or_name}?" } %></td>
+      </tr>
+    <% end %>
+
+    <% if @source.thumbnails.present? %>
+      <tr>
+        <td><strong>Thumbnail </strong></td>
+        <td><%= @source.thumbnails.first.file_name %></td>
+        <td><%= link_to "View", image_path(@source.thumbnails.first) %></td>
+        <td><%= link_to "Delete", image_path(@source.thumbnails.first),
+                        method: :delete,
+                        data: { confirm: "Are you sure you want to delete #{@source.thumbnails.first.file_name}?" } %></td>
+      </tr>
+    <% end %>
+
+    <% if @source.small_images.present? %>
+      <tr>
+        <td><strong>Small image </strong></td>
+        <td><%= @source.small_images.first.file_name %></td>
+        <td><%= link_to "View", image_path(@source.small_images.first) %></td>
+        <td><%= link_to "Delete", image_path(@source.small_images.first),
+                        method: :delete,
+                        data: { confirm: "Are you sure you want to delete #{@source.small_images.first.file_name}?" } %></td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -7,7 +7,7 @@ describe GuidesController, type: :controller do
   let(:invalid_attributes) { attributes_for(:invalid_guide_factory) }
   let(:parent) { resource.source_set }
 
-  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+  it_behaves_like 'admin-only route', :new, :edit
 
   context 'admin logged in' do
     login_admin

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -6,7 +6,7 @@ describe SourceSetsController, type: :controller do
   let(:attributes) { attributes_for(:source_set_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_source_set_factory) }
 
-  it_behaves_like 'admin-only route', :index, :show, :edit, :new
+  it_behaves_like 'admin-only route', :edit, :new
 
   context 'admin logged in' do
     login_admin

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -7,7 +7,7 @@ describe SourcesController, type: :controller do
   let(:invalid_attributes) { attributes_for(:invalid_source_factory) }
   let(:parent) { resource.source_set }
 
-  it_behaves_like 'admin-only route', :index, :show, :new, :edit
+  it_behaves_like 'admin-only route', :new, :edit
 
   context 'admin logged in' do
     login_admin

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -2,4 +2,5 @@ require 'rspec/rails'
 
 RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
+  config.include Devise::TestHelpers, type: :view
 end


### PR DESCRIPTION
Allow public access to `source_set#index`, `source_sets#show`, `source#show`, and `guide#show`.  Only show admin menus and information on these views if the admin is logged in.

This addresses task [#8085](https://issues.dp.la/issues/8085).