### PR TITLE
move source_name helper to source model

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,5 @@
 module ApplicationHelper
 
-  def source_name(source)
-    source.name.present? ? source.name : source.aggregation
-  end
-
   ##
   # Returns frontend path with correctly joining '/'
   # @param path String (with or without leading slash)

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -59,4 +59,8 @@ class Source < ActiveRecord::Base
   def small_image
     small_images.first
   end
+
+  def display_name
+    name.present? ? name : aggregation
+  end
 end

--- a/app/views/audios/new.html.erb
+++ b/app/views/audios/new.html.erb
@@ -13,7 +13,7 @@
 <% if @source.present? %>
   <p>
     <strong>This audio will be associated with: </strong>
-    <%= inline_markdown(source_name(@source)) %>
+    <%= inline_markdown(@source.display_name) %>
   </p>
 <% end %>
 

--- a/app/views/audios/show.html.erb
+++ b/app/views/audios/show.html.erb
@@ -16,7 +16,7 @@
 <h2>Sources</h2>
 <ul>
 <% @audio.sources.each do |source| %>
-  <li><%= link_to inline_markdown(source_name(source)), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
+  <li><%= link_to inline_markdown(source.display_name), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
 <% end %>
 </ul>
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -13,7 +13,7 @@
 <% if @source.present? %>
   <p>
     <strong>This document will be associated with: </strong>
-    <%= inline_markdown(source_name(@source)) %>
+    <%= inline_markdown(@source.display_name) %>
   </p>
 <% end %>
 

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -18,6 +18,6 @@
 <h2>Sources</h2>
 <ul>
 <% @document.sources.each do |source| %>
-  <li><%= link_to inline_markdown(source_name(source)), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
+  <li><%= link_to inline_markdown(source.display_name), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
 <% end %>
 </ul>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -13,7 +13,7 @@
 <% if @source.present? %>
   <p>
     <strong>This image will be associated with: </strong>
-    <%= inline_markdown(source_name(@source)) %>
+    <%= inline_markdown(@source.display_name) %>
   </p>
 <% end %>
 

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -42,7 +42,7 @@
 <h2>Sources</h2>
 <ul>
 <% @image.sources.each do |source| %>
-  <li><%= link_to inline_markdown(source_name(source)), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
+  <li><%= link_to inline_markdown(source.display_name), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
 <% end %>
 </ul>
 

--- a/app/views/source_sets/_source_list.html.erb
+++ b/app/views/source_sets/_source_list.html.erb
@@ -15,7 +15,7 @@
                 <% end %>
               </div>
               <div class='source-name-container'>
-                <%= link_to inline_markdown(source_name(source)),
+                <%= link_to inline_markdown(source.display_name),
                             source_path(source) %>
               </div>
             </div>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -21,7 +21,7 @@
 </div>
 
 <div class='source'>
-  <h1><%= inline_markdown(source_name(@source)) %></h1>
+  <h1><%= inline_markdown(@source.display_name) %></h1>
 
   <%= render_media_asset %>
 

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -13,7 +13,7 @@
 <% if @source.present? %>
   <p>
     <strong>This video will be associated with: </strong>
-    <%= inline_markdown(source_name(@source)) %>
+    <%= inline_markdown(@source.display_name) %>
   </p>
 <% end %>
 

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -16,7 +16,7 @@
 <h2>Sources</h2>
 <ul>
 <% @video.sources.each do |source| %>
-  <li><%= link_to inline_markdown(source_name(source)), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
+  <li><%= link_to inline_markdown(source.display_name), source_path(source) %>, <%= link_to inline_markdown(source.source_set.name), source_set_path(source.source_set) %></li>
 <% end %>
 </ul>
 

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -132,5 +132,18 @@ describe Source, type: :model do
         expect(source.small_image).to eq small_image
       end
     end
+
+    describe '#display_name' do
+      it 'returns name' do
+        expect(source.display_name).to eq source.name
+      end
+
+      context 'no name' do
+        it 'returns aggregation' do
+          nameless_source = create(:source_factory, name: nil)
+          expect(nameless_source.display_name).to eq nameless_source.aggregation
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This moves a helper method into a model.  The helper method was `source_name`.  It returned a `source`'s `name` if present; if not, it returned its `aggregation`.  This functionality makes more sense as an instance method of the `Source` model, so I moved it, renamed it `display_name`, and wrote a test.  I also changed the associated views and checked them all locally.

This addresses [ticket #8202](https://issues.dp.la/issues/8202).