### PR TITLE
fix validation specs for media assets

### DIFF
--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -3,4 +3,9 @@ require 'rails_helper'
 describe Audio, type: :model do
   let(:attributes) { attributes_for(:audio_factory) }
   it_behaves_like 'media asset'
+
+  it 'is invalid without file_base' do
+    attributes[:file_base] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -3,4 +3,9 @@ require 'rails_helper'
 describe Document, type: :model do
   let(:attributes) { attributes_for(:document_factory) }
   it_behaves_like 'media asset'
+
+  it 'is invalid without file_name' do
+    attributes[:file_name] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -20,4 +20,9 @@ describe Image, type: :model do
     attributes[:width] = 'abc'
     expect(described_class.new(attributes)).not_to be_valid
   end
+
+  it 'is invalid without file_name' do
+    attributes[:file_name] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -3,4 +3,9 @@ require 'rails_helper'
 describe Video, type: :model do
   let(:attributes) { attributes_for(:video_factory) }
   it_behaves_like 'media asset'
+
+  it 'is invalid without file_base' do
+    attributes[:file_base] = nil
+    expect(described_class.new(attributes)).not_to be_valid
+  end
 end

--- a/spec/support/shared_examples/media_asset.rb
+++ b/spec/support/shared_examples/media_asset.rb
@@ -18,10 +18,4 @@ shared_examples 'media asset' do
     asset.sources << source
     expect(asset.sources).to eq [source]
   end
-
-  # Fixme: depends on type
-  xit 'is invalid without file_base' do
-    attributes[:file_base] = nil
-    expect(described_class.new(attributes)).not_to be_valid
-  end
 end


### PR DESCRIPTION
This fixes the specs for media assets regarding validations in the models.  With this change, all of our rspec tests are passing, and none are skipped!

This addresses [ticket #8193](https://issues.dp.la/issues/8193).