### PR TITLE
move author list from helper to model concern

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,16 +54,4 @@ module ApplicationHelper
       image_name
     end
   end
-
-  ##
-  # Get all the authors for an object with related authors
-  # @param Guide or SourceSet
-  # @return Array
-  def authors(authored)
-    return unless authored.present?
-    authored.authors.map do |author|
-      author.affiliation.present? ? author.name + ', ' + author.affiliation :
-        author.name
-    end
-  end
 end

--- a/app/models/concerns/authored.rb
+++ b/app/models/concerns/authored.rb
@@ -1,0 +1,19 @@
+##
+# Functionality for a Model with related authors
+module Authored
+  extend ActiveSupport::Concern
+
+  included do
+    has_and_belongs_to_many :authors
+  end
+
+  ##
+  # Get all the authors related to the Model with their affiliations
+  # @return Array[String]
+  def author_list
+    authors.map do |author|
+      author.affiliation.present? ? author.name + ', ' + author.affiliation :
+        author.name
+    end
+  end
+end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,7 +1,7 @@
 class Guide < ActiveRecord::Base
   extend FriendlyId
+  include Authored
   belongs_to :source_set
-  has_and_belongs_to_many :authors
   validates :name, presence: true
   ##
   # FriendlyId generates a human-readable slug to be used in the URL, in place

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -1,10 +1,10 @@
 class SourceSet < ActiveRecord::Base
   extend FriendlyId
+  include Authored
   has_many :sources, dependent: :destroy
   has_many :guides, dependent: :destroy
   has_one :featured_source, -> { where featured: true }, class_name: 'Source'
   has_many :small_images, through: :featured_source
-  has_and_belongs_to_many :authors
   has_and_belongs_to_many :tags
   validates :name, presence: true
   validates_numericality_of :year, only_integer: true, allow_nil: true,

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -23,7 +23,7 @@
       <div class='title-inner-container'>
         <h1><%= inline_markdown(@guide.name) %></h1>
         <% if @guide.authors.present? %>
-          <span class='byline'>By <%= authors(@guide).join(' and ') %></span>
+          <span class='byline'>By <%= @guide.author_list.to_sentence %></span>
         <% end %>
       </div>
     </div>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -24,7 +24,7 @@
         <h1><%= inline_markdown(@source_set.name) %></h1>
         <span class='subheading'>Primary Source Set</span>
         <% if @source_set.authors.present? %>
-          <span class='byline'>By <%= authors(@source_set).join(' and ') %></span>
+          <span class='byline'>By <%= @source_set.author_list.to_sentence %></span>
         <% end %>
       </div>
     </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -86,13 +86,4 @@ describe ApplicationHelper, type: :helper do
       expect(helper.base_src).to eq 'something-example.com/'
     end
   end
-
-  describe '#authors' do
-    it 'returns Array of authors with affilations' do
-      guide = create(:guide_factory)
-      guide.authors << [create(:author_factory, name: 'x', affiliation: 'y'),
-                        create(:author_factory, name: 'z', affiliation: nil)]
-      expect(helper.authors(guide)).to include('x, y', 'z')
-    end
-  end
 end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -2,13 +2,12 @@ require 'rails_helper'
 
 describe Guide, type: :model do
 
-  it 'belong to a source set' do
-    expect(Guide.reflect_on_association(:source_set).macro).to eq :belongs_to
+  it_behaves_like 'authored' do
+    let(:resource) { create(:guide_factory) }
   end
 
-  it 'has and belongs to many authors' do
-    expect(Guide.reflect_on_association(:authors).macro)
-      .to eq :has_and_belongs_to_many
+  it 'belong to a source set' do
+    expect(Guide.reflect_on_association(:source_set).macro).to eq :belongs_to
   end
 
   it 'is invalid without name' do

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -5,17 +5,16 @@ describe SourceSet, type: :model do
   let(:source_set) { create(:source_set_factory) }
   let(:published_set) { create(:source_set_factory, published: true) }
 
+  it_behaves_like 'authored' do
+    let(:resource) { source_set }
+  end
+
   it 'has many sources' do
     expect(SourceSet.reflect_on_association(:sources).macro).to eq :has_many
   end
 
   it 'has many guides' do
     expect(SourceSet.reflect_on_association(:guides).macro).to eq :has_many
-  end
-
-  it 'has and belongs to many authors' do
-    expect(SourceSet.reflect_on_association(:authors).macro)
-      .to eq :has_and_belongs_to_many
   end
 
   it 'has and belongs to many tags' do

--- a/spec/support/shared_examples/authored.rb
+++ b/spec/support/shared_examples/authored.rb
@@ -1,0 +1,21 @@
+##
+# Tests for models that include the Authored concern.
+#
+# This assumes the following variable have been defined in the controller spec,
+# or are passed as a block to this example:
+#   :resource
+shared_examples 'authored' do
+
+  it 'has and belongs to many authors' do
+    expect(described_class.reflect_on_association(:authors).macro)
+      .to eq :has_and_belongs_to_many
+  end
+
+  describe '#author_list' do
+    it 'returns Array of authors with affilations' do
+      resource.authors << [create(:author_factory, name: 'x', affiliation: 'y'),
+                           create(:author_factory, name: 'z', affiliation: nil)]
+      expect(resource.author_list).to include('x, y', 'z')
+    end
+  end
+end


### PR DESCRIPTION
This refactors existing code by introducing a concern module for models with associated authors.  Functionality is factored out of the `ApplicationHelper` and the `Source` and `Guide` models.

This addresses [ticket #8202](https://issues.dp.la/issues/8202).