### PR TITLE
title, description, & canonical link tags

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,3 +1,13 @@
+<% content_for :head_script do %>
+  <title><%= strip_tags(inline_markdown(@guide.name)) %></title>
+  <meta name='description' content="This teaching guide helps instructors use a specific primary source set, '<%= strip_tags(inline_markdown(@guide.source_set.name)) %>', in the classroom." />
+  <link rel='canonical' href='<%= url_for(controller: 'guides',
+                                          action: 'show',
+                                          id: @guide.slug,
+                                          only_path: false,
+                                          trailing_slash: true) %>' /> 
+<% end %>
+
 <% content_for :foot_script do %>
 <%= render partial: 'shared/analytics' %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>PrimarySourceSets</title>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
     <%= branding_stylesheets %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head_script do %>
+  <title>Primary Source Sets</title>
+  <meta name='description' content="DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources." />
+<% end %>
+
 <% content_for :foot_script do %>
 <%= render partial: 'shared/analytics' %>
 <% end %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -1,3 +1,13 @@
+<% content_for :head_script do %>
+  <title><%= strip_tags(inline_markdown(@source_set.name)) %></title>
+  <meta name='description' content="<%= @source_set.description %>" />
+  <link rel='canonical' href='<%= url_for(controller: 'source_sets',
+                                          action: 'show',
+                                          id: @source_set.slug,
+                                          only_path: false,
+                                          trailing_slash: true) %>' /> 
+<% end %>
+
 <% content_for :foot_script do %>
 <%= render partial: 'shared/analytics' %>
 <% end %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,4 +1,14 @@
 <% content_for :head_script do %>
+  <title><%= strip_tags(inline_markdown(@source.name)) %></title>
+  <meta name='description' content="This <%= @source.main_asset.class.name.downcase %> is part of '<%= strip_tags(inline_markdown(@source.source_set.name)) %>', a primary source set for educational use." />
+  <link rel='canonical' href='<%= url_for(controller: 'sources',
+                                          action: 'show',
+                                          id: @source.id,
+                                          only_path: false,
+                                          trailing_slash: true) %>' /> 
+<% end %>
+
+<% content_for :head_script do %>
 <%= javascript_include_tag 'lightbox' %>
 <% end %>
 


### PR DESCRIPTION
This adds unique SEO tags to the `head` of public-facing views.

1. A `title` tag.
2. A `meta` `description` tag.
3. A `canonical` `link` tag, which should be an absolute URL with a trailing slash.  `source_set#index` does not have a `canonical` `link` tag because in future iterations, the contents of this page will change based on search parameters (ie. there will not be only one version of the page).

The contents of these tags are text-only, so they are stripped of any nested HTML tags where appropriate.