### PR TITLE
add specs that test if views render

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,6 @@ require File.expand_path('../../config/environment', __FILE__)
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-# Load view files
-Dir["#{File.dirname(__FILE__)}/views/**/*.rb"].each { |f| require f }
-
 RSpec.configure do |config|
   config.color = true
   config.formatter = :progress

--- a/spec/support/shared_examples/renderable_new_media_view.rb
+++ b/spec/support/shared_examples/renderable_new_media_view.rb
@@ -1,0 +1,17 @@
+##
+# This checks that a new media view renders without error.
+# It checks that the s3form partial renders, but stubs out the partial itself.
+shared_examples 'renderable new media view' do
+  it 'renders the view' do
+    expect do
+      stub_template 'shared/_s3form.erb' => 's3form content'
+      render
+    end.not_to raise_error 
+  end
+
+  it 'renders the s3form partial' do
+    stub_template 'shared/_s3form.erb' => 's3form content'
+    render
+    expect(rendered).to include('s3form content')
+  end
+end

--- a/spec/support/shared_examples/renderable_view.rb
+++ b/spec/support/shared_examples/renderable_view.rb
@@ -1,0 +1,7 @@
+##
+# This checks that a view renders without error.
+shared_examples 'renderable view' do
+  it 'renders the view' do
+    expect{ render }.not_to raise_error 
+  end
+end

--- a/spec/views/audios/index.html.erb_spec.rb
+++ b/spec/views/audios/index.html.erb_spec.rb
@@ -7,6 +7,8 @@ describe 'audios/index.html.erb', type: :view do
                      create(:audio_factory, file_base: 'file2')])
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each audio' do
     render
     expect(rendered).to include('file1')

--- a/spec/views/audios/new.html.erb_spec.rb
+++ b/spec/views/audios/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'audios/new.html.erb', type: :view do
+  before(:each) { assign(:audio, build(:audio_factory)) }
+  it_behaves_like 'renderable new media view'
+end

--- a/spec/views/audios/show.html.erb_spec.rb
+++ b/spec/views/audios/show.html.erb_spec.rb
@@ -8,6 +8,8 @@ describe 'audios/show.html.erb', type: :view do
     assign(:audio, audio)
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders the audio' do
     render
     expect(rendered).to include(audio.file_base)

--- a/spec/views/authors/edit.html.erb_spec.rb
+++ b/spec/views/authors/edit.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'authors/edit.html.erb', type: :view do
+  before { assign(:author, create(:author_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/authors/index.html.erb_spec.rb
+++ b/spec/views/authors/index.html.erb_spec.rb
@@ -7,6 +7,8 @@ describe 'authors/index.html.erb', type: :view do
                       create(:author_factory, name: 'Snorkmaiden')])
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each author' do
     render
     expect(rendered).to include('Moomin')

--- a/spec/views/authors/new.html.erb_spec.rb
+++ b/spec/views/authors/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'authors/new.html.erb', type: :view do
+  before { assign(:author, build(:author_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/authors/show.html.erb_spec.rb
+++ b/spec/views/authors/show.html.erb_spec.rb
@@ -5,6 +5,8 @@ describe 'authors/show.html.erb', type: :view do
 
   before { assign(:author, author) }
 
+  it_behaves_like 'renderable view'
+
   it 'renders the author' do
     render
     expect(rendered).to include(author.name)

--- a/spec/views/documents/index.html.erb_spec.rb
+++ b/spec/views/documents/index.html.erb_spec.rb
@@ -7,6 +7,8 @@ describe 'documents/index.html.erb', type: :view do
                         create(:document_factory, file_name: 'file2')])
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each document' do
     render
     expect(rendered).to include('file1')

--- a/spec/views/documents/new.html.erb_spec.rb
+++ b/spec/views/documents/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'documents/new.html.erb', type: :view do
+  before(:each) { assign(:document, build(:document_factory)) }
+  it_behaves_like 'renderable new media view'
+end

--- a/spec/views/documents/show.html.erb_spec.rb
+++ b/spec/views/documents/show.html.erb_spec.rb
@@ -8,6 +8,8 @@ describe 'documents/show.html.erb', type: :view do
     assign(:document, document)
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders the document' do
     render
     expect(rendered).to include(document.file_name)

--- a/spec/views/guides/edit.html.erb_spec.rb
+++ b/spec/views/guides/edit.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'guides/edit.html.erb', type: :view do
+  before { assign(:guide, create(:guide_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/guides/new.html.erb_spec.rb
+++ b/spec/views/guides/new.html.erb_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'guides/new.html.erb', type: :view do
+  before do
+    guide = build(:guide_factory)
+    assign(:guide, guide)
+    assign(:source_set, guide.source_set)
+  end
+
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/guides/show.html.erb_spec.rb
+++ b/spec/views/guides/show.html.erb_spec.rb
@@ -9,6 +9,8 @@ describe 'guides/show.html.erb', type: :view do
     assign(:source_set, guide.source_set)
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders the guide' do
     render
     expect(rendered).to include(guide.name)

--- a/spec/views/images/index.html.erb_spec.rb
+++ b/spec/views/images/index.html.erb_spec.rb
@@ -7,6 +7,8 @@ describe 'images/index.html.erb', type: :view do
                      create(:image_factory, file_name: 'file2')])
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each image' do
     render
     expect(rendered).to include('file1')

--- a/spec/views/images/new.html.erb_spec.rb
+++ b/spec/views/images/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'images/new.html.erb', type: :view do
+  before(:each) { assign(:image, build(:image_factory)) }
+  it_behaves_like 'renderable new media view'
+end

--- a/spec/views/images/show.html.erb_spec.rb
+++ b/spec/views/images/show.html.erb_spec.rb
@@ -8,6 +8,8 @@ describe 'images/show.html.erb', type: :view do
     assign(:image, image)
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders the image' do
     render
     expect(rendered).to include(image.file_name)

--- a/spec/views/source_sets/edit.html.erb_spec.rb
+++ b/spec/views/source_sets/edit.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'source_sets/edit.html.erb', type: :view do
+  before { assign(:source_set, create(:source_set_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/source_sets/index.html.erb_spec.rb
+++ b/spec/views/source_sets/index.html.erb_spec.rb
@@ -9,6 +9,8 @@ describe 'source_sets/index.html.erb', type: :view do
     assign(:unpublished_sets, SourceSet.unpublished_sets)
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each published source set' do
     render
     expect(rendered).to include('Snorkmaiden')

--- a/spec/views/source_sets/new.html.erb_spec.rb
+++ b/spec/views/source_sets/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'source_sets/new.html.erb', type: :view do
+  before { assign(:source_set, build(:source_set_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/source_sets/show.html.erb_spec.rb
+++ b/spec/views/source_sets/show.html.erb_spec.rb
@@ -8,6 +8,8 @@ describe 'source_sets/show.html.erb', type: :view do
 
   before { assign(:source_set, source_set) }
 
+  it_behaves_like 'renderable view'
+
   it 'renders the source set' do
     render
     expect(rendered).to include(source_set.name)

--- a/spec/views/sources/edit.html.erb_spec.rb
+++ b/spec/views/sources/edit.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'sources/edit.html.erb', type: :view do
+  before { assign(:source, create(:source_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/sources/new.html.erb_spec.rb
+++ b/spec/views/sources/new.html.erb_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'sources/new.html.erb', type: :view do
+  before do
+    source = build(:source_factory)
+    assign(:source, source)
+    assign(:source_set, source.source_set)
+  end
+
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/sources/show.html.erb_spec.rb
+++ b/spec/views/sources/show.html.erb_spec.rb
@@ -9,6 +9,8 @@ describe 'sources/show.html.erb', type: :view do
     assign(:source_set, source.source_set)
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders the source' do
     render
     expect(rendered).to include(source.aggregation)

--- a/spec/views/tags/edit.html.erb_spec.rb
+++ b/spec/views/tags/edit.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'tags/edit.html.erb', type: :view do
+  before { assign(:tag, create(:tag_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/tags/index.html.erb_spec.rb
+++ b/spec/views/tags/index.html.erb_spec.rb
@@ -7,6 +7,8 @@ describe 'tags/index.html.erb', type: :view do
                    create(:tag_factory, label: 'Snorkmaiden')])
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each tag' do
     render
     expect(rendered).to include('Moomin')

--- a/spec/views/tags/new.html.erb_spec.rb
+++ b/spec/views/tags/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'tags/new.html.erb', type: :view do
+  before { assign(:tag, build(:tag_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/tags/show.html.erb_spec.rb
+++ b/spec/views/tags/show.html.erb_spec.rb
@@ -5,6 +5,8 @@ describe 'tags/show.html.erb', type: :view do
 
   before { assign(:tag, tag) }
 
+  it_behaves_like 'renderable view'
+
   it 'renders the tag' do
     render
     expect(rendered).to include(tag.label)

--- a/spec/views/videos/index.html.erb_spec.rb
+++ b/spec/views/videos/index.html.erb_spec.rb
@@ -9,6 +9,8 @@ describe 'videos/index.html.erb', type: :view do
                             transcoding_job: '2')])
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each video' do
     render
     expect(rendered).to include('file1')

--- a/spec/views/videos/new.html.erb_spec.rb
+++ b/spec/views/videos/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'videos/new.html.erb', type: :view do
+  before(:each) { assign(:video, build(:video_factory)) }
+  it_behaves_like 'renderable new media view'
+end

--- a/spec/views/videos/show.html.erb_spec.rb
+++ b/spec/views/videos/show.html.erb_spec.rb
@@ -8,6 +8,8 @@ describe 'videos/show.html.erb', type: :view do
     assign(:video, video)
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders the video' do
     render
     expect(rendered).to include(video.file_base)

--- a/spec/views/vocabularies/edit.html.erb_spec.rb
+++ b/spec/views/vocabularies/edit.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'vocabularies/edit.html.erb', type: :view do
+  before { assign(:vocabulary, create(:vocabulary_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/vocabularies/index.html.erb_spec.rb
@@ -7,6 +7,8 @@ describe 'vocabularies/index.html.erb', type: :view do
                            create(:vocabulary_factory, name: 'Snorkmaiden')])
   end
 
+  it_behaves_like 'renderable view'
+
   it 'renders each vocabulary' do
     render
     expect(rendered).to include('Moomin')

--- a/spec/views/vocabularies/new.html.erb_spec.rb
+++ b/spec/views/vocabularies/new.html.erb_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe 'vocabularies/new.html.erb', type: :view do
+  before { assign(:vocabulary, build(:vocabulary_factory)) }
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/vocabularies/show.html.erb_spec.rb
+++ b/spec/views/vocabularies/show.html.erb_spec.rb
@@ -5,6 +5,8 @@ describe 'vocabularies/show.html.erb', type: :view do
 
   before { assign(:vocabulary, vocabulary) }
 
+  it_behaves_like 'renderable view'
+
   it 'renders the vocabulary' do
     render
     expect(rendered).to include(vocabulary.name)


### PR DESCRIPTION
This adds rspec tests to all views confirming that they render without error.

Most views can be tested using the shared example `'renderable view'`.  However, the new media views (`audio#new`, `video#new`, `image#new`, and `document#new`) require a special shared example that stubs out the `s3form`.  This form is rendered through the `s3_browser_uploads` gem, and seems to require a fair bit of logic to test - so I am thinking that testing whether or not the `s3form` renders may be out of scope for this PR.

This also removes a statement from `spec_helper` that explicitly loads view specs.  I had added this back in [PR#21](https://github.com/dpla/primary-source-sets/pull/21) because view files hadn't been loading when we ran `rspec`.  But upon further local testing, it seems that this line is not needed, and is, in fact, causing the view specs to run twice.

This addresses [ticket #8208](https://issues.dp.la/issues/8208),