### PR TITLE
clean up global variables

### DIFF
--- a/spec/javascripts/av_upload_handler_spec.js
+++ b/spec/javascripts/av_upload_handler_spec.js
@@ -1,17 +1,22 @@
 
 describe("AVUploadHandler", function() {
+    var a;
 
     beforeEach(function() {
         a = new AVUploadHandler();
         spyOn(a, 'postAssetRecord').and.stub();
-        html = '<script>var pss_asset_type = "video";</script>' +
-               '<form></form>';
+        var html = '<form></form>';
+        pss_asset_type = 'video'; //global var set in view
         setFixtures(html);
+    });
+
+    afterEach(function() {
+        delete pss_asset_type; //clean up
     });
 
     it("Generates AJAX POST data with path prefix and alphabetic extension",
         function() {
-            good_data = {video: {file_base: 'a', key: 'video/a.a'}};
+            var good_data = {video: {file_base: 'a', key: 'video/a.a'}};
             a.createAssetRecord('video/a.a');
             expect(a.postAssetRecord).toHaveBeenCalledWith(good_data);
         }
@@ -19,7 +24,7 @@ describe("AVUploadHandler", function() {
 
     it("Generates AJAX POST data with alphnumeric file extension",
         function() {
-            good_data = {video: {file_base: 'a', key: 'video/a.mp4'}};
+            var good_data = {video: {file_base: 'a', key: 'video/a.mp4'}};
             a.createAssetRecord('video/a.mp4');
             expect(a.postAssetRecord).toHaveBeenCalledWith(good_data);
         }

--- a/spec/javascripts/doc_upload_handler_spec.js
+++ b/spec/javascripts/doc_upload_handler_spec.js
@@ -1,17 +1,22 @@
 
 describe("DocUploadHandler", function() {
+    var duh;
 
     beforeEach(function() {
         duh = new DocUploadHandler();
         spyOn(duh, 'postAssetRecord').and.stub();
-        html = '<script>var pss_asset_type = "document";</script>' +
-               '<form></form>';
+        var html = '<form></form>';
+        pss_asset_type = 'document'; //global var set in view
         setFixtures(html);
+    });
+
+    afterEach(function() {
+        delete pss_asset_type; //clean up
     });
 
     it("Generates AJAX POST data with the file name",
         function() {
-            good_data = {document: {file_name: 'a.pdf'}};
+            var good_data = {document: {file_name: 'a.pdf'}};
             duh.createAssetRecord('a.pdf');
             expect(duh.postAssetRecord).toHaveBeenCalledWith(good_data);
         }

--- a/spec/javascripts/image_upload_handler_spec.js
+++ b/spec/javascripts/image_upload_handler_spec.js
@@ -1,17 +1,22 @@
 
 describe("ImageUploadHandler", function() {
+    var iuh;
 
     beforeEach(function() {
         iuh = new ImageUploadHandler();
         spyOn(iuh, 'postAssetRecord').and.stub();
-        html = '<script>var pss_asset_type = "image";</script>' +
-               '<form></form>';
+        var html = '<form></form>';
+        pss_asset_type = 'image'; //global var set in the view
         setFixtures(html);
+    });
+
+    afterEach(function() {
+        delete pss_asset_type;  //clean up
     });
 
     it("Generates AJAX POST data with the file name",
         function() {
-            good_data = {
+            var good_data = {
                 image: {
                     file_name: 'a.jpg',
                     size: undefined,
@@ -27,7 +32,7 @@ describe("ImageUploadHandler", function() {
 
     it("Generates AJAX POST data with the image size",
         function() {
-            good_data = {
+            var good_data = {
                 image: {
                     file_name: 'a.jpg',
                     size: 'small',
@@ -36,7 +41,7 @@ describe("ImageUploadHandler", function() {
                     alt_text: undefined
                 }
             };
-            html =
+            var html =
                 '<input name="image[size]" type="radio" value="large">' +
                 '<input name="image[size]" type="radio" value="small" checked>';
             appendSetFixtures(html);
@@ -47,7 +52,7 @@ describe("ImageUploadHandler", function() {
 
     it("Generates AJAX POST data with width and height",
         function() {
-            good_data = {
+            var good_data = {
                 image: {
                     file_name: 'a.jpg',
                     size: undefined,
@@ -56,7 +61,7 @@ describe("ImageUploadHandler", function() {
                     alt_text: undefined
                 }
             };
-            html =
+            var html =
                '<input name="image[width]" type="text" value="600" />' +
                '<input name="image[height]" type="text" value="400" />';
             appendSetFixtures(html);
@@ -67,7 +72,7 @@ describe("ImageUploadHandler", function() {
 
     it("Generates AJAX POST data with alt text",
         function() {
-            good_data = {
+            var good_data = {
                 image: {
                     file_name: 'a.jpg',
                     size: undefined,
@@ -76,7 +81,7 @@ describe("ImageUploadHandler", function() {
                     alt_text: 'x'
                 }
             };
-            html =
+            var html =
                '<input name="image[alt_text]" type="text" value="x" />';
             appendSetFixtures(html);
             iuh.createAssetRecord('a.jpg');

--- a/spec/javascripts/upload_handler_spec.js
+++ b/spec/javascripts/upload_handler_spec.js
@@ -1,5 +1,6 @@
 
 describe("UploadHandler", function() {
+    var u;
 
     it("Initializes with #upload-form", function() {
         var html = '<form id="upload-form"></form>';


### PR DESCRIPTION
This cleans up the use of global and Fixture variables and in the jasmine tests.

In this app, some JavaScript variables are set in views (ie. `pss_asset_type`).  Before, these variables were simulated in Jasmine tests by adding them to Fixtures with HTML `<script>` tags.  For example:

    <script>var pss_asset_type = "video";</script>

While this accurately replicates the way in which these variables are set the app, the difficulty with this approach is that when Jasmine runs its `cleanUp` function between tests, the JavaScript variables are not cleaned up, so they remain set for _all_ subsequent tests.

This introduces a different approach.  The variables set in views are introduced as global variables for the Jasmine tests .  Since they are global variables, they can be set in Before blocks, accessed by individual tests, and deleted in After blocks (local variables cannot be deleted in JavaScript outside of garbage collection).

This PR also scopes variables that do not need to be global to keep the namespace clean and minimize potential confusion.