### PR TITLE
style and static content fixes for public faces pages

### DIFF
--- a/app/assets/javascripts/style.js
+++ b/app/assets/javascripts/style.js
@@ -22,4 +22,14 @@ function setAsideHeight() {
   if (minHeight > height) {
     $('.source aside .module').outerHeight(minHeight);
   }
+
+  var moduleHeight = $('.set aside .module').outerHeight();
+  var titleHeight = $('.set .title-outer-container').outerHeight();
+
+  if (moduleHeight < titleHeight) {
+    $('.set aside .module').outerHeight(titleHeight);
+  }
+  if (titleHeight < moduleHeight) {
+    $('.set .title-outer-container').outerHeight(moduleHeight);
+  }
 }

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -13,8 +13,9 @@
   margin-bottom: 2em;
 }
 
-.contact-outer-container {
+.primary-source-sets .contact-outer-container {
   clear: both;
+  margin-top: 2em;
 }
 
 /* SourceSet and Guide shared styles */
@@ -22,6 +23,7 @@
 .set .title-outer-container,
 .guide .title-outer-container {
   background-color: #6592A6;
+  margin-bottom: 2em;
 }
 
 .set .title-inner-container,
@@ -38,13 +40,15 @@
 .set .subheading, .guide .subheading {
   font-size: 1.2em;
   font-weight: bold;
+  display: block;
+}
+
+.set .byline, .guide .byline {
+  display: block;
+  margin-top: 1em;
 }
 
 /* SourceSets index styles */
-
-.all-sets .set-list {
-  padding-bottom: 2em;
-}
 
 .all-sets .module {
   border-color: #6592A6;
@@ -79,7 +83,7 @@
 }
 
 .set .source-list-container .module {
-  background-color: #DBE5E9;
+  background-color: #f0f3f4;
   border: none;
 }
 
@@ -105,11 +109,10 @@
   vertical-align: middle;
   max-height: 160px;
   max-width: 160px;
-  /*max-width: 160px;*/
 }
 
 .set .source-name-container {
-  text-align: center;
+  text-align: left;
 }
 
 

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -7,16 +7,16 @@
   <article>
     <div class='title-outer-container'>
       <div class='title-inner-container'>
-        <h1>Teaching Guide: <%= inline_markdown(@guide.name) %></h1>
+        <h1><%= inline_markdown(@guide.name) %></h1>
         <% if @guide.authors.present? %>
-          <span>By <%= authors(@guide).join(' and ') %>.</span>
+          <span class='byline'>By <%= authors(@guide).join(' and ') %>.</span>
         <% end %>
       </div>
     </div>
 
     <div class='textual_content'>
       <div class='overview'>
-        <p>This teaching guide helps instructors use a specific primary source set, <%= link_to @guide.source_set.name, source_set_path(@guide.source_set) %>, in the classroom.  It offers discussion questions, classroom activities, and primary source analysis tools. It is intended to spark pedagogical creativity by giving a sample approach to the material. Please feel free to share, reuse, and adapt the resources in this guide for your teaching purposes.</p>
+        <p>This teaching guide helps instructors use a specific primary source set, <%= link_to inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set) %>, in the classroom.  It offers discussion questions, classroom activities, and primary source analysis tools. It is intended to spark pedagogical creativity by giving a sample approach to the material. Please feel free to share, reuse, and adapt the resources in this guide for your teaching purposes.</p>
       </div>
 
       <% if @guide.questions.present? %>
@@ -37,8 +37,7 @@
         <h2>Primary source set</h2>
         <p><span>This teaching guide is a companion to </span>
           <%= link_to inline_markdown(@guide.source_set.name),
-                      source_set_path(@guide.source_set) %> by 
-          <%= authors(@guide).join(' and ') %>.
+                      source_set_path(@guide.source_set) %>
         </p>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,15 @@
       <%= render partial: 'shared/header' %>
       <div class='layout primary-source-sets'>
         <%= render partial: 'shared/search_panel' %>
-        <div class="breadcrumbs">
-          <%= render_breadcrumbs separator: ' / ' %>
-        </div>
+
+        <% unless current_page?(url_for(controller: 'source_sets',
+                                        action: 'index')) ||
+                  current_page?(root_url) %>
+          <div class="breadcrumbs">
+            <%= render_breadcrumbs separator: ' / ' %>
+          </div>
+        <% end %>
+
         <%= render partial: 'shared/admin_menu' if admin_signed_in? %>
         <%= yield %>
       </div>

--- a/app/views/source_sets/_source_list.html.erb
+++ b/app/views/source_sets/_source_list.html.erb
@@ -8,9 +8,10 @@
               <div class='thumbnail-container'>
                 <% if source.thumbnail.present? %>
                   <span class='align-helper'></span>
-                  <%= image_tag base_src + source.thumbnail.file_name,
-                                alt: source.thumbnail.alt_text.present? ? 
-                                       source.thumbnail.alt_text : source.name %>
+                  <%= link_to((image_tag base_src + source.thumbnail.file_name,
+                                         alt: source.thumbnail.alt_text.present? ? 
+                                           source.thumbnail.alt_text : source.name),
+                               source_path(source)) %>
                 <% end %>
               </div>
               <div class='source-name-container'>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -6,8 +6,8 @@
 
   <h1>Primary Source Sets</h1>
 
-  <p>DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources. Each set includes an overview, ten to fifteen primary sources, links to related resources, and a teaching guide. 
-  These sets were created, and reviewed by the teachers on the DPLA's <%= link_to 'Education Advisory Committee', wordpress_path('education/education-advisory-committee') %>. We will be adding new sets and features through Spring 2016. Read about our <%= link_to 'education projects', wordpress_path('education') %> and contact us with feedback at <%= link_to Settings.contact_email, Settings.contect_email %> .</p>
+  <p>DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources. Each set includes an overview, ten to fifteen primary sources, links to related resources, and a teaching guide.</p>
+  <p>These sets were created and reviewed by the teachers on the DPLA's <%= link_to 'Education Advisory Committee', wordpress_path('education/education-advisory-committee') %>. We will be adding new sets and features through Spring 2016. Read about our <%= link_to 'education projects', wordpress_path('education') %> and contact us with feedback at <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
 
   <div class='set-list'>
     <%= @source_sets.order('created_at ASC').each_slice(3) do |sets_row| %>
@@ -15,12 +15,13 @@
         <% sets_row.each_with_index do |set, i| %>
           <section class='module'>
             <% if set.featured_image.present? %>
-              <%= image_tag base_src + set.featured_image.file_name,
-                           alt: set.featured_image.alt_text.present? ? 
-                           set.featured_image.alt_text : set.name %>
+              <%= link_to((image_tag base_src + set.featured_image.file_name,
+                                     alt: set.featured_image.alt_text.present? ? 
+                                       set.featured_image.alt_text : set.name),
+                          source_set_path(set)) %>
             <% end %>
             <div class='set-name-container'>
-              <%= link_to set.name, source_set_path(set) %>
+              <%= link_to inline_markdown(set.name), source_set_path(set) %>
             </div>
           </section>
         <% end %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -9,6 +9,9 @@
       <div class='title-inner-container'>
         <h1><%= inline_markdown(@source_set.name) %></h1>
         <span class='subheading'>Primary Source Set</span>
+        <% if @source_set.authors.present? %>
+          <span class='byline'>By <%= authors(@source_set).join(' and ') %>.</span>
+        <% end %>
       </div>
     </div>
   </article>
@@ -20,8 +23,7 @@
         <p>
           <% if @source_set.guides.present? %>
             <%= link_to inline_markdown(@source_set.guides.first.name),
-                        guide_path(@source_set.guides.first) %> by 
-            <%= authors(@source_set.guides.first).join(' and ') %>.
+                        guide_path(@source_set.guides.first) %>
           <% end %>
         </p>
       </div>
@@ -29,9 +31,6 @@
   </aside>
 
   <div class='overview'>
-    <% if @source_set.authors.present? %>
-      <p>By <%= authors(@source_set).join(' and ') %>.</p>
-    <% end %>
     <%= markdown(@source_set.overview) %>
   </div>
 

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -20,7 +20,7 @@
         <%= markdown(@source.credits) %>
         <h2>Need more information?</h2>
         <%= link_to 'View the description of this item in DPLA',
-                    frontend_path(@source.aggregation) %>
+                    frontend_path('item/' + @source.aggregation) %>
       </div>
     </div>
   </aside>
@@ -29,10 +29,6 @@
     <%= markdown(@source.textual_content) %>
   </div>
 </div>
-
-  <div class='contact-outer-container'>
-    <p>Send feedback about this primary source or our other educational resources to <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
-  </div>
 
 <% if admin_signed_in? %>
   <h2>Admin info</h2>


### PR DESCRIPTION
This makes many small style and static content fixes for the public-facing pages.  They include:

`sets#index`
* Fix email link in introductory text
* Remove comma after “These sets were created”
* Add paragraph break before “These sets were created" 
* Render markdown for set titles
* Hyperlink thumbnails
* Remove breadcrumbs

`set#show`
* Hyperlink thumbnails 
* Left-align source titles
* Change source tile background color from light blue to light grey
* Make the blue title bar and the grey "Teaching Guide" sidebar the same height (this is done with JavaScript, which will not fix the style on browsers with JavaScript disabled)

`source#show`
* Add `/item` to "Need more information..." URLs
* Remove “Send feedback” div from bottom of page

`guide#show`
* Remove author name and affiliation from "Primary Source Set" sidebar
* Remove “Teaching guide” from title

General changes:
* Make the whitespace above "Send feedback" `div` consistent across pages

This addresses ticket [#8084](https://issues.dp.la/issues/8084).