### PR TITLE
order sets by date created or year

### DIFF
--- a/app/assets/javascripts/results-bar.js
+++ b/app/assets/javascripts/results-bar.js
@@ -1,0 +1,8 @@
+$(function() {
+  $(document).ready(function() {
+    // auto-sumbit forms when dropdown menu selections change
+    $('.resultsBar select').change(function() {
+      $(this).closest('form').submit();
+    });
+  });
+});

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -49,8 +49,22 @@
 
 /* SourceSets index styles */
 
+.all-sets .resultsBar {
+  clear: both;
+}
+
 .all-sets .module {
   border-color: #6592A6;
+  padding: 0;
+  background-color: white;
+  max-width: 440px;
+}
+
+.all-sets img {
+  margin: 0;
+}
+
+.all-sets .set-tile {
   padding: 0;
   background-color: white;
   max-width: 440px;
@@ -111,6 +125,26 @@
 
 .all-sets .admin-info .set-name-container {
   background-color: #777;
+}
+
+/* Results bar */
+
+.all-sets .resultsBar select {
+  width: 210px;
+}
+
+.all-sets .resultsBar input[type='submit'] {
+  background: none;
+  background-color: #DD4E00;
+  text-indent: 0;
+  position: relative;
+  font-size: 1em;
+  text-transform: none;
+  color: white;
+  padding: 4px 8px;
+  margin-left: 8px;
+  height: auto;
+  width: auto;
 }
 
 /* SourceSet styles */

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -9,8 +9,10 @@ class SourceSetsController < ApplicationController
 
   def index
     @tags = params[:tags]
-    @published_sets = SourceSet.published_sets.with_tags(@tags)
-    @unpublished_sets = SourceSet.unpublished_sets.with_tags(@tags)
+    @order = params[:order]
+    @published_sets = SourceSet.published_sets.order_by(@order).with_tags(@tags)
+    @unpublished_sets = SourceSet.unpublished_sets.order_by(@order)
+                                 .with_tags(@tags)
   end
 
   def show

--- a/app/helpers/source_sets_helper.rb
+++ b/app/helpers/source_sets_helper.rb
@@ -1,0 +1,7 @@
+module SourceSetsHelper
+  def sort_options
+    [['Recently added', 'recently_added'],
+     ['Chronologically, oldest first', 'chronology_asc'],
+     ['Chronologically, most recent first', 'chronology_desc']]
+  end
+end

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :head_script do %>
   <title>Primary Source Sets</title>
   <meta name='description' content="DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources." />
+  <%= javascript_include_tag 'results-bar', defer: 'defer' %>
 <% end %>
 
 <% content_for :foot_script do %>
@@ -24,6 +25,14 @@
       <% end %>
     </ul>
   <% end %>
+
+  <div class='resultsBar'>
+    <%= form_tag(source_sets_path, method: :get) do %>
+      <%= label_tag(:order, 'Sort by:') %>
+      <%= select_tag(:order, options_for_select(sort_options, @order)) %>
+      <noscript><%= submit_tag 'Re-sort', name: nil %></noscript>
+    <% end %>
+  </div>
 
   <%= render partial: 'source_sets/set_list',
              locals: { sets: @published_sets } %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,6 +10,7 @@ Rails.application.config.assets.precompile += %w( imgupload.js )
 Rails.application.config.assets.precompile += %w( form.js )
 Rails.application.config.assets.precompile += %w( style.js )
 Rails.application.config.assets.precompile += %w( openseadragon.js )
+Rails.application.config.assets.precompile += %w( results-bar.js )
 
 # Precompile assets from gems
 Rails.application.config.assets.precompile += %w( dpla-colors.css dpla-fonts.css )

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -36,6 +36,19 @@ describe SourceSetsController, type: :controller do
         get :index, tags: ['a']
       end
 
+      it 'sets @order variable' do
+        get :index, order: 'recently_added'
+        expect(assigns(:order)).to eq 'recently_added'
+      end
+
+      it 'requests SourceSets with specified order' do
+        relation = double('ActiveRecord::Relation')
+        allow(relation).to receive(:with_tags)
+        expect(SourceSet).to receive(:order_by).with('recently_added').twice
+          .and_return(relation)
+        get :index, order: 'recently_added'
+      end
+
       it 'renders the :index view' do
         get :index
         expect(response).to render_template :index

--- a/spec/helpers/source_sets_helper_spec.rb
+++ b/spec/helpers/source_sets_helper_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe SourceSetsHelper, type: :helper do
+
+  describe '#sort_options' do
+    it 'returns an array' do
+      expect(helper.sort_options).to be_a Array
+    end
+  end
+end

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -18,6 +18,7 @@ src_files:
   - assets/avupload.js
   - assets/docupload.js
   - assets/imgupload.js
+  - assets/results-bar.js
 
 # stylesheets
 #

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -49,10 +49,6 @@ describe SourceSet, type: :model do
       .not_to be_valid
   end
 
-  it 'orders by created date' do
-    expect(SourceSet.all).to eq([source_set, published_set])
-  end
-
   context 'with featured source' do
 
     let(:source) do
@@ -111,6 +107,39 @@ describe SourceSet, type: :model do
       it 'returns all SourceSets if no tags specified' do
         expect(SourceSet.with_tags([])).to include(source_set, published_set)
       end
+    end
+  end
+
+  describe '#order_by' do
+
+    let(:set_a) { create(:source_set_factory, year: 1920) }
+    let(:set_b) { create(:source_set_factory, year: 1930) }
+
+    before(:each) do
+      set_a
+      set_b
+    end
+
+    it 'orders by most recently created' do
+      expect(SourceSet.order_by('recently_added')).to eq([set_b, set_a])
+    end
+
+    it 'orders by time period ascending' do
+      expect(SourceSet.order_by('chronology_asc'))
+        .to eq([set_a, set_b])
+    end
+
+    it 'orders by time period descending' do
+      expect(SourceSet.order_by('chronology_desc'))
+        .to eq([set_b, set_a])
+    end
+
+    it 'defaults to ordering by most recently created' do
+      expect(SourceSet.order_by(nil)).to eq([set_b, set_a])
+    end
+
+    it 'ignores unexpected params' do
+      expect(SourceSet.order_by('*****')).to eq([set_b, set_a])
     end
   end
 end


### PR DESCRIPTION
This introduces a feature that allows users to sort sets by `created_date` and `year` on the `sets#index` view.  

The sort option is included in the URI as an `order` param.  For example: `/sets?order=recently_added'`  The application recognizes three legitimate `order` params, `recently_added`, `chronology_asc`, and `chronology_desc`.  Any other `order` param is ignored.  If there is no legitimate `order` param, it defaults to `recently_added`.

Changes include:

* A method in the `SourceSet` model that parses the `order` param and adds sort options to a database query.

* Updating the `source_sets#index` controller method.

* Adding a dropdown menu to the view so users can select a sort option.

* Unobtrusive JavaScript.  If JavaScript is disabled, a form submit button will appear.  If JavaScript is enabled, the form submit button will be hidden and the dropdown menu will auto-submit upon change.

This addresses [ticket #8205](https://issues.dp.la/issues/8205).