### PR TITLE
Add account management

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,25 @@ it to "use local source," in other words, use this working copy as the source of
 deployments, please be aware that the working copy's configuration files will be
 copied into the `automation` VM, by design.
 
+### ActionMailer setup
+
+This project uses ActionMailer to send account-creation confirmation emails. We
+use the [mailcatcher](http://mailcatcher.me/) gem in development to simulate a
+mail server, rather than running a real one. Per [its
+documentation](http://mailcatcher.me/), we do not include it in our Gemfile, and
+you need to install it with `gem install mailcatcher`.
+
+The mail settings for production are ActionMailer `smtp_settings` key/value
+pairs.  There are defaults in `settings.yml` that can be overridden in
+`settings.local.yml`.
+
+If you're running in the development VM (with our Vagrantfile), you'll want to
+invoke `mailcatcher` this way:
+```
+mailcatcher --http-ip 0.0.0.0
+```
+This ensures that the HTTP interface will be listening on the network interface
+that is being forwarded to `localhost` on your host machine.
 
 Testing
 -------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure(2) do |config|
     pss.vm.network :private_network, ip: '192.168.50.22'
     pss.vm.network "forwarded_port", guest: 3000, host: 3000  # Rails
     pss.vm.network "forwarded_port", guest: 3001, host: 3001  # Jasmine
+    pss.vm.network "forwarded_port", guest: 1080, host: 1080  # mailcatcher
     pss.vm.provider 'virtualbox' do |vb|
       vb.memory = 1024
     end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,93 @@
+##
+# Overrides for Devise::ConfirmationsController
+#
+# Override confirmation behavior to allow creation of accounts without
+# passwords, where user action is required to respond to an email and activate
+# the account, at which point a password is chosen.
+#
+# @see https://github.com/plataformatec/devise/wiki/How-To:-Override-confirmations-so-users-can-pick-their-own-passwords-as-part-of-confirmation-activation
+#
+class ConfirmationsController < Devise::ConfirmationsController
+  skip_before_filter :authenticate_user!
+
+  ##
+  # Confirm account by updating password
+  # PATCH  /admins/confirmation(.:format)
+  #
+  def update
+    with_unconfirmed_confirmable do
+      if @confirmable.has_no_password?
+        @confirmable.attempt_set_password(params[:admin])
+        if @confirmable.valid? and password_match?
+          do_confirm
+        else
+          do_show
+          @confirmable.errors.clear  # So that we won't render :new
+        end
+      else
+        @confirmable.errors.add(:email, :password_already_set)
+      end
+    end
+
+    if !@confirmable.errors.empty?
+      self.resource = @confirmable
+      render 'devise/confirmations/new'
+    end
+  end
+
+  ##
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # Show the choose-password form for a new account, or log the user in and
+  # redirect, otherwise.
+  #
+  def show
+    with_unconfirmed_confirmable do
+      if @confirmable.has_no_password?
+        do_show
+      else
+        do_confirm
+      end
+    end
+    unless @confirmable.errors.empty?
+      self.resource = @confirmable
+      render 'devise/confirmations/new'
+    end
+  end
+
+  protected
+
+  def with_unconfirmed_confirmable
+    digest = Devise.token_generator.digest(
+      Admin,
+      :confirmation_token,
+      params[:confirmation_token]
+    )
+    @confirmable = Admin.find_or_initialize_with_error_by(
+      :confirmation_token,
+      digest
+    )
+
+    if !@confirmable.new_record?
+      @confirmable.only_if_unconfirmed { yield }
+    end
+  end
+
+  def do_show
+    @confirmation_token = params[:confirmation_token]
+    @requires_password = true
+    self.resource = @confirmable
+    render 'devise/confirmations/show'
+  end
+
+  def do_confirm
+    @confirmable.confirm!
+    set_flash_message :notice, :confirmed
+    sign_in_and_redirect(resource_name, @confirmable)
+  end
+
+  private
+
+  def password_match?
+    params[:password] == params[:password_confirmation]
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,63 @@
+
+class RegistrationsController < Devise::RegistrationsController
+  skip_before_action :require_no_authentication
+  before_action :authenticate_admin!
+
+  ##
+  # New #index method not defined in Devise::RegistrationsController
+  def index
+    @admins = Admin.all
+  end
+
+  def create
+    build_resource(sign_up_params)
+    resource.save
+    yield resource if block_given?
+    if resource.persisted?
+      redirect_to registrations_path
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  def edit
+    @admin = Admin.find(params[:id])
+  end
+
+  ##
+  # @see Devise::RegistrationsController#update
+  def update
+    self.resource = Admin.find(params[:id])
+    prev_unconfirmed_email = resource.unconfirmed_email \
+      if resource.respond_to?(:unconfirmed_email)
+
+    resource_updated = update_resource(resource, account_update_params)
+    yield resource if block_given?
+    if resource_updated
+      if is_flashing_format?
+        flash_key = \
+          update_needs_confirmation?(resource, prev_unconfirmed_email) ?
+          :update_needs_confirmation : :updated
+        set_flash_message :notice, flash_key
+      end
+      redirect_to registrations_path
+    else
+      clean_up_passwords resource
+      respond_with resource
+    end
+  end
+
+  def destroy
+    @admin = Admin.find(params[:id])
+    @admin.destroy
+    redirect_to registrations_path    
+  end
+
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,3 +1,88 @@
+##
+# Admin -- administrative user
+#
+# Most functionality is handled by Devise, with some overridden or custom
+# methods that allow for account creations to trigger email confirmations that
+# prompt users for passwords.
+#
+# @see https://github.com/plataformatec/devise/wiki/How-To:-Override-confirmations-so-users-can-pick-their-own-passwords-as-part-of-confirmation-activation
+#
 class Admin < ActiveRecord::Base
-  devise :database_authenticatable, :trackable, :validatable
+  devise :database_authenticatable, :trackable, :validatable, :confirmable,
+         :recoverable, :registerable
+
+  ##
+  # Determine whether to validate the presence of the password.
+  #
+  # This comes into play when a record is being saved with a new password and
+  # a confirmation token, after having originally been saved without a
+  # password, pending confirmation.
+  #
+  # @see Devise::Models::Validatable
+  def password_required?
+    if !persisted?
+      # Password is not required for new, unsaved records
+      false
+    else
+      # Evaluate a record that's been saved before, and is in the process of
+      # being updated.
+      #
+      # When the password-set form is being submitted upon confirming an
+      # account, the password confirmation token should be set, and, hopefully,
+      # the password as well.
+      #
+      # NOTE: `password' and `password_confirmation' are not persisted fields.
+      #       They will only be set during the processing of a form submission.
+      #       This can make things extremely confusing in the code below.
+      #
+      # *true* if there is a password *or* confirmation token, meaning a
+      #        validation should take place
+      #
+      # *false* if neither a password or confirmation token are set, meaning
+      #        no validation should take place
+      #
+      # ... This can be counter-intuitive.  It says to validate the presence
+      # of a password if a password exists, which seems redundant, but this is
+      # the way Devise::Models::Validatable works and is the way the Devise
+      # Wiki recommends to do it, per
+      # https://github.com/plataformatec/devise/wiki/How-To:-Override-confirmations-so-users-can-pick-their-own-passwords-as-part-of-confirmation-activation
+      #
+      password_update_assigned? || password_confirmation_update_assigned?
+    end
+  end
+
+  # New function to set the password without knowing the current
+  # password used in our confirmation controller.
+  def attempt_set_password(params)
+    p = {
+      password: params[:password],
+      password_confirmation: params[:password_confirmation]
+    }
+    update_attributes(p)
+  end
+
+  # New function to return whether a password has been set
+  def has_no_password?
+    self.encrypted_password.blank?
+  end
+
+  def only_if_unconfirmed
+    pending_any_confirmation { yield }
+  end
+
+  private
+
+  ##
+  # @see #password_required?
+  # @see Devise::Models:Validatable
+  def password_update_assigned?
+    !password.nil?
+  end
+
+  ##
+  # @see #password_required?
+  # @see
+  def password_confirmation_update_assigned?
+    !password_confirmation.nil?
+  end
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,19 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource,
+             as: resource_name,
+             url: confirmation_path(resource_name),
+             html: { method: :post, class: 'pss-admin-form' }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions", class: 'form-submit' %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -1,0 +1,27 @@
+<h2>Account Activation</h2>
+
+<%= form_for resource,
+    :as => resource_name,
+    :url => update_user_confirmation_path,
+    :html => {:method => 'patch', class: 'pss-admin-form'},
+    :id => 'activation-form' do |f| %>
+
+  <%= devise_error_messages! %>
+
+  <fieldset>
+    <legend>Account Activation for <%= resource.email %></legend>
+
+  <% if @requires_password %>
+      <%= f.label :password, 'Choose a Password:' %>
+      <%= f.password_field :password %>
+
+      <%= f.label :password_confirmation, 'Password Confirmation:' %>
+      <%= f.password_field :password_confirmation %>
+  <% end %>
+
+    <%= hidden_field_tag :confirmation_token, @confirmation_token %>
+
+    <%= f.submit "Activate", class: 'form-submit' %>
+  </fieldset>
+
+<% end %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Welcome, <%= @email %>!</p>
+
+<p>You have a new account for DPLA Primary Source Sets.</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,13 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this
+   through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please alert <%= Settings.contact_email %>,
+because somebody may be trying to modify your account without your
+permission.</p>
+
+<p>Your password won't change until you access the link above and create a
+   new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,19 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource,
+             as: resource_name,
+             url: password_path(resource_name),
+             html: { method: :post, class: 'pss-admin-form' }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions", class: 'form-submit' %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Log in</h2>
+
+<%= form_for(resource,
+             as: resource_name,
+             url: session_path(resource_name),
+             html: { class: 'pss-admin-form' }) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit "Log in", class: 'form-submit' %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,15 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,19 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource,
+             as: resource_name,
+             url: unlock_path(resource_name),
+             html: { method: :post, class: 'pss-admin-form' }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions", class: 'form-submit' %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -1,0 +1,34 @@
+<h2>Edit Account</h2>
+
+<% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+  <div>Currently awaiting confirmation for: <%= resource.unconfirmed_email %>
+  </div>
+<% end %>
+
+<%= devise_error_messages! %>
+
+<%# View for Devise method inherited by Registrations controller. %>
+<%# Uses `resource` for consistency with Devise::Registrations#new %>
+<%= form_for(resource,
+             as: resource_name,
+             url: registration_path(resource),
+             html: { class: 'pss-admin-form' }) do |f| %>
+
+  <%= f.label :email %><br />
+  <%= f.email_field :email, autofocus: true %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password, autocomplete: "off" %>
+  <div><i>(leave blank if you don't want to change it)</i></div>
+
+  <%= f.label :password_confirmation %><br />
+  <%= f.password_field :password_confirmation, autocomplete: "off" %>
+
+  <div>
+    <%= f.submit "Update", class: 'form-submit' %>
+  </div>
+
+<% end %>
+
+
+<%= link_to "Back", :back %>

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -1,0 +1,15 @@
+<h1>Admins</h1>
+
+<p><%= link_to "Create new admin", new_registration_path %></p>
+
+<table>
+<% @admins.each do |admin| %>
+  <tr>
+    <td><%= admin.email %></td>
+    <td><%= link_to "Edit", edit_registration_path(admin) %></td>
+    <td><%= link_to "Delete", registration_path(admin),
+                    method: :delete,
+                    data: { confirm: "Are you sure you want to delete #{admin.email}?" } %></td>
+  </tr>
+<% end %>
+</table>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,0 +1,17 @@
+<h2>Create Account</h2>
+
+<%= devise_error_messages! %>
+
+<%# View for Devise method inherited by Registrations controller. %>
+<%# Uses `resource` for consistency with Devise::Registrations#new %>
+<%= form_for(resource,
+             as: resource_name,
+             url: registrations_path(resource),
+             html: { class: 'pss-admin-form' }) do |f| %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email, autofocus: true %>
+
+  <%= f.submit "Create", class: 'form-submit' %>
+
+<% end %>

--- a/app/views/shared/_admin_menu.html.erb
+++ b/app/views/shared/_admin_menu.html.erb
@@ -1,4 +1,8 @@
 <div id='admin-menu'>
+  <%= link_to 'My Account', edit_registration_path(current_admin) %>
+  |
+  <%= link_to 'Administrators', registrations_path %>
+  |
   <%= link_to 'Sets', source_sets_path %>
   |
   <%= link_to 'Authors', authors_path %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,16 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = {
+    host: Settings.app_host,
+    script_name: Settings.relative_url_root,
+    protocol: Settings.app_scheme.tr(':/', '')
+  }
+  config.action_mailer.delivery_method =
+    Settings.action_mailer.delivery_method.to_sym
+  config.action_mailer.smtp_settings =
+    Settings.action_mailer.smtp_settings.to_h
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,16 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = {
+    host: Settings.app_host,
+    script_name: Settings.relative_url_root,
+    protocol: Settings.app_scheme.tr(':/', '')
+  }
+  config.action_mailer.delivery_method =
+    Settings.action_mailer.delivery_method.to_sym
+  config.action_mailer.smtp_settings =
+    Settings.action_mailer.smtp_settings.to_h
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -105,7 +105,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming their account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 0.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
@@ -113,7 +113,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 7.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,23 @@
 Rails.application.routes.draw do
-  devise_for :admins
+
+  # Devise-related routes that handle sessions and account confirmation...
+  devise_for :admins,
+             controllers: {confirmations: 'confirmations'},
+             skip: [:registrations]
+  as :admin do
+    patch '/admins/confirmation' => 'confirmations#update',
+          :via => :patch,
+          :as => :update_user_confirmation
+  end
+  authenticate :admin do
+    scope '/admins' do
+      devise_scope :admin do
+        resources :registrations,
+                  only: [:index, :create, :new, :edit, :update, :destroy]
+      end
+    end
+  end
+
   resources :sets, controller: 'source_sets', as: 'source_sets' do
     resources :sources, shallow: :true
     resources :guides, shallow: :true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -76,3 +76,13 @@ googleanalytics:
 contact_email: email@example.com
 
 display_tags_on_public_ui: false
+
+action_mailer:
+  delivery_method: smtp
+  smtp_settings:
+    host: localhost
+    # Port 1025 is for mailcatcher, in development.  This should probably be
+    # overridden in production if you use a SMTP daemon rather than the
+    # `sendmail' executable.  (I.e. the :smtp option for ActionMailer's
+    # `delivery_method'.)
+    port: 1025

--- a/db/migrate/20160113221031_add_confirmable_to_admin.rb
+++ b/db/migrate/20160113221031_add_confirmable_to_admin.rb
@@ -1,0 +1,20 @@
+class AddConfirmableToAdmin < ActiveRecord::Migration
+  def self.up
+    add_column :admins, :confirmation_token, :string
+    add_column :admins, :confirmed_at, :datetime
+    add_column :admins, :confirmation_sent_at, :datetime
+    add_column :admins, :unconfirmed_email, :string
+    add_index :admins, :confirmation_token, :unique => true
+
+    Admin.update_all({
+      :confirmed_at => DateTime.now,
+      :confirmation_sent_at => DateTime.now
+    })
+  end
+
+  def self.down
+    remove_column :admins,
+                  [:confirmation_token, :confirmed_at, :confirmation_sent_at,
+                   :unconfirmed_email]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,8 +26,13 @@ ActiveRecord::Schema.define(version: 20160114144803) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
   end
 
+  add_index "admins", ["confirmation_token"], name: "index_admins_on_confirmation_token", unique: true
   add_index "admins", ["email"], name: "index_admins_on_email", unique: true
   add_index "admins", ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+describe RegistrationsController, type: :controller do
+
+  let(:resource) { create(:unconfirmed_admin_factory) }
+  let(:attributes) { attributes_for(:unconfirmed_admin_factory) }
+  let(:invalid_attributes) { attributes_for(:invalid_admin_factory) }
+
+  context 'with manager logged in' do
+    login_admin
+    before do
+      # Controller extends Devise class.  Adjust routing.
+      request.env['devise.mapping'] = Devise.mappings[:admin]
+      # Stub confirmation emails.
+      allow_any_instance_of(Admin).to receive(:send_confirmation_instructions)
+      # Stub #set_minimum_password_length, which is a magical accessor method
+      # in the parent Devise::RegistrationsController, and works in the running
+      # app, but which is undefined in the spec test.
+      # @see https://github.com/plataformatec/devise/blob/v3.4.1/app/controllers/devise/registrations_controller.rb#L10
+      allow(subject).to receive(:set_minimum_password_length)
+    end
+
+    it_behaves_like 'basic controller', :index, :edit
+
+    # The "basic controller" shared example doesn't work due to email
+    # validation, thus we test #update here
+    describe '#update' do
+      let(:new_addr) { 'changed@example.org' }
+
+      it 'updates the email by setting it pending confirmation' do
+        patch :update, id: resource.id,
+                           admin: { email: 'changed@example.org' }
+        resource.reload
+        expect(resource.unconfirmed_email).to eq new_addr
+        # This is considered proof that the update happened.  Other fields
+        # like the confirmation token ones are expected to be covered by
+        # Devise's tests.
+      end
+
+      context 'with an invalid email address' do
+        it 'does not update the record' do
+          patch :update, id: resource.id, admin: { email: 'x' }
+          resource.reload
+          expect(resource.unconfirmed_email).not_to eq('x')
+        end
+        it 're-renders the :edit view' do
+          patch :update, id: resource.id, admin: { email: 'x' }
+          expect(response).to render_template :edit
+        end
+      end
+    end
+
+    # The "basic controller" shared example doesn't work due to the redirect
+    # situation described below.
+    describe '#destroy' do
+      it 'deletes the resource' do
+        resource
+        expect do
+          delete :destroy, id: resource.id
+        end.to change(resource.class, :count).by(-1)
+      end
+
+      # The redirect below is to registrations_path instead of
+      # admins_path, which is what "basic controller" example would do
+      it 'redirects to the registrations (admins) page' do
+        resource
+        delete :destroy, id: resource.id
+        expect(response).to redirect_to registrations_path
+      end
+    end
+
+    # This is like the "redirecting controller" example but it has to
+    # redirect to registrations_path instead of the nonexistent admins_path.
+    describe '#create' do
+      before(:each) do
+        Admin.destroy(Admin.find(resource.id)) if
+          Admin.where(id: resource.id).present?
+      end
+
+      it 'creates a new resource' do
+        count = resource.class.count
+        post :create, admin: attributes
+        expect(resource.class.count).to eq(count + 1)
+      end
+
+      it 'redirects to the new registrations (admins) listing' do
+        post :create, { admin: attributes }
+        expect(response).to redirect_to registrations_path
+      end
+
+      context 'with invalid attributes' do
+        it 'does not save new resource' do
+          expect do
+            post :create, admin: invalid_attributes
+          end.to change(Admin, :count).by(0)
+        end
+        it 're-renders the :new view' do
+          post :create, { admin: invalid_attributes }
+          expect(response).to render_template :new
+        end
+      end
+    end
+
+    describe '#edit' do
+      it 'renders the :edit view' do
+        get :edit, id: resource.id
+        expect(response).to render_template :edit
+      end
+    end
+  end
+
+  # TODO: when permissions and roles are added:
+  # context 'with non-manager logged in' do
+  # end
+end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,6 +1,28 @@
 FactoryGirl.define do
-  factory :admin do
+  factory :admin, class: Admin do
     email 'test@example.org'
     password 'password'
+    confirmed_at DateTime.now
+    confirmation_sent_at DateTime.now
+  end
+
+  factory :existing_admin_factory, class: Admin do
+    email 'test2@example.org'
+    encrypted_password '$2a$04$1Za0y3arNrlTBH7geX2qXeTQAqFGOkKK9VWh/K9LmT1eG3ZWB/rfC'
+    confirmed_at DateTime.now
+    confirmation_sent_at DateTime.now
+  end
+
+  factory :brandnew_admin_factory, class: Admin do
+    skip_create
+    email 'test3@example.org'
+  end
+
+  factory :unconfirmed_admin_factory, class: Admin do
+    email 'test4@example.org'
+  end
+
+  factory :invalid_admin_factory, class: Admin do
+    email 'x'
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe Admin, type: :model do
+
+  context 'with a saved, confirmed record' do
+    let(:existing_admin) { create(:existing_admin_factory) }
+
+    context 'where it IS NOT having password fields updated' do
+      it 'determines that the password does not need to be validated' do
+        expect(existing_admin.password_required?).to eq false
+      end
+    end
+
+    context 'where it IS having its password updated' do
+      it 'requires the password to be validated' do
+        existing_admin.password = 'x'
+        expect(existing_admin.password_required?).to eq true
+      end
+    end
+
+    it 'reports correctly whether it has a password saved' do
+      expect(existing_admin.has_no_password?).to eq false
+    end
+
+    it 'reports that it has been confirmed' do
+      expect(existing_admin.only_if_unconfirmed { 'yes' }).not_to eq 'yes'
+    end
+  end
+
+  context 'with a saved yet unconfirmed record' do
+    before do
+      # Stub confirmation email; see below
+      allow_any_instance_of(Admin).to receive(:send_confirmation_instructions)
+    end
+
+    it 'reports that it has not been confirmed' do
+      # Do not use a fixture. A fixture would save the record and cause the
+      # email call to be made, before we can stub it above.
+      a = Admin.new(email: 'testunconfirmed@example.org')
+      a.save
+      expect(a.only_if_unconfirmed {'yes'}).to eq 'yes'
+    end
+  end
+
+  context 'where the record has not been saved' do
+    let(:brandnew_admin) { create(:brandnew_admin_factory) }
+
+    it 'does not require the password to be validated yet' do
+      expect(brandnew_admin.password_required?).to eq false
+    end
+  end
+
+  it 'attempts to set the password with the correct parameters' do
+    admin = Admin.new(email: 'testsetpw@example.org')
+    pw = 'thepassword'
+    pc = 'theconfirmation'
+    params = {
+      this: 'x',
+      that: 'y',
+      password: pw,
+      password_confirmation: pc
+    }
+    expect(admin).to receive(:update_attributes)
+                 .with({password: pw, password_confirmation: pc})
+    admin.attempt_set_password(params)
+  end
+end

--- a/spec/support/shared_examples/basic_controller.rb
+++ b/spec/support/shared_examples/basic_controller.rb
@@ -19,7 +19,7 @@ shared_examples 'basic controller' do |*actions|
       it 'sets resources variable' do
         get :index
         expect(assigns(resource.class.name.pluralize.underscore.to_sym))
-          .to eq([resource])
+          .to include(resource)
       end
 
       it 'renders the :index view' do
@@ -47,15 +47,15 @@ shared_examples 'basic controller' do |*actions|
 
   if actions.include? :create
     describe '#create' do
-
       it 'creates a new resource' do
-        expect do
-          post :create, resource_sym => attributes
-        end.to change(resource.class, :count).by(1)
+        # Can not use expect ... .to change(...).by(1) below.
+        # Might be related to using login_admin in some enclosing contexts.
+        count = resource.class.count
+        post :create, resource_sym => attributes
+        expect(resource.class.count).to eq(count + 1)
       end
 
       context 'with invalid attributes' do
-
         it 'does not save new resource' do
           expect do
             post :create, resource_sym => invalid_attributes


### PR DESCRIPTION
Add account management, mostly using Devise, and overriding some of its default behavior.

Accounts are only created by admins. When the account is created, an email is sent to the new account's address for confirmation. During confirmation, the new user must set a password.

README.md contains some notes about setting up `mailcatcher` for development with confirmation emails.

References https://issues.dp.la/issues/8162

Possible TODO:  Add a full-name field to Admin.