### PR TITLE
fix settings file and muliple tags/orders params

### DIFF
--- a/app/views/source_sets/_set_list.html.erb
+++ b/app/views/source_sets/_set_list.html.erb
@@ -18,7 +18,8 @@
               <% set.tags.each do |tag| %>
                 <li class='tag'>
                   <% link_tags = ([@tags].flatten.compact + [tag.label]).uniq %>
-                  <%= link_to tag.label, source_sets_path(tags: link_tags) %>
+                  <% new_params = params.merge(tags: link_tags) %>
+                  <%= link_to tag.label, source_sets_path(new_params) %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -20,7 +20,8 @@
       <% @tags.each do |tag| %>
         <li class='tag'>
           <% link_tags = [@tags].flatten.compact - [tag] %>
-          <%= tag %> <%= link_to '×', source_sets_path(tags: link_tags) %>
+          <% new_params = params.merge(tags: link_tags) %>
+          <%= tag %> <%= link_to '×', source_sets_path(new_params) %>
         </li>
       <% end %>
     </ul>
@@ -28,6 +29,11 @@
 
   <div class='resultsBar'>
     <%= form_tag(source_sets_path, method: :get) do %>
+      <% if params[:tags].present? %>
+        <% params[:tags].each do |tag| %>
+          <%= hidden_field_tag('tags[]', tag) %>
+        <% end %>
+      <% end %>
       <%= label_tag(:order, 'Sort by:') %>
       <%= select_tag(:order, options_for_select(sort_options, @order)) %>
       <noscript><%= submit_tag 'Re-sort', name: nil %></noscript>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -75,4 +75,4 @@ googleanalytics:
 
 contact_email: email@example.com
 
-display_tags_on_public_ui: true
+display_tags_on_public_ui: false


### PR DESCRIPTION
This solves two bugs that that were introduced in release v1.2.2.  

1. In v1.2.2, user-selected tags and orders are over-riding one another. For example, from the browser window, if I select a tag and then select and order, I will lose the tag definition in the URI, and visa versa. This ensures that when tags are selected/deselected, and when orders are changed, all relevant params are passed along.

2. It changes default value of `display_tags_on_public_ui` to `false`.