### PR TITLE
Fix/move javascript

### DIFF
--- a/app/views/audios/new.html.erb
+++ b/app/views/audios/new.html.erb
@@ -1,10 +1,12 @@
-<% content_for :head_script do %>
+<% content_for :foot_script do %>
 
   <script>
       var pss_create_asset_path = '<%= audios_path() %>';
       var pss_asset_type = 'audio';
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
+
+  <%= javascript_include_tag 'avupload' %>
 
 <% end %>
 
@@ -18,5 +20,3 @@
 <% end %>
 
 <%= render "shared/s3form" %>
-
-<%= javascript_include_tag 'avupload' %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,10 +1,12 @@
-<% content_for :head_script do %>
+<% content_for :foot_script do %>
 
   <script>
       var pss_create_asset_path = '<%= documents_path() %>';
       var pss_asset_type = 'document';
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
+
+  <%= javascript_include_tag 'docupload' %>
 
 <% end %>
 
@@ -18,5 +20,3 @@
 <% end %>
 
 <%= render "shared/s3form" %>
-
-<%= javascript_include_tag 'docupload' %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <% content_for :foot_script do %>
-<%= render partial: 'shared/analytics' %>
+  <%= render partial: 'shared/analytics' %>
 <% end %>
 
 <div class="breadcrumbs">

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,10 +1,12 @@
-<% content_for :head_script do %>
+<% content_for :foot_script do %>
 
   <script>
       var pss_create_asset_path = '<%= images_path() %>';
       var pss_asset_type = 'image';
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
+
+  <%= javascript_include_tag 'imgupload' %>
 
 <% end %>
 
@@ -38,5 +40,3 @@
 </fieldset>
 
 <%= render "shared/s3form" %>
-
-<%= javascript_include_tag 'imgupload' %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head_script do %>
-<%= javascript_include_tag 'lightbox' %>
+  <%= javascript_include_tag 'lightbox' %>
 <% end %>
 
 <h1>Image: <%= @image.file_name %></h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,7 @@
       <%= render partial: 'shared/footer' %>
     </div>
     <%= render partial: 'shared/jump_links' %>
-
-    <%= yield :foot_script %>
   </body>
+  <%= yield :foot_script %>
   <%= javascript_include_tag 'style' %>
 </html>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% content_for :foot_script do %>
-<%= render partial: 'shared/analytics' %>
+  <%= render partial: 'shared/analytics' %>
 <% end %>
 
 <div class='all-sets'>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <% content_for :foot_script do %>
-<%= render partial: 'shared/analytics' %>
+  <%= render partial: 'shared/analytics' %>
 <% end %>
 
 <div class="breadcrumbs">

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <h1>Edit source</h1>
 
 <p>
@@ -11,5 +15,3 @@
 <p>This source belongs to <%= link_to inline_markdown(@source.source_set.name), source_set_path(@source.source_set) %></p>
 
 <%= render "form" %>
-
-<%= javascript_include_tag 'form' %>

--- a/app/views/sources/new.html.erb
+++ b/app/views/sources/new.html.erb
@@ -1,7 +1,9 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <p><%= link_to "Back to set", source_set_path(@source_set) %></p>
 
 <h1>New source for <%= inline_markdown(@source_set.name) %></h1>
 
 <%= render "form" %>
-
-<%= javascript_include_tag 'form' %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -8,12 +8,9 @@
                                           trailing_slash: true) %>' /> 
 <% end %>
 
-<% content_for :head_script do %>
-<%= javascript_include_tag 'lightbox' %>
-<% end %>
-
 <% content_for :foot_script do %>
-<%= render partial: 'shared/analytics' %>
+  <%= javascript_include_tag 'lightbox' %>
+  <%= render partial: 'shared/analytics' %>
 <% end %>
 
 <div class="breadcrumbs">

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -1,10 +1,12 @@
-<% content_for :head_script do %>
+<% content_for :foot_script do %>
 
   <script>
       var pss_create_asset_path = '<%= videos_path() %>';
       var pss_asset_type = 'video';
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
+
+  <%= javascript_include_tag 'avupload' %>
 
 <% end %>
 
@@ -18,5 +20,3 @@
 <% end %>
 
 <%= render "shared/s3form" %>
-
-<%= javascript_include_tag 'avupload' %>


### PR DESCRIPTION
This moves javascripts to the bottom of rendered HTML pages in order to ensure proper loading.  It also moves the `foot_script` (the section of the HTML where the javascripts go) _after_ the `</body>` tag in the HTML, rather than before.

I've tested this locally and all javascripts seem to still be working as expected.

This addresses [ticket #8067](https://issues.dp.la/issues/8067).