### PR TITLE
show and filter by tags on user interface

### DIFF
--- a/app/assets/javascripts/style.js
+++ b/app/assets/javascripts/style.js
@@ -5,10 +5,12 @@
 
   $(document).ready(function() {
     setAsideHeight();
+    setNameContainerHeight();
   });
 
   $(window).resize(function() {
     setAsideHeight();
+    setNameContainerHeight();
   })
 })();
 
@@ -33,4 +35,28 @@ function setAsideHeight() {
   if (titleHeight < moduleHeight) {
     $('.set .title-outer-container').outerHeight(moduleHeight);
   }
+}
+
+/*
+ * This dynamically styles the boxes (class = set-name-container) that contain
+ * the title in a set tile, for example those found in the sets#index view.
+ * Ensure that each title box is the same height as all other boxes in the same
+ * row.  Each box will be resized to be a tall as the tallest box in the row.
+ */
+function setNameContainerHeight() {
+  
+  $('div.moduleContainer.threeCol').each(function() {
+    var maxHeight = 0;
+    var container = $(this).find('.set-name-container');
+
+    container.each(function() {
+      if ($(this).height() > maxHeight) {
+        maxHeight = $(this).height();
+      }
+    });
+
+    container.each(function() {
+      $(this).height(maxHeight);
+    });
+  })
 }

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -4,6 +4,11 @@
   word-wrap: break-word;
 }
 
+.inline-block {
+  display: inline-block;
+  float: left;
+}
+
 .primary-source-sets aside {
   margin-left: 1em;
   margin-bottom: 1em;
@@ -44,6 +49,72 @@
 
 /* SourceSets index styles */
 
+.all-sets .module {
+  border-color: #6592A6;
+  padding: 0;
+  background-color: white;
+  max-width: 440px;
+}
+
+.all-sets img {
+  margin: 0;
+}
+
+.all-sets .set-tile {
+  border-color: #6592A6;
+  background-color: #6592A6;
+}
+
+.all-sets .set-name-container {
+  padding: 1em;
+  background-color: #6592A6;
+}
+
+.all-sets .set-name-container a {
+  color: white;
+  font-weight: normal;
+  font-size: 1.2em;
+}
+
+.all-sets .tag-label {
+  margin: 0.8em 1em 0.8em 0;
+}
+
+.all-sets .tag-list {
+  background-color: white;
+  margin: 0 -0.5em 1.5em 0;
+  padding: 0;
+}
+
+.all-sets .tag {
+  display: inline;
+  float: left;
+  background-color: #EDEDED;
+  border: 1px solid #D2D2D2;
+  padding: 0.2em 0.5em;
+  margin: 0.5em 0.5em 0 0;
+}
+
+.all-sets .set-list .tag a {
+  display: block;
+}
+
+.all-sets .tag a:hover {
+  text-decoration: none;
+}
+
+/* Unpublished SourceSets */
+
+.all-sets .admin-info .module {
+  border-color: #777;
+}
+
+.all-sets .admin-info .set-name-container {
+  background-color: #777;
+}
+
+/* SourceSet styles */
+
 .set .title-outer-container {
   background-color: #6592A6;
   margin-bottom: 2em;
@@ -58,25 +129,6 @@
   color: white;
   margin: 0;
 }
-
-.all-sets .module {
-  border-color: #6592A6;
-  padding: 0;
-  background-color: #6592A6;
-  max-width: 440px;
-}
-
-.all-sets .set-name-container {
-  margin: 0.5em 1em;
-}
-
-.all-sets .set-name-container a {
-  color: white;
-  font-weight: bold;
-  font-size: 1.2em;
-}
-
-/* SourceSet styles */
 
 .set .overview {
   clear: both;

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -8,8 +8,9 @@ class SourceSetsController < ApplicationController
   before_action :authenticate_admin!, only: [:new, :edit]
 
   def index
-    @published_sets = SourceSet.published_sets
-    @unpublished_sets = SourceSet.unpublished_sets
+    @tags = params[:tags]
+    @published_sets = SourceSet.published_sets.with_tags(@tags)
+    @unpublished_sets = SourceSet.unpublished_sets.with_tags(@tags)
   end
 
   def show

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -9,6 +9,7 @@ class SourceSet < ActiveRecord::Base
   validates :name, presence: true
   validates_numericality_of :year, only_integer: true, allow_nil: true,
                                    less_than_or_equal_to: Date.today.year
+  default_scope { order(created_at: :asc) }
 
   ##
   # FriendlyId generates a human-readable slug to be used in the URL, in place
@@ -31,4 +32,24 @@ class SourceSet < ActiveRecord::Base
   def self.unpublished_sets
     self.where(published: false)
   end
+
+  ##
+  # Get SourceSets associated with all of the specified tags.
+  # EACH returned SourceSet will have ALL of the tags.
+  # If no tags are specified, return all SourceSets.
+  # @param tags [Array<String>]
+  # @return [Array<SourceSet>]
+  def self.with_tags(tags)
+    return all unless tags.present?
+    tags.map { |tag| with_tag(tag) }.inject(:&)
+  end
+
+  ##
+  # Get SourceSets associated with the specified tag.
+  # @param tag [String]
+  # @return [SourceSet]
+  def self.with_tag(tag)
+    joins(:tags).where('tags.label = ?', tag)
+  end
+  private_class_method :with_tag
 end

--- a/app/views/source_sets/_set_list.html.erb
+++ b/app/views/source_sets/_set_list.html.erb
@@ -1,5 +1,5 @@
 <div class='set-list'>
-  <%= sets.order('created_at ASC').each_slice(3) do |sets_row| %>
+  <%= sets.each_slice(3) do |sets_row| %>
     <div class='moduleContainer threeCol'>
       <% sets_row.each_with_index do |set, i| %>
         <section class='module'>
@@ -12,6 +12,18 @@
           <div class='set-name-container'>
             <%= link_to inline_markdown(set.name), source_set_path(set) %>
           </div>
+
+          <% if Settings.display_tags_on_public_ui == true %>
+            <ul class='tag-list'>
+              <% set.tags.each do |tag| %>
+                <li class='tag'>
+                  <% link_tags = ([@tags].flatten.compact + [tag.label]).uniq %>
+                  <%= link_to tag.label, source_sets_path(tags: link_tags) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
         </section>
       <% end %>
     </div>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -13,6 +13,18 @@
 
   <p>DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources. Each set includes an overview, ten to fifteen primary sources, links to related resources, and a teaching guide. These sets were created and reviewed by the teachers on the DPLA's <%= link_to 'Education Advisory Committee', wordpress_path('education/education-advisory-committee') %>. We will be adding new sets and features through Spring 2016. Read about our <%= link_to 'education projects', wordpress_path('education') %> and contact us with feedback at <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
 
+  <% if @tags.present? && Settings.display_tags_on_public_ui == true %>
+    <span class='tag-label inline-block'>Refined by: </span>
+    <ul class='tag-list inline-block'>
+      <% @tags.each do |tag| %>
+        <li class='tag'>
+          <% link_tags = [@tags].flatten.compact - [tag] %>
+          <%= tag %> <%= link_to '×', source_sets_path(tags: link_tags) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
   <%= render partial: 'source_sets/set_list',
              locals: { sets: @published_sets } %>
 
@@ -20,17 +32,18 @@
     <p>Send feedback about these primary source sets or our other educational resources to <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
   </div>
 
+  <% if admin_signed_in? %>
+
+    <div class='admin-info'>
+
+      <h2>Admin Info</h2>
+
+      <p><%= link_to "Create new set", new_source_set_path %></p>
+
+      <h3>Unpublished sets</h3>
+
+      <%= render partial: 'source_sets/set_list',
+                 locals: { sets: @unpublished_sets } %>
+    </div>
+  <% end %>
 </div>
-
-<% if admin_signed_in? %>
-
-  <h2>Admin Info</h2>
-
-  <p><%= link_to "Create new set", new_source_set_path %></p>
-
-  <h3>Unpublished sets</h3>
-
-  <%= render partial: 'source_sets/set_list',
-             locals: { sets: @unpublished_sets } %>
-
-<% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -74,3 +74,5 @@ googleanalytics:
   tracker: false
 
 contact_email: email@example.com
+
+display_tags_on_public_ui: true

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe SourceSetsController, type: :controller do
 
   let(:resource) { create(:source_set_factory) }
-  let(:published) { create(:source_set_factory, published: true)}
+  let(:published) { create(:source_set_factory, published: true) }
   let(:attributes) { attributes_for(:source_set_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_source_set_factory) }
 
@@ -24,6 +24,16 @@ describe SourceSetsController, type: :controller do
       it 'sets @unpublished_sets variable' do
         get :index
         expect(assigns(:unpublished_sets)).to eq([resource])
+      end
+
+      it 'sets @tags variable' do
+        get :index, tags: ['a']
+        expect(assigns(:tags)).to eq(['a'])
+      end
+
+      it 'requests SourceSets with specified tags' do
+        expect(SourceSet).to receive(:with_tags).with(['a']).twice
+        get :index, tags: ['a']
       end
 
       it 'renders the :index view' do

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -49,6 +49,10 @@ describe SourceSet, type: :model do
       .not_to be_valid
   end
 
+  it 'orders by created date' do
+    expect(SourceSet.all).to eq([source_set, published_set])
+  end
+
   context 'with featured source' do
 
     let(:source) do
@@ -80,6 +84,33 @@ describe SourceSet, type: :model do
   describe '#unpublished_sets' do
     it 'returns unpublished sets' do
       expect(SourceSet.unpublished_sets).to contain_exactly(source_set)
+    end
+  end
+
+  context 'with tags' do
+
+    let(:a_tag) { create(:tag_factory, label: 'a') }
+    let(:b_tag) { create(:tag_factory, label: 'b') }
+
+    before(:each) do
+      source_set.tags << a_tag
+      published_set.tags << [a_tag, b_tag]
+    end
+
+    describe '#with_tags' do
+      it 'returns source sets with all specified tags' do
+        expect(SourceSet.with_tags(['a', 'b']))
+          .to contain_exactly(published_set)
+      end
+
+      it 'works in conjuction with published_sets' do
+        expect(SourceSet.published_sets.with_tags(['a']))
+          .to contain_exactly(published_set)
+      end
+
+      it 'returns all SourceSets if no tags specified' do
+        expect(SourceSet.with_tags([])).to include(source_set, published_set)
+      end
     end
   end
 end


### PR DESCRIPTION
This adds functionality to show `tags` on the user interface, and allows users to filter by `tags`.  `tags` only appear on the the `source_sets#index` view.

Basic CRUD interfaces for tags were added in [PR#84](https://github.com/dpla/primary-source-sets/pull/84); however, tags were _only_ visible to logged-in admins.  This PR introduces functionality available to non-logged-in users.

Here is an example of the how the functionality should work:

A user goes to `/primary-source-sets/sets?tags[]=dogs` and sees only those sets with a tag whose label is `dogs`.  All of the tags associated with a set (including `dogs`) are listed beneath each set.

One set also has a tag `cats`.  The user clicks on `cats`, and is taken to `/primary-source-sets/sets?tags[]=dogs&tags[]=cats`.  The users is shown all sets having _both_ `cats` and `dogs` tags.

Changes include:

* Updating the `source_sets#index` controller to parse a `tags` param.  

* Adding methods the `SourceSets` model to request sets by tag.

* Updating the views to show the tags and allow filtering.

* Styling, including changes to the HTML and CSS.  This includes a JavaScript function to ensure that that the dark blue boxes containing the name of each set are the same height in each row.

* A system config that allows us specify whether or not to display tags to the end user.  This will help us to manage deployment - admins need time to add all of the tags before we start showing them to the end user.