### PR TITLE
Fix mobile layout and menus

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,3 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require nav-menu-effects

--- a/app/assets/javascripts/nav-menu-effects.js
+++ b/app/assets/javascripts/nav-menu-effects.js
@@ -1,0 +1,35 @@
+
+/*
+ * Things to do on all pages, which have navigation menus that need to behave
+ * responsively.
+ */
+$(function() {
+
+    $('.menu-btn').click(function() {
+        $('.topNav, .MainNav').toggle(400);
+        $('span', this).toggleClass('icon-arrow-thin-up');
+        $('span', this).toggleClass('icon-arrow-thin-down');
+        return false;
+    });
+
+    // If the window is resized, we have to ensure the state of the `.topNav'
+    // and `.MainNav' divs, depending on which way the window is being sized,
+    // and what is being hidden or redisplayed.
+    $(window).resize(function() {
+        $iconSpan = $('.menu-btn span');
+        $divs = $('.topNav, .MainNav');
+        if ($(window).width() > 679) {
+            // Getting bigger.  Make sure the divs are shown and reset the
+            // arrow so that it's pointing down, inviting you to expand the
+            // menu, if you make the window narrower again.
+            $divs.show();
+            $iconSpan.removeClass('icon-arrow-thin-up');
+            $iconSpan.addClass('icon-arrow-thin-down');
+        } else {
+            // The reverse.  It may have been explicitly shown, so make sure
+            // it's hidden.
+            $divs.hide();
+        }
+    });
+
+});

--- a/app/assets/stylesheets/vendor/main.css.erb
+++ b/app/assets/stylesheets/vendor/main.css.erb
@@ -711,7 +711,7 @@ aside .module span { color: #000; }
     transition: 0.3s ease;
 }
 
-.btn:hover, .btn a:hover, .shareSave .btn a:hover, .menu-btn:hover, .toggle:hover {
+.btn:hover, .btn a:hover, .shareSave .btn a:hover, .toggle:hover {
     background: black;
     -webkit-transition: 0.3s ease;
     -moz-transition: 0.3s ease;
@@ -3423,7 +3423,7 @@ div.timeline-year {
 .menu-btn .icon-arrow-thin-down:before { font-size: 10px; margin: 0;}
 
 .menu-btn {
-    background: #808080;
+    background: #DD4E00;
     color: #FFFFFF;
     display: none;
     font-size: 10px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8" />
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0" />
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600,600italic'
           rel='stylesheet' type='text/css'>
     <%= stylesheet_link_tag 'application', media: 'all' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
                         alt: 'DPLA: Digital Public Library of America'),
               frontend_path,
               class: 'logo' %>
-  <%= link_to '', class: 'menu-btn' do %>
+  <%= link_to '#', class: 'menu-btn' do %>
     <span class='icon-arrow-thin-down' aria-hidden='true'></span>
     <span class='visuallyhidden'>Navigation</span>
   <% end %>


### PR DESCRIPTION
Fixes https://issues.dp.la/issues/8093

* Add "viewport" `<meta>` element to the layout that makes mobile browsers show the page at the correct scale.
* Add a "charset" `<meta>` element while we're at it, as a best practice.
* Enable the menu buttons that show the navigation menu when the screen is small.

It would be nice not to need code to pull off the menus. I've implemented an adaptive menu like this (with the menu that gets replaced by a button) in pure CSS, not that I understand it that well. We can probably get rid of some of the code in a future iteration. It's harder to do it differently now without rewriting a lot of stylesheets and templates.
