### PR TITLE
style form inputs and text areas

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -205,7 +205,25 @@ input.form-submit {
   padding: 2px;
 }
 
-textarea {
-  height: 300px;
+.pss-admin-form input, #upload-form input.form-submit {
+  border: 1px solid grey;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.pss-admin-form input.form-submit, #upload-form input.form-submit {
+  background-color: #E6A425;
+}
+
+.pss-admin-form textarea {
+  height: 100px;
   width: 99%;
+}
+
+.primary-source-sets fieldset {
+  border: none;
+}
+
+#source_set_year {
+  width: 4em;
 }

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @author do |f| %>
+<%= form_for @author, html: { class: 'pss-admin-form' } do |f| %>
  
   <% if @author.errors.any? %>
     <div id="error_explanation">

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [@source_set, @guide] do |f| %>
+<%= form_for [@source_set, @guide], html: { class: 'pss-admin-form' } do |f| %>
 
   <% if @guide.errors.any? %>
     <div id="error_explanation">

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -17,7 +17,7 @@
   </p>
 <% end %>
 
-<fieldset>
+<fieldset class='pss-admin-form'>
     <div>
         <input type="radio" name="image[size]" value="large" checked>large</input>
         <input type="radio" name="image[size]" value="small">small</input>

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @source_set do |f| %>
+<%= form_for @source_set, html: { class: 'pss-admin-form' } do |f| %>
 
   <% if @source_set.errors.any? %>
     <div id="error_explanation">

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [@source_set, @source] do |f| %>
+<%= form_for [@source_set, @source], html: { class: 'pss-admin-form' } do |f| %>
 
   <% if @source.errors.any? %>
     <div id="error_explanation">

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @tag do |f| %>
+<%= form_for @tag, html: { class: 'pss-admin-form' } do |f| %>
  
   <% if @tag.errors.any? %>
     <div id="error_explanation">
@@ -13,6 +13,10 @@
       </ul>
     </div>
   <% end %>
+
+  <p>
+    <%= f.submit 'Submit', class: 'form-submit' %>
+  </p>
  
   <p>
     <strong><%= f.label "Label (required)" %></strong><br/>

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @vocabulary do |f| %>
+<%= form_for @vocabulary, html: { class: 'pss-admin-form' } do |f| %>
  
   <% if @vocabulary.errors.any? %>
     <div id="error_explanation">
@@ -13,6 +13,10 @@
       </ul>
     </div>
   <% end %>
+
+  <p>
+    <%= f.submit 'Submit', class: 'form-submit' %>
+  </p>
  
   <p>
     <strong><%= f.label "Name (required)" %></strong><br/>


### PR DESCRIPTION
This adds a little style to the admin input forms to make page elements more visible, thus making data entry easier.  I added a class name to the admin forms so that they can be distinguished from other forms on the pages, such as the DPLA search box.

This also corrects an oversight in the `tag` and `vocabulary` forms - to be consistent with the other admin forms in the application, they needed "Submit" buttons at the top of the form, as well as the bottom.

I have run the views locally and confirmed that they look as expected.

This addresses [ticket #8206](https://issues.dp.la/issues/8206).