### PR TITLE
set height and width for textareas

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -193,3 +193,8 @@ input.form-submit {
   font-size: 100%;
   padding: 2px;
 }
+
+textarea {
+  height: 300px;
+  width: 99%;
+}


### PR DESCRIPTION
This sets a default height and width of `textarea` elements to ease data entry.  It addresses [ticket #8135](https://issues.dp.la/issues/8135).