### PR TITLE
Fix sign-in page server error

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -2,6 +2,10 @@
 <%= render partial: 'shared/analytics' %>
 <% end %>
 
+<div class="breadcrumbs">
+  <%= render_breadcrumbs separator: ' / ' %>
+</div>
+
 <div class='guide'>
 
   <article>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,15 +14,6 @@
       <%= render partial: 'shared/header' %>
       <div class='layout primary-source-sets'>
         <%= render partial: 'shared/search_panel' %>
-
-        <% unless current_page?(url_for(controller: 'source_sets',
-                                        action: 'index')) ||
-                  current_page?(root_url) %>
-          <div class="breadcrumbs">
-            <%= render_breadcrumbs separator: ' / ' %>
-          </div>
-        <% end %>
-
         <%= render partial: 'shared/admin_menu' if admin_signed_in? %>
         <%= yield %>
       </div>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -2,6 +2,10 @@
 <%= render partial: 'shared/analytics' %>
 <% end %>
 
+<div class="breadcrumbs">
+  <%= render_breadcrumbs separator: ' / ' %>
+</div>
+
 <div class='set'>
 
   <article>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -6,6 +6,10 @@
 <%= render partial: 'shared/analytics' %>
 <% end %>
 
+<div class="breadcrumbs">
+  <%= render_breadcrumbs separator: ' / ' %>
+</div>
+
 <div class='source'>
   <h1><%= inline_markdown(source_name(@source)) %></h1>
 


### PR DESCRIPTION
Move breadcrumb link rendering to just those three views that need it, taking it out of the application layout.

The presence of a `url_for` call that asked for the location of `source_sets#index` caused a server error in the context of a Devise login page, with an error indicating that no route matches `{:action=>"index", :controller=>"devise/source_sets"}`.