### PR TITLE
Allow admins to designate and view unpublished sets

### DIFF
--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -8,7 +8,8 @@ class SourceSetsController < ApplicationController
   before_action :authenticate_admin!, only: [:new, :edit]
 
   def index
-    @source_sets = SourceSet.all
+    @published_sets = SourceSet.published_sets
+    @unpublished_sets = SourceSet.unpublished_sets
   end
 
   def show
@@ -58,6 +59,7 @@ class SourceSetsController < ApplicationController
                                        :description,
                                        :overview,
                                        :resources,
+                                       :published,
                                        author_ids: [])
   end
 end

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -20,4 +20,12 @@ class SourceSet < ActiveRecord::Base
   def featured_image
     small_images.first
   end
+
+  def self.published_sets
+    self.where(published: true)
+  end
+
+  def self.unpublished_sets
+    self.where(published: false)
+  end
 end

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -21,6 +21,11 @@
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
+
+  <p>
+    <strong><%= f.label :published, style: 'display:inline' %></strong>
+    <%= f.check_box :published %><br />
+  </p>
  
   <p>
     <strong><%= f.label 'SEO description' %></strong><br/>

--- a/app/views/source_sets/_set_list.html.erb
+++ b/app/views/source_sets/_set_list.html.erb
@@ -1,0 +1,19 @@
+<div class='set-list'>
+  <%= sets.order('created_at ASC').each_slice(3) do |sets_row| %>
+    <div class='moduleContainer threeCol'>
+      <% sets_row.each_with_index do |set, i| %>
+        <section class='module'>
+          <% if set.featured_image.present? %>
+            <%= link_to((image_tag base_src + set.featured_image.file_name,
+                                   alt: set.featured_image.alt_text.present? ? 
+                                     set.featured_image.alt_text : set.name),
+                        source_set_path(set)) %>
+          <% end %>
+          <div class='set-name-container'>
+            <%= link_to inline_markdown(set.name), source_set_path(set) %>
+          </div>
+        </section>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -13,25 +13,8 @@
 
   <p>DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources. Each set includes an overview, ten to fifteen primary sources, links to related resources, and a teaching guide. These sets were created and reviewed by the teachers on the DPLA's <%= link_to 'Education Advisory Committee', wordpress_path('education/education-advisory-committee') %>. We will be adding new sets and features through Spring 2016. Read about our <%= link_to 'education projects', wordpress_path('education') %> and contact us with feedback at <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
 
-  <div class='set-list'>
-    <%= @source_sets.order('created_at ASC').each_slice(3) do |sets_row| %>
-      <div class='moduleContainer threeCol'>
-        <% sets_row.each_with_index do |set, i| %>
-          <section class='module'>
-            <% if set.featured_image.present? %>
-              <%= link_to((image_tag base_src + set.featured_image.file_name,
-                                     alt: set.featured_image.alt_text.present? ? 
-                                       set.featured_image.alt_text : set.name),
-                          source_set_path(set)) %>
-            <% end %>
-            <div class='set-name-container'>
-              <%= link_to inline_markdown(set.name), source_set_path(set) %>
-            </div>
-          </section>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
+  <%= render partial: 'source_sets/set_list',
+             locals: { sets: @published_sets } %>
 
   <div class='contact-outer-container'>
     <p>Send feedback about these primary source sets or our other educational resources to <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
@@ -44,5 +27,10 @@
   <h2>Admin Info</h2>
 
   <p><%= link_to "Create new set", new_source_set_path %></p>
+
+  <h3>Unpublished sets</h3>
+
+  <%= render partial: 'source_sets/set_list',
+             locals: { sets: @unpublished_sets } %>
 
 <% end %>

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe SourceSetsController, type: :controller do
 
   let(:resource) { create(:source_set_factory) }
+  let(:published) { create(:source_set_factory, published: true)}
   let(:attributes) { attributes_for(:source_set_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_source_set_factory) }
 
@@ -11,8 +12,24 @@ describe SourceSetsController, type: :controller do
   context 'admin logged in' do
     login_admin
 
-    it_behaves_like 'basic controller', :index, :show, :create, :update,
-                                        :destroy
+    it_behaves_like 'basic controller', :show, :create, :update, :destroy
     it_behaves_like 'redirecting controller', :create
+
+    describe '#index' do
+      it 'sets @published_sets variable' do
+        get :index
+        expect(assigns(:published_sets)).to eq([published])
+      end
+
+      it 'sets @unpublished_sets variable' do
+        get :index
+        expect(assigns(:unpublished_sets)).to eq([resource])
+      end
+
+      it 'renders the :index view' do
+        get :index
+        expect(response).to render_template :index
+      end
+    end
   end
 end

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe SourceSet, type: :model do
 
   let(:source_set) { create(:source_set_factory) }
+  let(:published_set) { create(:source_set_factory, published: true) }
 
   it 'has many sources' do
     expect(SourceSet.reflect_on_association(:sources).macro).to eq :has_many
@@ -49,6 +50,18 @@ describe SourceSet, type: :model do
 
     it 'recognizes a featured image' do
       expect(source_set.featured_image).to eq small_image
+    end
+  end
+
+  describe '#published_sets' do
+    it 'returns published sets' do
+      expect(SourceSet.published_sets).to contain_exactly(published_set)
+    end
+  end
+
+  describe '#unpublished_sets' do
+    it 'returns unpublished sets' do
+      expect(SourceSet.unpublished_sets).to contain_exactly(source_set)
     end
   end
 end

--- a/spec/views/source_sets/index.html.erb_spec.rb
+++ b/spec/views/source_sets/index.html.erb_spec.rb
@@ -4,13 +4,18 @@ describe 'source_sets/index.html.erb', type: :view do
 
   before do
     create(:source_set_factory, name: 'Moomin')
-    create(:source_set_factory, name: 'Snorkmaiden')
-    assign(:source_sets, SourceSet.all)
+    create(:source_set_factory, name: 'Snorkmaiden', published: true)
+    assign(:published_sets, SourceSet.published_sets)
+    assign(:unpublished_sets, SourceSet.unpublished_sets)
   end
 
-  it 'renders each source set' do
+  it 'renders each published source set' do
     render
-    expect(rendered).to include('Moomin')
     expect(rendered).to include('Snorkmaiden')
+  end
+
+  it 'does not render unpublished source sets' do
+    render
+    expect(rendered).not_to include('Moomin')
   end
 end


### PR DESCRIPTION
This allows admins to assert whether or not `source_sets` are "published".  Published sets are visible to all users from `source_sets#index`; unpublished sets are visible only to admins.  The `source_sets` table has a column, `published`, that takes a boolean value.  Up to this point, the default has been to set all `source_sets` as `published=true` in the database.

Changes include:
* A place on the `source_sets` form to specify whether a set is "published" or not.
* Model methods that get published and unpublished sets from the database.
* Setting instance variables in the `source_sets#index` controller for `@published_sets` and `@unpublished_sets`.
* Abstracting out a view partial that renders a list of sets, be they published or unpublished.
* Changing the `source_sets#index` view to show unpublished sets only to admins.

This PR purposely leaves all sets visible to all users when accessed directly with the URL.  This will allow members of the EAC to view unpublished sets before we build out the authentication system to create view-only access (see [task #8163](https://issues.dp.la/issues/8163)).

If you view `source_sets#index` in your browser, you will notice that the unpublished sets have a different background color than the sets.  This is intentional.

This addresses [task #8102](https://issues.dp.la/issues/8102).