### PR TITLE
link Primary Source Sets header

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -49,6 +49,15 @@
 
 /* SourceSets index styles */
 
+.all-sets h1 a:link,
+.all-sets h1 a:hover {
+  color: #4691b9;
+}
+
+.all-sets h1 a:hover {
+  text-decoration: none;
+}
+
 .all-sets .resultsBar {
   clear: both;
 }

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -18,7 +18,7 @@
 
 <div class='all-sets'>
 
-  <h1>Primary Source Sets</h1>
+  <h1><%= link_to 'Primary Source Sets', source_sets_path %></h1>
 
   <p>DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources. Each set includes an overview, ten to fifteen primary sources, links to related resources, and a teaching guide. These sets were created and reviewed by the teachers on the DPLA's <%= link_to 'Education Advisory Committee', wordpress_path('education/education-advisory-committee') %>. We will be adding new sets and features through Spring 2016. Read about our <%= link_to 'education projects', wordpress_path('education') %> and contact us with feedback at <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
 


### PR DESCRIPTION
On the `source_sets#index view`, link the "Primary Source Sets" header to `source_sets#index` without any order/filter parameters. This will serve as an "out" for users who become confused by the order/filter options. 

This feature was requested by Franky.  It addresses [ticket #8242](https://issues.dp.la/issues/8242).