### PR TITLE
fix title style and content spacing

### DIFF
--- a/app/assets/javascripts/style.js
+++ b/app/assets/javascripts/style.js
@@ -33,15 +33,4 @@ function setAsideHeight() {
   if (titleHeight < moduleHeight) {
     $('.set .title-outer-container').outerHeight(moduleHeight);
   }
-
-  // resize header on guide page
-  var moduleHeight = $('.guide .set-link .module').outerHeight();
-  var titleHeight = $('.guide .title-outer-container').outerHeight();
-
-  if (moduleHeight < titleHeight) {
-    $('.guide .set-link .module').outerHeight(titleHeight);
-  }
-  if (titleHeight < moduleHeight) {
-    $('.guide .title-outer-container').outerHeight(moduleHeight);
-  }
 }

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -20,23 +20,6 @@
 
 /* SourceSet and Guide shared styles */
 
-.set .title-outer-container,
-.guide .title-outer-container {
-  background-color: #6592A6;
-  margin-bottom: 2em;
-}
-
-.set .title-inner-container,
-.guide .title-inner-container {
-  color: white;
-  padding: 1.5em;
-}
-
-.set h1, .guide h1 {
-  color: white;
-  margin: 0;
-}
-
 .set .subheading, .guide .subheading {
   font-size: 1.2em;
   font-weight: bold;
@@ -54,6 +37,21 @@
 }
 
 /* SourceSets index styles */
+
+.set .title-outer-container {
+  background-color: #6592A6;
+  margin-bottom: 2em;
+}
+
+.set .title-inner-container {
+  color: white;
+  padding: 1.5em;
+}
+
+.set h1 {
+  color: white;
+  margin: 0;
+}
 
 .all-sets .module {
   border-color: #6592A6;
@@ -121,6 +119,15 @@
   text-align: left;
 }
 
+/* Guide styles */
+
+.guide .textual-content, .guide .questions, .guide .activity {
+  margin-top: 3em;
+}
+
+.guide .byline {
+  color: #818285;
+}
 
 /* Source */
 

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -28,19 +28,23 @@
       </div>
     </div>
 
-    <div class='textual_content'>
+    <div class='textual-content'>
       <div class='overview'>
         <p>This teaching guide helps instructors use a specific primary source set, <%= link_to inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set) %>, in the classroom.  It offers discussion questions, classroom activities, and primary source analysis tools. It is intended to spark pedagogical creativity by giving a sample approach to the material. Please feel free to share, reuse, and adapt the resources in this guide for your teaching purposes.</p>
       </div>
 
       <% if @guide.questions.present? %>
-        <h2>Discussion questions</h2>
-        <%= markdown(@guide.questions) %>
+        <div class='questions'>
+          <h2>Discussion questions</h2>
+          <%= markdown(@guide.questions) %>
+        </div>
       <% end %>
 
       <% if @guide.activity.present? %>
-        <h2>Classroom activities</h2>
-        <%= markdown(@guide.activity) %>
+        <div class='activity'>
+          <h2>Classroom activities</h2>
+          <%= markdown(@guide.activity) %>
+        </div>
       <% end %>
     </div>
   </article>


### PR DESCRIPTION
This makes some small changes to the style of the `guide`.

It removes the blue background from the title and byline, instead making the title blue text on a white background.  It also adds more whitespace in-between sections of the main content of the page.

This addresses [ticket #8150](https://issues.dp.la/issues/8150).