### PR TITLE
Fix double-encoding of characters in titles

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,3 +1,5 @@
+require 'redcarpet/render_strip'
+
 module MarkdownHelper
   ##
   # @param String text A markdown formatted String
@@ -16,6 +18,10 @@ module MarkdownHelper
   # @raise TypeError if @param is not a String
   def inline_markdown(text)
     strip_p_tags(markdown(text))
+  end
+
+  def plaintext_from_md(text)
+    Redcarpet::Markdown.new(Redcarpet::Render::StripDown).render(text)
   end
 
   private

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head_script do %>
-  <title><%= strip_tags(inline_markdown(@guide.name)) %></title>
+  <title><%= plaintext_from_md(@guide.name) %></title>
   <meta name='description' content="This teaching guide helps instructors use a specific primary source set, '<%= strip_tags(inline_markdown(@guide.source_set.name)) %>', in the classroom." />
   <link rel='canonical' href='<%= url_for(controller: 'guides',
                                           action: 'show',

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head_script do %>
-  <title><%= strip_tags(inline_markdown(@source_set.name)) %></title>
+  <title><%= plaintext_from_md(@source_set.name) %></title>
   <meta name='description' content="<%= @source_set.description %>" />
   <link rel='canonical' href='<%= url_for(controller: 'source_sets',
                                           action: 'show',

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head_script do %>
-  <title><%= strip_tags(inline_markdown(@source.name)) %></title>
+  <title><%= plaintext_from_md(@source.name) %></title>
   <meta name='description' content="This <%= @source.main_asset.class.name.downcase %> is part of '<%= strip_tags(inline_markdown(@source.source_set.name)) %>', a primary source set for educational use." />
   <link rel='canonical' href='<%= url_for(controller: 'sources',
                                           action: 'show',


### PR DESCRIPTION
Remove the double-HTML-encoding of characters into HTML entities.

See https://issues.dp.la/issues/8199

The `#inline_markdown` method call is not necessary for `<title>` elements, because it's not desirable to have markup in titles -- all we need is straight text.  The `#inline_markdown` method encodes HTML entities, and the resulting string was being encoded one more time by Rails automatically when the view was rendered.
