### PR TITLE
publish all existing sets

### DIFF
--- a/db/migrate/20151221210743_publish_existing_sets.rb
+++ b/db/migrate/20151221210743_publish_existing_sets.rb
@@ -1,0 +1,5 @@
+class PublishExistingSets < ActiveRecord::Migration
+  def self.up
+    SourceSet.update_all(published: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151221141547) do
+ActiveRecord::Schema.define(version: 20151221210743) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false


### PR DESCRIPTION
This sets the value of the `published` attribute for all existing `source_sets` to `true`.  We are about to deploy code to the production server that adds the `published` column to the `source_sets` table.  In order to ensure that all existing `source_sets` in production remain visible to the end user, we need to publish them all (unpublished sets are hidden from the end user).  This could be done from the rails console in the production server, but doing it as a migration will prevent both human error and "downtime" for the sets.

I tested this locally and it executed as expected.