### PR TITLE
reduce whitespace below guide byline

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -121,7 +121,11 @@
 
 /* Guide styles */
 
-.guide .textual-content, .guide .questions, .guide .activity {
+.guide .textual-content {
+  margin-top: 1.5em;
+}
+
+.guide .questions, .guide .activity {
   margin-top: 3em;
 }
 


### PR DESCRIPTION
Reduce the whitespace on `guides`, below the byline and above the `.textual-content` block.  This addresses [note #6 in task #8150](https://issues.dp.la/issues/8150#note-6).  I tested it locally, and also showed it Franky for approval.