### PR TITLE
Set up and run CodeClimate to check code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 - redis-server
 addons:
   code_climate:
-    repo_token: 62a83766ff231b1463ac35e2d2fe856dc36d9dba30441ed1f82eaeaf05bc0854
+    repo_token: d5bdc6bb6c51d8a75b74099ee5fc6f084ecf4b53f849baeb3a425a6aad5f2d54
 before_install:
 - openssl aes-256-cbc -K $encrypted_559d56905e8d_key -iv $encrypted_559d56905e8d_iv
   -in deploy-key.enc -out deploy-key -d

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 require 'simplecov'
+require 'codeclimate-test-reporter'
+
+CodeClimate::TestReporter.start
 SimpleCov.start
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
The Travis configuration was using the wrong CodeClimate token, and the CodeClimate test reporter was not being started.