### PR TITLE
change sort by menu language

### DIFF
--- a/app/helpers/source_sets_helper.rb
+++ b/app/helpers/source_sets_helper.rb
@@ -1,7 +1,8 @@
 module SourceSetsHelper
+  # Options for the Sort By menu
   def sort_options
     [['Recently added', 'recently_added'],
-     ['Chronologically, oldest first', 'chronology_asc'],
-     ['Chronologically, most recent first', 'chronology_desc']]
+     ['Chronology, oldest first', 'chronology_asc'],
+     ['Chronology, most recent first', 'chronology_desc']]
   end
 end


### PR DESCRIPTION
In the "Sort by" menu, change the word "Chronologially" to "Chronology" wherever it occurs, as per request from Franky.  This addresses ticket [#8233](https://issues.dp.la/issues/8233).