### PR TITLE
UI presentational fixes for launch

### DIFF
--- a/app/assets/javascripts/style.js
+++ b/app/assets/javascripts/style.js
@@ -23,13 +23,25 @@ function setAsideHeight() {
     $('.source aside .module').outerHeight(minHeight);
   }
 
-  var moduleHeight = $('.set aside .module').outerHeight();
+  // resize header on set page
+  var moduleHeight = $('.set .guide-link .module').outerHeight();
   var titleHeight = $('.set .title-outer-container').outerHeight();
 
   if (moduleHeight < titleHeight) {
-    $('.set aside .module').outerHeight(titleHeight);
+    $('.set .guide-link .module').outerHeight(titleHeight);
   }
   if (titleHeight < moduleHeight) {
     $('.set .title-outer-container').outerHeight(moduleHeight);
+  }
+
+  // resize header on guide page
+  var moduleHeight = $('.guide .set-link .module').outerHeight();
+  var titleHeight = $('.guide .title-outer-container').outerHeight();
+
+  if (moduleHeight < titleHeight) {
+    $('.guide .set-link .module').outerHeight(titleHeight);
+  }
+  if (titleHeight < moduleHeight) {
+    $('.guide .title-outer-container').outerHeight(moduleHeight);
   }
 }

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -48,12 +48,18 @@
   margin-top: 1em;
 }
 
+.set .guide-link .moduleSection,
+.guide  .set-link .moduleSection {
+  margin-bottom: 1em;
+}
+
 /* SourceSets index styles */
 
 .all-sets .module {
   border-color: #6592A6;
   padding: 0;
   background-color: #6592A6;
+  max-width: 440px;
 }
 
 .all-sets .set-name-container {
@@ -69,7 +75,7 @@
 /* SourceSet styles */
 
 .set .overview {
-  clear: left;
+  clear: both;
 }
 
 .set .resources-outer-container {

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -13,7 +13,7 @@
       <div class='title-inner-container'>
         <h1><%= inline_markdown(@guide.name) %></h1>
         <% if @guide.authors.present? %>
-          <span class='byline'>By <%= authors(@guide).join(' and ') %>.</span>
+          <span class='byline'>By <%= authors(@guide).join(' and ') %></span>
         <% end %>
       </div>
     </div>
@@ -35,7 +35,7 @@
     </div>
   </article>
 
-  <aside>
+  <aside class='set-link'>
     <div class='module yellow line'>
       <div class='moduleSection'>
         <h2>Primary source set</h2>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -6,8 +6,7 @@
 
   <h1>Primary Source Sets</h1>
 
-  <p>DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources. Each set includes an overview, ten to fifteen primary sources, links to related resources, and a teaching guide.</p>
-  <p>These sets were created and reviewed by the teachers on the DPLA's <%= link_to 'Education Advisory Committee', wordpress_path('education/education-advisory-committee') %>. We will be adding new sets and features through Spring 2016. Read about our <%= link_to 'education projects', wordpress_path('education') %> and contact us with feedback at <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
+  <p>DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources. Each set includes an overview, ten to fifteen primary sources, links to related resources, and a teaching guide. These sets were created and reviewed by the teachers on the DPLA's <%= link_to 'Education Advisory Committee', wordpress_path('education/education-advisory-committee') %>. We will be adding new sets and features through Spring 2016. Read about our <%= link_to 'education projects', wordpress_path('education') %> and contact us with feedback at <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
 
   <div class='set-list'>
     <%= @source_sets.order('created_at ASC').each_slice(3) do |sets_row| %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -14,13 +14,13 @@
         <h1><%= inline_markdown(@source_set.name) %></h1>
         <span class='subheading'>Primary Source Set</span>
         <% if @source_set.authors.present? %>
-          <span class='byline'>By <%= authors(@source_set).join(' and ') %>.</span>
+          <span class='byline'>By <%= authors(@source_set).join(' and ') %></span>
         <% end %>
       </div>
     </div>
   </article>
 
-  <aside>
+  <aside class='guide-link'>
     <div class='module yellow line'>
       <div class='moduleSection'>
         <h2>Teaching guide</h2>


### PR DESCRIPTION
This makes some presentational adjustments to the public UI for launch.  Changes include:

`source_sets#index`
* Remove paragraph break in intro text
* Remove period at end of byline
* Fix width of set tiles for mobile view
* Make bottom margin of first aside module smaller

`source_sets#show`
* Eliminate text wrapping in intro text

`guides#show`
* Make title bar and first `aside` module the same height (this is done dynamically with JavaScript, which is not ideal but will get us to launch)
* Remove period at end of byline
* Make bottom margin of first aside module smaller