### PR TITLE
render markdown in breadcrumbs

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -3,6 +3,7 @@
 #
 # @see Guide
 class GuidesController < ApplicationController
+  include MarkdownHelper
   before_filter :load_source_set, only: [:index, :new, :create]
   before_action :authenticate_admin!, only: [:new, :edit, :create, :update,
                                              :destroy]
@@ -14,7 +15,7 @@ class GuidesController < ApplicationController
 
   def show
     @guide = Guide.friendly.find(params[:id])
-    add_breadcrumb @guide.source_set.name, source_set_path(@guide.source_set)
+    add_breadcrumb inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set)
     add_breadcrumb 'Guide', guide_path(@guide)
   end
 

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -3,6 +3,7 @@
 #
 # @see SourceSet
 class SourceSetsController < ApplicationController
+  include MarkdownHelper
   add_breadcrumb 'Primary Source Sets', :root_path
   before_action :authenticate_admin!, only: [:new, :edit]
 
@@ -12,7 +13,7 @@ class SourceSetsController < ApplicationController
 
   def show
     @source_set = SourceSet.friendly.find(params[:id])
-    add_breadcrumb @source_set.name, source_set_path(@source_set)
+    add_breadcrumb inline_markdown(@source_set.name), source_set_path(@source_set)
   end
 
   def new

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -5,6 +5,7 @@
 class SourcesController < ApplicationController
   include VideoPlayerHelper
   include AudioPlayerHelper
+  include MarkdownHelper
   before_filter :load_source_set, only: [:index, :new, :create]
   before_action :authenticate_admin!, only: [:new, :edit]
   add_breadcrumb 'Primary Source Sets', :root_path
@@ -15,7 +16,7 @@ class SourcesController < ApplicationController
 
   def show
     @source = Source.find(params[:id])
-    add_breadcrumb @source.source_set.name, source_set_path(@source.source_set)
+    add_breadcrumb inline_markdown(@source.source_set.name), source_set_path(@source.source_set)
     add_breadcrumb 'Source', source_path(@source)
     ma = @source.main_asset
     @file_base_or_name = nil

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,24 +1,5 @@
 module ApplicationHelper
 
-  ##
-  # @param String text A markdown formatted String
-  # @return String An HTML representation of the markdown string given in 'text'
-  # @raise TypeError if @param is not a String
-  def markdown(text)
-    options = { autolink: true, footnotes: true }
-    Redcarpet::Markdown.new(Redcarpet::Render::HTML, options).render(text)
-      .html_safe
-  end
-
-  ##
-  # @param String text A markdown formatted String
-  # @return String An HTML representation of the markdown string given in 'text'
-  # without enclosing <p> tags.
-  # @raise TypeError if @param is not a String
-  def inline_markdown(text)
-    strip_p_tags(markdown(text))
-  end
-
   def source_name(source)
     source.name.present? ? source.name : source.aggregation
   end
@@ -68,26 +49,5 @@ module ApplicationHelper
       author.affiliation.present? ? author.name + ', ' + author.affiliation :
         author.name
     end
-  end
-
-  private
-
-  ##
-  # This strips enclosing <p> tags from an HTML formatted String.
-  #
-  # @param String html An HTML formatted String
-  # @return String An HTML fomratted String
-  #
-  # This is intended for HTML-formatted Strings that were rendered from markdown
-  # with the Redcarpet gem.  Redcarpet automatically encloses all markdown-
-  # formatted Strings in <p> tags, which need to be stripped for inline
-  # elements.
-  # As a sanity check, if a String has internal <p> tags, the enclosing <p> tags
-  # are not stripped.
-  def strip_p_tags(html)
-    match = Regexp.new('^<p>(.*)<\/p>$').match(html)
-    return html unless match.present?
-    return html if match[1].include?("<p>") || match[1].include?("</p>")
-    match[1].html_safe
   end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,41 @@
+module MarkdownHelper
+  ##
+  # @param String text A markdown formatted String
+  # @return String An HTML representation of the markdown string given in 'text'
+  # @raise TypeError if @param is not a String
+  def markdown(text)
+    options = { autolink: true, footnotes: true }
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML, options).render(text)
+      .html_safe
+  end
+
+  ##
+  # @param String text A markdown formatted String
+  # @return String An HTML representation of the markdown string given in 'text'
+  # without enclosing <p> tags.
+  # @raise TypeError if @param is not a String
+  def inline_markdown(text)
+    strip_p_tags(markdown(text))
+  end
+
+  private
+
+  ##
+  # This strips enclosing <p> tags from an HTML formatted String.
+  #
+  # @param String html An HTML formatted String
+  # @return String An HTML fomratted String
+  #
+  # This is intended for HTML-formatted Strings that were rendered from markdown
+  # with the Redcarpet gem.  Redcarpet automatically encloses all markdown-
+  # formatted Strings in <p> tags, which need to be stripped for inline
+  # elements.
+  # As a sanity check, if a String has internal <p> tags, the enclosing <p> tags
+  # are not stripped.
+  def strip_p_tags(html)
+    match = Regexp.new('^<p>(.*)<\/p>$').match(html)
+    return html unless match.present?
+    return html if match[1].include?("<p>") || match[1].include?("</p>")
+    match[1].html_safe
+  end
+end


### PR DESCRIPTION
This renders markdown in the breadcrumbs.  It addresses [#8087](https://issues.dp.la/issues/8087).