### PR TITLE
Allow creation of media assets with specified source.

### DIFF
--- a/app/assets/javascripts/avupload.js
+++ b/app/assets/javascripts/avupload.js
@@ -7,12 +7,16 @@ function AVUploadHandler() { UploadHandler.call(this); }
 AVUploadHandler.prototype = Object.create(UploadHandler.prototype);
 
 
-AVUploadHandler.prototype.createAssetRecord = function(key) {
+AVUploadHandler.prototype.createAssetRecord = function(postdata) {
     // For file basename, get rid of "video/" or "audio/" path part and
     // file extension.
-    file_base = key.replace(/^[a-z]+\/(.*)\.[a-z0-9]+$/i, "$1");
-    postdata = {};
-    postdata[pss_asset_type] = {file_base: file_base, key: key};
+    var key = postdata[pss_asset_type]['file_name'];
+    var file_base = key.replace(/^[a-z]+\/(.*)\.[a-z0-9]+$/i, "$1");
+
+    postdata[pss_asset_type]['file_base'] = file_base;
+    postdata[pss_asset_type]['key'] = key;
+    delete postdata[pss_asset_type]['file_name'];
+
     this.postAssetRecord(postdata);
 };
 

--- a/app/assets/javascripts/docupload.js
+++ b/app/assets/javascripts/docupload.js
@@ -7,9 +7,7 @@ function DocUploadHandler() { UploadHandler.call(this); }
 DocUploadHandler.prototype = Object.create(UploadHandler.prototype);
 
 
-DocUploadHandler.prototype.createAssetRecord = function(key) {
-    postdata = {};
-    postdata[pss_asset_type] = {file_name: key};
+DocUploadHandler.prototype.createAssetRecord = function(postdata) {
     this.postAssetRecord(postdata);
 };
 

--- a/app/assets/javascripts/imgupload.js
+++ b/app/assets/javascripts/imgupload.js
@@ -7,15 +7,12 @@ function ImageUploadHandler() { UploadHandler.call(this); }
 ImageUploadHandler.prototype = Object.create(UploadHandler.prototype);
 
 
-ImageUploadHandler.prototype.createAssetRecord = function(key) {
-    postdata = {};
-    postdata[pss_asset_type] = {
-        file_name: key,
-        size: $('input[name="image[size]"]:checked').val(),
-        width: $('input[name="image[width]"]').val(),
-        height: $('input[name="image[height]"]').val(),
-        alt_text: $('input[name="image[alt_text]"]').val()
-    };
+ImageUploadHandler.prototype.createAssetRecord = function(postdata) {
+    postdata[pss_asset_type]['size'] = $('input[name="image[size]"]:checked').val();
+    postdata[pss_asset_type]['width'] = $('input[name="image[width]"]').val();
+    postdata[pss_asset_type]['height'] = $('input[name="image[height]"]').val();
+    postdata[pss_asset_type]['alt_text'] = $('input[name="image[alt_text]"]').val();
+
     this.postAssetRecord(postdata);
 };
 

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -72,12 +72,31 @@ UploadHandler.prototype.updateProgress = function(e) {
 UploadHandler.prototype.handleResponseIfDone = function(xhr) {
     if (xhr.readyState == 4) {
         if (xhr.status == '201') {
-            key = $('Key', xhr.responseXML).text();
-            this.createAssetRecord(key);
+            var key = $('Key', xhr.responseXML).text();
+            var postdata = this.initializePostdata(key);
+            this.createAssetRecord(postdata);
         } else {
             alert('Got an unexpected response: ' + xhr.statusText);
         }
     }
+};
+
+
+UploadHandler.prototype.initializePostdata = function(key) {
+    var postdata = {};
+    postdata[pss_asset_type] = {file_name: key};
+
+    if (typeof source_id !== 'undefined' && source_id !== null) {
+        /* 
+         * source_id is defined in the view.
+         *
+         * Note plural key name with singular value; this is necessary to work
+         * with the Rails model and its associations 'magic'.
+         */
+        postdata[pss_asset_type].source_ids = source_id;
+    }
+
+    return postdata;
 };
 
 

--- a/app/controllers/audios_controller.rb
+++ b/app/controllers/audios_controller.rb
@@ -20,6 +20,7 @@ class AudiosController < ApplicationController
     @formdef = PSSBrowserUploads.av_form_definition('audio')
     @accepted_types = %w(.mp3 .mp2 .mp4a .wav .flac .aif .aiff .wma .mpga .oga
                          .ogg .au .adp .aac .weba).join(',')
+    @source = Source.find_by_id(params[:source_id])
   end
 
   ##
@@ -53,7 +54,11 @@ class AudiosController < ApplicationController
   private
 
   def audio_params
-    params.require(:audio).permit(:file_base,
-                                  source_ids: [])
+    ##
+    # Note that :source_ids is expressed as single hash, rather than
+    # "source_ids: []", as seen in other controllers.
+    # The single hash notation is required to work with the JavaScript code
+    # @see: app/javascripts/avupload.js
+    params.require(:audio).permit(:file_base, :source_ids)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -19,6 +19,7 @@ class DocumentsController < ApplicationController
     @formdef.add_field('Content-Type', '')
     @formdef.add_condition('Content-Type', 'starts-with' => '')
     @accepted_types = '.pdf'
+    @source = Source.find_by_id(params[:source_id])
   end
 
   def create
@@ -45,7 +46,11 @@ class DocumentsController < ApplicationController
   private
 
   def document_params
-    params.require(:document).permit(:file_name,
-                                     source_ids: [])
+    ##
+    # Note that :source_ids is expressed as single hash, rather than
+    # "source_ids: []", as seen in other controllers.
+    # The single hash notation is required to work with the JavaScript code
+    # @see: app/javascripts/avupload.js
+    params.require(:document).permit(:file_name, :source_ids)
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -19,6 +19,7 @@ class ImagesController < ApplicationController
     @formdef.add_field('Content-Type', '')
     @formdef.add_condition('Content-Type', 'starts-with' => '')
     @accepted_types = %w(.jpg .jpeg .png .gif).join(',')
+    @source = Source.find_by_id(params[:source_id])
   end
 
   def create
@@ -46,11 +47,16 @@ class ImagesController < ApplicationController
   private
 
   def image_params
+    ##
+    # Note that :source_ids is expressed as single hash, rather than
+    # "source_ids: []", as seen in other controllers.
+    # The single hash notation is required to work with the JavaScript code
+    # @see: app/javascripts/avupload.js
     params.require(:image).permit(:file_name,
                                   :size,
                                   :height,
                                   :width,
                                   :alt_text,
-                                  source_ids: [])
+                                  :source_ids)
   end
 end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -30,6 +30,7 @@ class VideosController < ApplicationController
     @accepted_types = %w(.mov .m4v .mp4 .mpeg .mp1 .3gp .3g2 .avi .f4v .flv
                          .h261 .h263 .h264 .jpm .jpgv .asf .wm .wmv .mj2 .ogv
                          .webm .qt .movie .dv).join(',')
+    @source = Source.find_by_id(params[:source_id])
   end
 
   ##
@@ -63,7 +64,11 @@ class VideosController < ApplicationController
   private
 
   def video_params
-    params.require(:video).permit(:file_base,
-                                  source_ids: [])
+    ##
+    # Note that :source_ids is expressed as single hash, rather than
+    # "source_ids: []", as seen in other controllers.
+    # The single hash notation is required to work with the JavaScript code
+    # @see: app/javascripts/avupload.js
+    params.require(:video).permit(:file_base, :source_ids)
   end
 end

--- a/app/views/audios/new.html.erb
+++ b/app/views/audios/new.html.erb
@@ -3,11 +3,19 @@
   <script>
       var pss_create_asset_path = '<%= audios_path() %>';
       var pss_asset_type = 'audio';
+      var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
 <% end %>
 
 <h1>New audio</h1>
+
+<% if @source.present? %>
+  <p>
+    <strong>This audio will be associated with: </strong>
+    <%= inline_markdown(source_name(@source)) %>
+  </p>
+<% end %>
 
 <%= render "shared/s3form" %>
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -3,11 +3,19 @@
   <script>
       var pss_create_asset_path = '<%= documents_path() %>';
       var pss_asset_type = 'document';
+      var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
 <% end %>
 
 <h1>New PDF Document</h1>
+
+<% if @source.present? %>
+  <p>
+    <strong>This document will be associated with: </strong>
+    <%= inline_markdown(source_name(@source)) %>
+  </p>
+<% end %>
 
 <%= render "shared/s3form" %>
 

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -3,11 +3,19 @@
   <script>
       var pss_create_asset_path = '<%= images_path() %>';
       var pss_asset_type = 'image';
+      var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
 <% end %>
 
 <h1>New Image</h1>
+
+<% if @source.present? %>
+  <p>
+    <strong>This image will be associated with: </strong>
+    <%= inline_markdown(source_name(@source)) %>
+  </p>
+<% end %>
 
 <fieldset>
     <div>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -73,6 +73,16 @@
 
   <h3>Media assets</h2>
 
+  <p>
+    <%= link_to "Add new image", new_image_path(source_id: @source.id) %>
+    |
+    <%= link_to "Add new document", new_document_path(source_id: @source.id) %>
+    |
+    <%= link_to "Add new audio", new_audio_path(source_id: @source.id) %>
+    |
+    <%= link_to "Add new video", new_video_path(source_id: @source.id) %>
+  </p>
+
   <table>
 
     <% if @source.main_asset.present? %>

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -3,11 +3,19 @@
   <script>
       var pss_create_asset_path = '<%= videos_path() %>';
       var pss_asset_type = 'video';
+      var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
 <% end %>
 
 <h1>New video</h1>
+
+<% if @source.present? %>
+  <p>
+    <strong>This video will be associated with: </strong>
+    <%= inline_markdown(source_name(@source)) %>
+  </p>
+<% end %>
 
 <%= render "shared/s3form" %>
 

--- a/spec/controllers/audios_controller_spec.rb
+++ b/spec/controllers/audios_controller_spec.rb
@@ -12,5 +12,6 @@ describe AudiosController, type: :controller do
     login_admin
 
     it_behaves_like 'basic controller', :index, :show
+    it_behaves_like 'media controller', :new, :create
   end
 end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -12,5 +12,6 @@ describe DocumentsController, type: :controller do
     login_admin
 
     it_behaves_like 'basic controller', :index, :show, :create, :destroy
+    it_behaves_like 'media controller', :new, :create
   end
 end

--- a/spec/controllers/images_controller_spec.rb
+++ b/spec/controllers/images_controller_spec.rb
@@ -11,5 +11,6 @@ describe ImagesController, type: :controller do
     login_admin
 
     it_behaves_like 'basic controller', :index, :show, :create, :destroy
+    it_behaves_like 'media controller', :new, :create
   end
 end

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -12,5 +12,6 @@ describe VideosController, type: :controller do
     login_admin
 
     it_behaves_like 'basic controller', :show
+    it_behaves_like 'media controller', :new, :create
   end
 end

--- a/spec/javascripts/av_upload_handler_spec.js
+++ b/spec/javascripts/av_upload_handler_spec.js
@@ -16,18 +16,23 @@ describe("AVUploadHandler", function() {
 
     it("Generates AJAX POST data with path prefix and alphabetic extension",
         function() {
-            var good_data = {video: {file_base: 'a', key: 'video/a.a'}};
-            a.createAssetRecord('video/a.a');
+            var input_data = {video: {file_name: 'video/a.a', source_ids: '4'}}
+            var good_data = {video: {file_base: 'a',
+                                     key: 'video/a.a',
+                                     source_ids: '4'}};
+            a.createAssetRecord(input_data);
             expect(a.postAssetRecord).toHaveBeenCalledWith(good_data);
         }
     );
 
     it("Generates AJAX POST data with alphnumeric file extension",
         function() {
-            var good_data = {video: {file_base: 'a', key: 'video/a.mp4'}};
-            a.createAssetRecord('video/a.mp4');
+            var input_data = {video: {file_name: 'video/a.mp4', source_ids: '4'}}
+            var good_data = {video: {file_base: 'a',
+                                     key: 'video/a.mp4',
+                                     source_ids: '4'}};
+            a.createAssetRecord(input_data);
             expect(a.postAssetRecord).toHaveBeenCalledWith(good_data);
         }
     );
-
 });

--- a/spec/javascripts/doc_upload_handler_spec.js
+++ b/spec/javascripts/doc_upload_handler_spec.js
@@ -14,12 +14,11 @@ describe("DocUploadHandler", function() {
         delete pss_asset_type; //clean up
     });
 
-    it("Generates AJAX POST data with the file name",
+    it("Generates AJAX POST data with the given data",
         function() {
-            var good_data = {document: {file_name: 'a.pdf'}};
-            duh.createAssetRecord('a.pdf');
+            good_data = {document: {file_name: 'x', source_ids: '4'}};
+            duh.createAssetRecord(good_data);
             expect(duh.postAssetRecord).toHaveBeenCalledWith(good_data);
         }
-    );
-
+    ); 
 });

--- a/spec/javascripts/image_upload_handler_spec.js
+++ b/spec/javascripts/image_upload_handler_spec.js
@@ -1,40 +1,26 @@
 
 describe("ImageUploadHandler", function() {
     var iuh;
+    var input_data = {image: {file_name: 'a.jpg', source_ids: '4'}};
 
     beforeEach(function() {
         iuh = new ImageUploadHandler();
         spyOn(iuh, 'postAssetRecord').and.stub();
         var html = '<form></form>';
-        pss_asset_type = 'image'; //global var set in the view
+        pss_asset_type = 'image'; //global var set in view
         setFixtures(html);
     });
 
     afterEach(function() {
-        delete pss_asset_type;  //clean up
+        delete pss_asset_type; //clean up
     });
-
-    it("Generates AJAX POST data with the file name",
-        function() {
-            var good_data = {
-                image: {
-                    file_name: 'a.jpg',
-                    size: undefined,
-                    width: undefined,
-                    height: undefined,
-                    alt_text: undefined
-                }
-            };
-            iuh.createAssetRecord('a.jpg');
-            expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
-        }
-    );
 
     it("Generates AJAX POST data with the image size",
         function() {
             var good_data = {
                 image: {
                     file_name: 'a.jpg',
+                    source_ids: '4',
                     size: 'small',
                     width: undefined,
                     height: undefined,
@@ -45,7 +31,7 @@ describe("ImageUploadHandler", function() {
                 '<input name="image[size]" type="radio" value="large">' +
                 '<input name="image[size]" type="radio" value="small" checked>';
             appendSetFixtures(html);
-            iuh.createAssetRecord('a.jpg');
+            iuh.createAssetRecord(input_data);
             expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
         }
     );
@@ -55,6 +41,7 @@ describe("ImageUploadHandler", function() {
             var good_data = {
                 image: {
                     file_name: 'a.jpg',
+                    source_ids: '4',
                     size: undefined,
                     width: '600',
                     height: '400',
@@ -65,7 +52,7 @@ describe("ImageUploadHandler", function() {
                '<input name="image[width]" type="text" value="600" />' +
                '<input name="image[height]" type="text" value="400" />';
             appendSetFixtures(html);
-            iuh.createAssetRecord('a.jpg');
+            iuh.createAssetRecord(input_data);
             expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
         }
     );
@@ -75,6 +62,7 @@ describe("ImageUploadHandler", function() {
             var good_data = {
                 image: {
                     file_name: 'a.jpg',
+                    source_ids: '4',
                     size: undefined,
                     width: undefined,
                     height: undefined,
@@ -84,9 +72,8 @@ describe("ImageUploadHandler", function() {
             var html =
                '<input name="image[alt_text]" type="text" value="x" />';
             appendSetFixtures(html);
-            iuh.createAssetRecord('a.jpg');
+            iuh.createAssetRecord(input_data);
             expect(iuh.postAssetRecord).toHaveBeenCalledWith(good_data);
         }
     );
-
 });

--- a/spec/javascripts/upload_handler_spec.js
+++ b/spec/javascripts/upload_handler_spec.js
@@ -17,4 +17,34 @@ describe("UploadHandler", function() {
         expect(u.$el('input').attr('name')).toEqual('b');
     });
 
+    describe("#initializePostdata", function() {
+
+        beforeEach(function() {
+            pss_asset_type = 'image'; //global vars set in view
+        });
+
+        afterEach(function() {
+            delete pss_asset_type; //clean up
+        });
+
+        it("Returns an object with asset_type and file_name", function() {
+            good_data = {'image': {file_name: 'a.jpg'}};
+            expect(u.initializePostdata('a.jpg')).toEqual(good_data);
+        });
+
+        describe("#with source_id", function() {
+            beforeEach(function() {
+                source_id = '4'; //global vars set in view
+            });
+
+            afterEach(function() {
+                delete source_id; //clean up
+            });
+
+            it("Returns an object with source_ids", function() {
+                expect(u.initializePostdata('a.jpg').image.source_ids)
+                    .toEqual('4');
+            });
+        });
+    });
 });

--- a/spec/support/shared_examples/media_controller.rb
+++ b/spec/support/shared_examples/media_controller.rb
@@ -1,0 +1,54 @@
+##
+# This has media controller specs for :new, :create
+#
+# @param actions Symbol the actions for this example to test.
+#
+# This assumes the following variable have been defined in the controller spec,
+# or are passed as a block to this example:
+#   :resource
+#   :attributes (:create only)
+#
+shared_examples 'media controller' do |*actions|
+
+  let(:resource_sym) { resource.class.name.downcase.to_sym }
+  let(:source) { create(:source_factory) }
+
+  if actions.include? :create
+    describe '#create' do
+      it 'creates a new resource' do
+        # stub encoding job
+        allow_any_instance_of(ApplicationController)
+          .to receive(:create_transcoding_job)
+
+        expect do
+          post :create, resource_sym => attributes
+        end.to change(resource.class, :count).by(1)
+      end
+
+      context 'with source' do
+        it 'creates a new Attachment association' do
+          attributes[:source_ids] = source.id
+
+          # stub encoding job
+          allow_any_instance_of(ApplicationController)
+            .to receive(:create_transcoding_job)
+
+          expect do
+            post :create, resource_sym => attributes
+          end.to change(Attachment, :count).by(1)
+        end
+      end
+    end
+  end
+
+  if actions.include? :new
+    describe '#new' do
+      context 'with source' do
+        it 'sets @source variable from param' do
+           get :new, source_id: source.id
+           expect(assigns(:source)).to eq source
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows creation of media assets (`image`, `document`, `video`, or `audio`) with a specified `source`. 

Sources and assets have a many-to-many relationship in the database.  Previously, admins could only persist relationships between assets and sources using the form on the `sources#new` view to select existing assets from a menu. This made workflow difficult for admins.

This PR introduces a way to specify which source an asset is associated with upon the asset's creation.  A source can be specified in a `source_id` parameter in the asset's `#new` route.  When the asset is saved, its association with the source is saved as well.

And important particularity of this approach is that _upon creation_, an asset can only be associated with one source (there are other ways to build additional associations after an asset is created).  However, the vast majority of assets are associated with only one source, so this approach should have a big positive impact on admin's workflow.

Changes include:

* In `sources#show`, add links to `asset#new` routes that include the source's id as a parameter.  For example, if you are a logged-in admin on `/sources/4`, when you click on "Add a new image", you will be taken to `/images/new?source_id=4`. 

* Allow the asset controllers to deal appropriately the `source_id` parameters.  For the `#new` method this means instantiating a `Source` object from the `source_id` param and making it accessible to the view.  For the `#create` method, this means permitting the `source_ids` param in a way that works with both the JavaScript and the asset models.

* On the `asset#new` view, set the `source_id` as a JavaScript variable.  This is necessary because JavaScript intercepts the normal form-submit action, and is responsible for sending all relevant data to to the `asset#create` action.  Also on the `asset#new` view, display a message to the user telling them which source the asset will be associated with upon creation.

* Update the JavaScript so that it sends the appropriate `source_id` data to the `asset#create` action.  The name of the function in which JavaScript posts to `asset#create` is `postAssetRecord`.

I have tested this locally in my browser, and it is working as expected.  I have also ensured that all Jasmine tests are passing.