### PR TITLE
persist year attribute for source_sets

### DIFF
--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -60,6 +60,7 @@ class SourceSetsController < ApplicationController
                                        :overview,
                                        :resources,
                                        :published,
+                                       :year,
                                        author_ids: [],
                                        tag_ids: [])
   end

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -7,6 +7,8 @@ class SourceSet < ActiveRecord::Base
   has_and_belongs_to_many :authors
   has_and_belongs_to_many :tags
   validates :name, presence: true
+  validates_numericality_of :year, only_integer: true, allow_nil: true,
+                                   less_than_or_equal_to: Date.today.year
 
   ##
   # FriendlyId generates a human-readable slug to be used in the URL, in place

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -26,6 +26,13 @@
     <strong><%= f.label :published, style: 'display:inline' %></strong>
     <%= f.check_box :published %><br />
   </p>
+
+  <p>
+    <strong><%= f.label :year %></strong>
+    <em>The year will be used for sorting; it will not be displayed to the user.<br/> 
+    Enter a numerical value representing a single year, for example '1924'. Use negative numbers to represent BCE, for example '-331'.</em><br/>
+    <%= f.text_field :year %>
+  </p>
  
   <p>
     <strong><%= f.label 'SEO description' %></strong><br/>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -84,6 +84,10 @@
       <td><%= @source_set.published %></td>
     </tr>
     <tr>
+      <td><strong>Year </strong></td>
+      <td><%= @source_set.year %></td>
+    </tr>
+    <tr>
       <td><strong>Featured image </strong></td>
       <td>
         <% if @source_set.featured_image.present? %>

--- a/db/migrate/20151221141547_add_year_to_source_set.rb
+++ b/db/migrate/20151221141547_add_year_to_source_set.rb
@@ -1,0 +1,5 @@
+class AddYearToSourceSet < ActiveRecord::Migration
+  def change
+    add_column :source_sets, :year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151216150330) do
+ActiveRecord::Schema.define(version: 20151221141547) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 20151216150330) do
     t.datetime "created_at",                                null: false
     t.datetime "updated_at",                                null: false
     t.string   "slug"
+    t.integer  "year"
   end
 
   create_table "source_sets_tags", force: true do |t|

--- a/spec/factories/source_sets.rb
+++ b/spec/factories/source_sets.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     description 'This set uses primary sources to explore Moominvalley.'
     overview 'Moominvalley and its inhabitants are lovely.'
     resources 'Here are some additional resources about Moominvalley.'
+    year 1984
     published false
   end
 

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -36,6 +36,20 @@ describe SourceSet, type: :model do
     expect(SourceSet.create(name: 'Little My').slug).to eq 'little-my'
   end
 
+  it 'validates numericality of year' do
+    expect(SourceSet.create(name: 'Little My', year: 'abc')).not_to be_valid
+  end
+
+  it 'allows year to be nil' do
+    expect(SourceSet.create(name: 'Little My', year: nil)).to be_valid
+  end
+
+  it 'validates year is less than or equal to current year' do
+    next_year = Date.today.year + 1
+    expect(SourceSet.create(name: 'Little My', year: next_year))
+      .not_to be_valid
+  end
+
   context 'with featured source' do
 
     let(:source) do


### PR DESCRIPTION
This persists a `year` attribute for `source_sets`.  It adds a column to the `source_sets` table.  The model validates that `year` is an integer.  It provides an interface for admins to add, view, and edit the `year`.  

This addresses [ticket #8204](https://issues.dp.la/issues/8204).