### PR TITLE
add save button to top of set, source, and guide forms

### DIFF
--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -14,6 +14,8 @@
     </div>
   <% end %>
 
+  <%= f.submit 'Submit', class: 'form-submit' %>
+
   <p>
     <strong><%= f.label "Name (required)" %></strong><br/>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
@@ -39,8 +41,6 @@
     <% end %>
   </p>
 
-  <p>
-    <%= f.submit 'Submit', class: 'form-submit' %>
-  </p>
+  <%= f.submit 'Submit', class: 'form-submit' %>
 
 <% end %>

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_for @source_set do |f| %>
- 
+
   <% if @source_set.errors.any? %>
     <div id="error_explanation">
       <h2>
@@ -13,6 +13,8 @@
       </ul>
     </div>
   <% end %>
+
+  <%= f.submit 'Submit', class: 'form-submit' %>
  
   <p>
     <strong><%= f.label "Name (required)" %></strong><br/>
@@ -45,8 +47,6 @@
     <% end %>
   </p>
  
-  <p>
-    <%= f.submit 'Submit', class: 'form-submit' %>
-  </p>
+  <%= f.submit 'Submit', class: 'form-submit' %>
  
 <% end %>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -14,6 +14,8 @@
     </div>
   <% end %>
 
+  <%= f.submit 'Submit', class: 'form-submit' %>
+
   <p>
     <strong><%= f.label "DPLA id (required)" %></strong><br/>
     <em>Example: ebc07432a6ba4f864daaddc4ad0a68f9</em><br/>
@@ -89,8 +91,6 @@
     <%= b.label { b.check_box(class: "small_image_check_box") + b.text } %><br />
   <% end %>
 
-  <p>
-    <%= f.submit 'Submit', class: 'form-submit' %>
-  </p>
+  <%= f.submit 'Submit', class: 'form-submit' %>
 
 <% end %>


### PR DESCRIPTION
This adds "submit" buttons to the tops of data entry forms for `source_sets`, `guides`, and `sources`.  When tested locally, these buttons work as expected.

This addresses [ticket #8101](https://issues.dp.la/issues/8101).