### PR TITLE
do not return nil assets in Source#assets

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -39,7 +39,7 @@ class Source < ActiveRecord::Base
   # Gets all assets associated with source through attachments table.
   # @return Array<ActiveRecord::Base>
   def assets
-    attachments.map(&:asset)
+    attachments.map(&:asset).reject{ |a| a.nil? }
   end
 
   ##

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :attachment, class: Attachment do
+    source_id nil
+    asset_id nil
+    asset_type nil
+  end
+end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -68,6 +68,26 @@ describe Source, type: :model do
       it 'returns all attached assets' do
         expect(source.assets).to contain_exactly(video, audio, document, image)
       end
+
+      context 'with nil asset' do
+        let(:attachment) do
+          create(:attachment, source_id: source.id,
+                              asset_id: video.id,
+                              asset_type: "Video")
+        end
+
+        let(:nil_attachment) do
+          create(:attachment, source_id: source.id,
+                              asset_id: 'invalid_id',
+                              asset_type: "Video")
+        end
+
+        it 'does not return nil asset' do
+          allow(source).to receive(:attachments)
+            .and_return([attachment, nil_attachment])
+          expect(source.assets).to contain_exactly(video)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This ensures that `Source#assets` does not return any `nil` values.  `nil` values may occur if someone deletes an asset (an `Image`, `Document`, `Video`, or `Audio`) without deleting its association to a `Source`, as expressed in the `attachments` table.  There are validations in place to dependent-destroy these associations, but this in an extra precaution that will catch any mistakes that have occurred or could occur in the future.

This addresses [task #8167](https://issues.dp.la/issues/8167). 