### PR TITLE
admin-only crud interfaces for tag, vocabulary

### DIFF
--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -60,6 +60,7 @@ class SourceSetsController < ApplicationController
                                        :overview,
                                        :resources,
                                        :published,
-                                       author_ids: [])
+                                       author_ids: [],
+                                       tag_ids: [])
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,61 @@
+##
+# Handles HTTP requests for tags
+#
+# @see Tag
+class TagsController < ApplicationController
+  before_action :authenticate_admin!
+
+  def index
+    @tags = Tag.all
+  end
+
+  def show
+    @tag = Tag.friendly.find(params[:id])
+  end
+
+  def new
+    @tag = Tag.new
+    @tag.source_set_ids = [params[:source_set_id]]
+    @tag.vocabulary_ids = [params[:vocabulary_id]]
+  end
+
+  def edit
+    @tag = Tag.friendly.find(params[:id])
+  end
+
+  def create
+    @tag = Tag.new(tag_params)
+
+    if @tag.save
+      redirect_to @tag
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @tag = Tag.friendly.find(params[:id])
+
+    if @tag.update(tag_params)
+      redirect_to @tag
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @tag = Tag.friendly.find(params[:id])
+    @tag.destroy
+
+    redirect_to tags_path
+  end
+
+  private
+
+  def tag_params
+    params.require(:tag).permit(:label,
+                                :uri,
+                                source_set_ids: [],
+                                vocabulary_ids: [])
+  end
+end

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -1,0 +1,56 @@
+##
+# Handles HTTP requests for vocabularies
+#
+# @see Vocabulary
+class VocabulariesController < ApplicationController
+  before_action :authenticate_admin!
+
+  def index
+    @vocabularies = Vocabulary.all
+  end
+
+  def show
+    @vocabulary = Vocabulary.friendly.find(params[:id])
+  end
+
+  def new
+    @vocabulary = Vocabulary.new
+  end
+
+  def edit
+    @vocabulary = Vocabulary.friendly.find(params[:id])
+  end
+
+  def create
+    @vocabulary = Vocabulary.new(vocabulary_params)
+
+    if @vocabulary.save
+      redirect_to @vocabulary
+    else
+      render 'new'
+    end
+  end
+
+  def update
+    @vocabulary = Vocabulary.friendly.find(params[:id])
+
+    if @vocabulary.update(vocabulary_params)
+      redirect_to @vocabulary
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @vocabulary = Vocabulary.friendly.find(params[:id])
+    @vocabulary.destroy
+
+    redirect_to vocabularies_path
+  end
+
+  private
+
+  def vocabulary_params
+    params.require(:vocabulary).permit(:name, tag_ids: [])
+  end
+end

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -5,6 +5,7 @@ class SourceSet < ActiveRecord::Base
   has_one :featured_source, -> { where featured: true }, class_name: 'Source'
   has_many :small_images, through: :featured_source
   has_and_belongs_to_many :authors
+  has_and_belongs_to_many :tags
   validates :name, presence: true
 
   ##

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,16 @@
+class Tag < ActiveRecord::Base
+  extend FriendlyId
+  has_and_belongs_to_many :source_sets
+  has_and_belongs_to_many :vocabularies
+  validates :label, presence: true, uniqueness: true
+
+  ##
+  # FriendlyId generates a human-readable slug to be used in the URL, in place
+  # of the ID.  The slug is automatically generated from the name field.
+  #
+  # Example:
+  #   Tag.create({ name: "Little My" }).slug = "little-my"
+  #   URL:  http://example.com/primary-source-sets/tags/little-my
+  #   To find this object: Tag.friendly.find("little-my")
+  friendly_id :label, use: :slugged
+end

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -1,0 +1,15 @@
+class Vocabulary < ActiveRecord::Base
+  extend FriendlyId
+  has_and_belongs_to_many :tags
+  validates :name, presence: true, uniqueness: true
+
+  ##
+  # FriendlyId generates a human-readable slug to be used in the URL, in place
+  # of the ID.  The slug is automatically generated from the name field.
+  #
+  # Example:
+  #   Vocabulary.create({ name: "Little My" }).slug = "little-my"
+  #   URL:  http://example.com/primary-source-sets/vocabularies/little-my
+  #   To find this object: Vocabulary.friendly.find("little-my")
+  friendly_id :name, use: :slugged
+end

--- a/app/views/shared/_admin_menu.html.erb
+++ b/app/views/shared/_admin_menu.html.erb
@@ -11,6 +11,10 @@
   |
   <%= link_to 'Documents', documents_path %>
   |
+  <%= link_to 'Tags', tags_path %>
+  |
+  <%= link_to 'Vocabularies', vocabularies_path %>
+  |
   <%= link_to 'Log out', destroy_admin_session_path, method: :delete %>
   </ul>
 </div>

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -51,6 +51,13 @@
       <%= b.label { b.check_box + b.text } %><br />
     <% end %>
   </p>
+
+  <p>
+    <strong><%= f.label :tag %></strong><br />
+    <%= f.collection_check_boxes(:tag_ids, Tag.all, :id, :label) do |b| %>
+      <%= b.label { b.check_box + b.text } %><br />
+    <% end %>
+  </p>
  
   <%= f.submit 'Submit', class: 'form-submit' %>
  

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -91,9 +91,20 @@
         <% end %>
       </td>
     </tr>
+    <tr>
+      <td><strong>Tags</strong></td>
+      <td>
+        <% @source_set.tags.each do |tag| %>
+          <%= link_to tag.label, tag_path(tag) %><br/>
+        <% end %>
+      </td>
+    </tr>
   </table>
+
+  <p><%= link_to "Add new tag", new_tag_path(source_set_id: @source_set.id) %></p>
 
   <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
 
   <p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
+
 <% end %>

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -1,0 +1,45 @@
+<%= form_for @tag do |f| %>
+ 
+  <% if @tag.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@tag.errors.count, "error") %> prohibited
+        this tag from being saved:
+      </h2>
+      <ul>
+        <% @tag.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+ 
+  <p>
+    <strong><%= f.label "Label (required)" %></strong><br/>
+    <%= f.text_field :label %>
+  </p>
+
+  <p>
+    <strong><%= f.label :uri %></strong><br/>
+    <%= f.text_field :uri %>
+  </p>
+
+  <p>
+    <strong><%= f.label :vocabularies %></strong><br />
+    <%= f.collection_check_boxes(:vocabulary_ids, Vocabulary.all, :id, :name) do |b| %>
+      <%= b.label { b.check_box + b.text } %><br />
+    <% end %>
+  </p>
+
+  <p>
+    <strong><%= f.label :source_sets %></strong><br />
+    <%= f.collection_check_boxes(:source_set_ids, SourceSet.all, :id, :name) do |b| %>
+      <%= b.label { b.check_box + b.text } %><br />
+    <% end %>
+  </p>
+  
+  <p>
+    <%= f.submit 'Submit', class: 'form-submit' %>
+  </p>
+ 
+<% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Edit tag</h1>
+
+<p>
+  <%= link_to "View", tag_path(@tag) %>
+  |
+  <%= link_to "Delete", tag_path(@tag),
+            method: :delete,
+            data: { confirm: "Are you sure you want to delete this tag?" } %></p>
+ 
+<%= render "form" %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,0 +1,16 @@
+<h1>Tags</h1>
+
+<p><%= link_to "Create new tag", new_tag_path %></p>
+
+<table>
+<% @tags.each do |tag| %>
+  <tr>
+    <td><%= tag.label %></td>
+    <td><%= link_to "View", tag_path(tag) %></td>
+    <td><%= link_to "Edit", edit_tag_path(tag) %></td>
+    <td><%= link_to "Delete", tag_path(tag),
+                              method: :delete,
+                              data: { confirm: "Are you sure you want to delete #{tag.label}?" } %> </td>
+  </tr>
+<% end %>
+</table>

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -1,0 +1,5 @@
+<p><%= link_to "Back to tags", tags_path %></p>
+
+<h1>New tag</h1>
+
+<%= render "form" %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,0 +1,33 @@
+<h1>Tag: <%= @tag.label %></h1>
+
+<p>
+  <%= link_to "Edit", edit_tag_path(@tag) %>
+  |
+  <%= link_to "Delete", tag_path(@tag), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@tag.label}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Label: </strong></td>
+    <td><%= @tag.label %></td>
+  </tr>
+  <tr>
+    <td><strong>URI: </strong></td>
+    <td><%= @tag.uri %></td>
+  </tr>
+</table>
+
+<h2>Vocabularies</h2>
+<ul>
+  <% @tag.vocabularies.each do |vocabulary| %>
+    <li><%= link_to vocabulary.name, vocabulary_path(vocabulary) %></li>
+  <% end %>
+</ul>
+
+<h2>Sets</h2>
+<ul>
+<% @tag.source_sets.each do |source_set| %>
+  <li><%= link_to inline_markdown(source_set.name), source_set_path(source_set) %></li>
+<% end %>
+</ul>

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_for @vocabulary do |f| %>
+ 
+  <% if @vocabulary.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@vocabulary.errors.count, "error") %> prohibited
+        this vocabulary from being saved:
+      </h2>
+      <ul>
+        <% @vocabulary.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+ 
+  <p>
+    <strong><%= f.label "Name (required)" %></strong><br/>
+    <%= f.text_field :name %>
+  </p>
+
+  <p>
+    <strong><%= f.label :tags %></strong><br />
+    <%= f.collection_check_boxes(:tag_ids, Tag.all, :id, :label) do |b| %>
+      <%= b.label { b.check_box + b.text } %><br />
+    <% end %>
+  </p>
+  
+  <p>
+    <%= f.submit 'Submit', class: 'form-submit' %>
+  </p>
+ 
+<% end %>

--- a/app/views/vocabularies/edit.html.erb
+++ b/app/views/vocabularies/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Edit vocabulary</h1>
+
+<p>
+  <%= link_to "View", vocabulary_path(@vocabulary) %>
+  |
+  <%= link_to "Delete", vocabulary_path(@vocabulary),
+            method: :delete,
+            data: { confirm: "Are you sure you want to delete this vocabulary?" } %></p>
+ 
+<%= render "form" %>

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -1,0 +1,16 @@
+<h1>Vocabularies</h1>
+
+<p><%= link_to "Create new vocabulary", new_vocabulary_path %></p>
+
+<table>
+<% @vocabularies.each do |vocabulary| %>
+  <tr>
+    <td><%= vocabulary.name %></td>
+    <td><%= link_to "View", vocabulary_path(vocabulary) %></td>
+    <td><%= link_to "Edit", edit_vocabulary_path(vocabulary) %></td>
+    <td><%= link_to "Delete", vocabulary_path(vocabulary),
+                              method: :delete,
+                              data: { confirm: "Are you sure you want to delete #{vocabulary.name}?" } %> </td>
+  </tr>
+<% end %>
+</table>

--- a/app/views/vocabularies/new.html.erb
+++ b/app/views/vocabularies/new.html.erb
@@ -1,0 +1,5 @@
+<p><%= link_to "Back to vocabularies", vocabularies_path %></p>
+
+<h1>New vocabulary</h1>
+
+<%= render "form" %>

--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -1,0 +1,24 @@
+<h1>Vocabulary: <%= @vocabulary.name %></h1>
+
+<p>
+  <%= link_to "Edit", edit_vocabulary_path(@vocabulary) %>
+  |
+  <%= link_to "Delete", vocabulary_path(@vocabulary), method: :delete,
+               data: { confirm: "Are you sure you want to delete #{@vocabulary.name}?" } %>
+</p>
+
+<table>
+  <tr>
+    <td><strong>Name: </strong></td>
+    <td><%= @vocabulary.name %></td>
+  </tr>
+</table>
+
+<h2>Tags</h2>
+<ul>
+<% @vocabulary.tags.each do |tag| %>
+  <li><%= link_to tag.label, tag_path(tag) %></li>
+<% end %>
+</ul>
+
+<p><%= link_to "Add new tag", new_tag_path(vocabulary_id: @vocabulary.id) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   resources :videos
   resources :video_notifications, only: [:create]
   resources :audio_notifications, only: [:create]
+  resources :tags
+  resources :vocabularies
 
   root 'source_sets#index'
 end

--- a/db/migrate/20151215220058_create_tags.rb
+++ b/db/migrate/20151215220058_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration
+  def change
+    create_table :tags do |t|
+      t.string :label
+      t.string :uri
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151215220205_create_vocabularies.rb
+++ b/db/migrate/20151215220205_create_vocabularies.rb
@@ -1,0 +1,8 @@
+class CreateVocabularies < ActiveRecord::Migration
+  def change
+    create_table :vocabularies do |t|
+      t.string :name
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151215220336_create_source_sets_tags.rb
+++ b/db/migrate/20151215220336_create_source_sets_tags.rb
@@ -1,0 +1,8 @@
+class CreateSourceSetsTags < ActiveRecord::Migration
+  def change
+    create_table :source_sets_tags do |t|
+      t.belongs_to :source_set, index: true
+      t.belongs_to :tag, index: true
+    end
+  end
+end

--- a/db/migrate/20151215220547_create_tags_vocabularies.rb
+++ b/db/migrate/20151215220547_create_tags_vocabularies.rb
@@ -1,0 +1,8 @@
+class CreateTagsVocabularies < ActiveRecord::Migration
+  def change
+    create_table :tags_vocabularies do |t|
+      t.belongs_to :vocabulary, index: true
+      t.belongs_to :tag, index: true
+    end
+  end
+end

--- a/db/migrate/20151216150316_vocabularies_slug.rb
+++ b/db/migrate/20151216150316_vocabularies_slug.rb
@@ -1,0 +1,7 @@
+class VocabulariesSlug < ActiveRecord::Migration
+  def change
+    change_table :vocabularies do |t|
+      t.string :slug, unique: true
+    end
+  end
+end

--- a/db/migrate/20151216150330_tags_slug.rb
+++ b/db/migrate/20151216150330_tags_slug.rb
@@ -1,0 +1,7 @@
+class TagsSlug < ActiveRecord::Migration
+  def change
+    change_table :tags do |t|
+      t.string :slug, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151009203626) do
+ActiveRecord::Schema.define(version: 20151216150330) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -127,6 +127,14 @@ ActiveRecord::Schema.define(version: 20151009203626) do
     t.string   "slug"
   end
 
+  create_table "source_sets_tags", force: true do |t|
+    t.integer "source_set_id"
+    t.integer "tag_id"
+  end
+
+  add_index "source_sets_tags", ["source_set_id"], name: "index_source_sets_tags_on_source_set_id"
+  add_index "source_sets_tags", ["tag_id"], name: "index_source_sets_tags_on_tag_id"
+
   create_table "sources", force: true do |t|
     t.integer  "source_set_id"
     t.string   "name"
@@ -141,6 +149,22 @@ ActiveRecord::Schema.define(version: 20151009203626) do
 
   add_index "sources", ["source_set_id"], name: "index_sources_on_source_set_id"
 
+  create_table "tags", force: true do |t|
+    t.string   "label"
+    t.string   "uri"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string   "slug"
+  end
+
+  create_table "tags_vocabularies", force: true do |t|
+    t.integer "vocabulary_id"
+    t.integer "tag_id"
+  end
+
+  add_index "tags_vocabularies", ["tag_id"], name: "index_tags_vocabularies_on_tag_id"
+  add_index "tags_vocabularies", ["vocabulary_id"], name: "index_tags_vocabularies_on_vocabulary_id"
+
   create_table "videos", force: true do |t|
     t.string   "file_base"
     t.datetime "created_at",      null: false
@@ -150,5 +174,12 @@ ActiveRecord::Schema.define(version: 20151009203626) do
   end
 
   add_index "videos", ["transcoding_job"], name: "index_videos_on_transcoding_job", unique: true
+
+  create_table "vocabularies", force: true do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string   "slug"
+  end
 
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe TagsController, type: :controller do
+  let(:resource) { create(:tag_factory) }
+  let(:attributes) { attributes_for(:tag_factory, label: 'unique label') }
+  let(:invalid_attributes) { attributes_for(:invalid_tag_factory) }
+
+  it_behaves_like 'admin-only route', :index, :show, :edit, :new
+
+  context 'admin logged in' do
+    login_admin
+
+    it_behaves_like 'basic controller', :index, :show, :update, :create,
+                                        :destroy
+
+    describe '#new' do
+      it 'adds source_set_id from param' do
+        source_set = create(:source_set_factory)
+        get :new, source_set_id: source_set.id
+        expect(assigns(:tag).source_set_ids).to contain_exactly(source_set.id)
+      end
+
+      it 'adds vocabulary_id from param' do
+        vocabulary = create(:vocabulary_factory)
+        get :new, vocabulary_id: vocabulary.id
+        expect(assigns(:tag).vocabulary_ids).to contain_exactly(vocabulary.id)
+      end
+    end
+  end
+end

--- a/spec/controllers/vocabularies_controller_spec.rb
+++ b/spec/controllers/vocabularies_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe VocabulariesController, type: :controller do
+  let(:resource) { create(:vocabulary_factory) }
+  let(:attributes) { attributes_for(:vocabulary_factory, name: 'unique name') }
+  let(:invalid_attributes) { attributes_for(:invalid_vocabulary_factory) }
+
+  it_behaves_like 'admin-only route', :index, :show, :edit, :new
+
+  context 'admin logged in' do
+    login_admin
+
+    it_behaves_like 'basic controller', :index, :show, :create, :update,
+                                        :destroy
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :tag_factory, class: Tag do
+    label 'Revolution and the New Nation (1754-1820s)'
+    uri 'http://www.nchs.ucla.edu/history-standards/us-history-content-standards'
+  end
+
+  factory :invalid_tag_factory, class: Tag do
+    label nil
+  end
+end

--- a/spec/factories/vocabularies.rb
+++ b/spec/factories/vocabularies.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :vocabulary_factory, class: Vocabulary do
+    name 'NHS time periods'
+  end
+
+  factory :invalid_vocabulary_factory, class: Vocabulary do
+    name nil
+  end
+end

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -18,6 +18,11 @@ describe SourceSet, type: :model do
       .to eq :has_and_belongs_to_many
   end
 
+  it 'has and belongs to many tags' do
+    expect(SourceSet.reflect_on_association(:tags).macro)
+      .to eq :has_and_belongs_to_many
+  end
+
   it 'has one featured source' do
     expect(SourceSet.reflect_on_association(:featured_source).macro)
       .to eq :has_one

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Tag, type: :model do
+
+  it 'has and belongs to many source sets' do
+    expect(Tag.reflect_on_association(:source_sets).macro)
+      .to eq :has_and_belongs_to_many
+  end
+
+  it 'has and belongs to many vocabularies' do
+    expect(Tag.reflect_on_association(:vocabularies).macro)
+      .to eq :has_and_belongs_to_many
+  end
+
+  it 'is invalid without label' do
+    expect(Tag.new(label: nil)).not_to be_valid
+  end
+
+  it 'is invalid without unique label' do
+    create(:tag_factory, label: 'non-unique-label')
+    expect(Tag.new(label: 'non-unique-label')).not_to be_valid
+  end
+
+  it 'has a slug' do
+    expect(Tag.create(label: 'Little My').slug).to eq 'little-my'
+  end
+end

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Vocabulary, type: :model do
+
+  it 'has and belongs to many tags' do
+    expect(Vocabulary.reflect_on_association(:tags).macro)
+      .to eq :has_and_belongs_to_many
+  end
+
+  it 'is invalid without name' do
+    expect(Vocabulary.new(name: nil)).not_to be_valid
+  end
+
+  it 'is invalid without unique name' do
+    create(:vocabulary_factory, name: 'non-unique-name')
+    expect(Vocabulary.new(name: 'non-unique-name')).not_to be_valid
+  end
+
+  it 'has a slug' do
+    expect(Vocabulary.create(name: 'Little My').slug).to eq 'little-my'
+  end
+end

--- a/spec/views/tags/index.html.erb_spec.rb
+++ b/spec/views/tags/index.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'tags/index.html.erb', type: :view do
+
+  before do
+    assign(:tags, [create(:tag_factory, label: 'Moomin'),
+                   create(:tag_factory, label: 'Snorkmaiden')])
+  end
+
+  it 'renders each tag' do
+    render
+    expect(rendered).to include('Moomin')
+    expect(rendered).to include('Snorkmaiden')
+  end
+end

--- a/spec/views/tags/show.html.erb_spec.rb
+++ b/spec/views/tags/show.html.erb_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'tags/show.html.erb', type: :view do
+  let(:tag) { create(:tag_factory) }
+
+  before { assign(:tag, tag) }
+
+  it 'renders the tag' do
+    render
+    expect(rendered).to include(tag.label)
+  end
+end

--- a/spec/views/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/vocabularies/index.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'vocabularies/index.html.erb', type: :view do
+
+  before do
+    assign(:vocabularies, [create(:vocabulary_factory, name: 'Moomin'),
+                           create(:vocabulary_factory, name: 'Snorkmaiden')])
+  end
+
+  it 'renders each vocabulary' do
+    render
+    expect(rendered).to include('Moomin')
+    expect(rendered).to include('Snorkmaiden')
+  end
+end

--- a/spec/views/vocabularies/show.html.erb_spec.rb
+++ b/spec/views/vocabularies/show.html.erb_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'vocabularies/show.html.erb', type: :view do
+  let(:vocabulary) { create(:vocabulary_factory) }
+
+  before { assign(:vocabulary, vocabulary) }
+
+  it 'renders the vocabulary' do
+    render
+    expect(rendered).to include(vocabulary.name)
+  end
+end


### PR DESCRIPTION
This introduces admin-only CRUD interfaces for `tag` and `vocabulary`.  Using this data in the non-admin UI is out of scope for this PR.

According to the [relational database model](https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Relational+Database+Model), `tags` have many-to-many relationships with both `vocabularies` and `source_sets`.

This follows boilerplate CRUD patterns that have been established elsewhere in the application.  A couple of things to note:

* `Tag` and `Vocabulary` have "friendly" id slugs.

* `Tag` validates the uniqueness of the `label` attribute.  `Vocabulary` validates the uniqueness of the `name` attribute.  This is to avoid duplications, which would be confusing to an admin user.

* The `tag#new` controller accepts params for `source_set_id` and `vocabulary_id`.  This is to support admin workflows.  From `source_set#show`, an admin can click "Add new tag" and be taken to a `new` `tag` form that has pre-set the association between the `source_set` and the new `tag`.  Ditto if an admin starts from `vocabulary#show`.

This addresses [ticket #8103](https://issues.dp.la/issues/8103).