### PR TITLE
Add permissions system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 's3_browser_uploads', '0.1.2'
 gem 'zencoder', '~>2.5'
 gem 'navigasmic', '~>1.0'
 gem 'turnout', '~>2.0'
+gem 'access-granted', '~> 1.0.0'
 
 group :test, :development do
   gem 'rspec-core', '~> 3.3.2'

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -335,6 +335,26 @@ input.form-submit {
   width: 99%;
 }
 
+.pss-admin-form fieldset {
+  margin-bottom: 1em;
+}
+
+.pss-admin-form-comment {
+  margin: -.5em 0 .5em .5em;
+}
+.pss-admin-form-doc {
+  width: 50%;
+  margin-left: .5em;
+}
+
+.status-buttons label {
+  display: inline;
+  margin-right: .5em;
+}
+.status-buttons input {
+  margin-left: .2em;
+}
+
 .primary-source-sets fieldset {
   border: none;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,35 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  rescue_from AccessGranted::AccessDenied do |exception|
+    redirect_to new_admin_session_path
+  end
+
+  ##
+  # `access-granted' is hardcoded to get the logged-in account with a call
+  # to #current_user.  We name our model Admin, so we have to make a shim.
+  def current_user
+    current_admin
+  end
+
+  ##
+  # Provide a way to check that the user is logged-in and then check the
+  # permissions only if this is the case and current_admin returns non-nil.
+  #
+  # If you just do `authorize!' without the user being logged-in you'll get
+  # an exception.
+  #
+  # We have actions where the permissions should only be checked
+  # if the resource is unpublished.
+  #
+  # @see AccessGranted::Rails::ControllerMethods#authorize!
+  def check_login_and_authorize(*args)
+    if admin_signed_in?
+      authorize! *args
+    else
+      flash[:alert] = 'You need to be signed in to see that page.'
+      redirect_to new_admin_session_path
+    end
+  end
 end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -15,20 +15,24 @@ class GuidesController < ApplicationController
 
   def show
     @guide = Guide.friendly.find(params[:id])
+    check_login_and_authorize(:read, Guide) unless @guide.source_set.published?
     add_breadcrumb inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set)
     add_breadcrumb 'Guide', guide_path(@guide)
   end
 
   def new
     @guide = @source_set.guides.new
+    authorize! :create, Guide
   end
 
   def edit
     @guide = Guide.friendly.find(params[:id])
+    authorize! :update, Guide
   end
 
   def create
     @guide = @source_set.guides.new(guide_params)
+    authorize! :create, Guide
 
     if @guide.save
       redirect_to @guide
@@ -39,6 +43,7 @@ class GuidesController < ApplicationController
 
   def update
     @guide = Guide.friendly.find(params[:id])
+    authorize! :update, Guide
 
     if @guide.update(guide_params)
       redirect_to @guide
@@ -49,6 +54,7 @@ class GuidesController < ApplicationController
 
   def destroy
     @guide = Guide.friendly.find(params[:id])
+    authorize! :destroy, Guide
     @guide.destroy
 
     redirect_to @guide.source_set

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,14 +2,22 @@
 class RegistrationsController < Devise::RegistrationsController
   skip_before_action :require_no_authentication
   before_action :authenticate_admin!
+  before_action :configure_permitted_parameters
 
   ##
   # New #index method not defined in Devise::RegistrationsController
   def index
+    authorize! :read, Admin
     @admins = Admin.all
   end
 
+  def new
+    authorize! :create, Admin
+    super
+  end
+
   def create
+    authorize! :create, Admin
     build_resource(sign_up_params)
     resource.save
     yield resource if block_given?
@@ -23,16 +31,17 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def edit
+    authorize! :update, Admin unless current_admin.id == params[:id].to_i
     @admin = Admin.find(params[:id])
   end
 
   ##
   # @see Devise::RegistrationsController#update
   def update
+    authorize! :update, Admin unless current_admin.id == params[:id].to_i
     self.resource = Admin.find(params[:id])
     prev_unconfirmed_email = resource.unconfirmed_email \
       if resource.respond_to?(:unconfirmed_email)
-
     resource_updated = update_resource(resource, account_update_params)
     yield resource if block_given?
     if resource_updated
@@ -50,6 +59,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def destroy
+    authorize! :destroy, Admin
     @admin = Admin.find(params[:id])
     @admin.destroy
     redirect_to registrations_path    
@@ -59,5 +69,9 @@ class RegistrationsController < Devise::RegistrationsController
 
   def update_resource(resource, params)
     resource.update_without_password(params)
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:account_update) << :status
   end
 end

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -5,7 +5,8 @@
 class SourceSetsController < ApplicationController
   include MarkdownHelper
   add_breadcrumb 'Primary Source Sets', :root_path
-  before_action :authenticate_admin!, only: [:new, :edit]
+  before_action :authenticate_admin!,
+                only: [:new, :edit, :create, :update, :destroy]
 
   def index
     @tags = get_tags_from_params
@@ -17,19 +18,23 @@ class SourceSetsController < ApplicationController
 
   def show
     @source_set = SourceSet.friendly.find(params[:id])
+    check_login_and_authorize(:read, SourceSet) unless @source_set.published?
     add_breadcrumb inline_markdown(@source_set.name), source_set_path(@source_set)
   end
 
   def new
     @source_set = SourceSet.new
+    authorize! :create, SourceSet
   end
 
   def edit
     @source_set = SourceSet.friendly.find(params[:id])
+    authorize! :update, SourceSet
   end
 
   def create
     @source_set = SourceSet.new(source_set_params)
+    authorize! :create, SourceSet
 
     if @source_set.save
       redirect_to @source_set
@@ -40,6 +45,7 @@ class SourceSetsController < ApplicationController
 
   def update
     @source_set = SourceSet.friendly.find(params[:id])
+    authorize! :update, SourceSet
 
     if @source_set.update(source_set_params)
       redirect_to @source_set
@@ -50,6 +56,7 @@ class SourceSetsController < ApplicationController
 
   def destroy
     @source_set = SourceSet.friendly.find(params[:id])
+    authorize! :destroy, SourceSet
     @source_set.destroy
 
     redirect_to source_sets_path

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -7,7 +7,8 @@ class SourcesController < ApplicationController
   include AudioPlayerHelper
   include MarkdownHelper
   before_filter :load_source_set, only: [:index, :new, :create]
-  before_action :authenticate_admin!, only: [:new, :edit]
+  before_action :authenticate_admin!,
+                only: [:new, :edit, :create, :update, :destroy]
   add_breadcrumb 'Primary Source Sets', :root_path
 
   def index
@@ -16,6 +17,8 @@ class SourcesController < ApplicationController
 
   def show
     @source = Source.find(params[:id])
+    check_login_and_authorize(:read, Source) \
+      unless @source.source_set.published?
     add_breadcrumb inline_markdown(@source.source_set.name), source_set_path(@source.source_set)
     add_breadcrumb 'Source', source_path(@source)
     ma = @source.main_asset
@@ -29,14 +32,17 @@ class SourcesController < ApplicationController
 
   def new
     @source = @source_set.sources.new
+    authorize! :create, Source
   end
 
   def edit
     @source = Source.find(params[:id])
+    authorize! :update, Source
   end
 
   def create
     @source = @source_set.sources.new(source_params)
+    authorize! :create, Source
 
     if @source.save
       redirect_to @source
@@ -47,6 +53,7 @@ class SourcesController < ApplicationController
 
   def update
     @source = Source.find(params[:id])
+    authorize! :update, Source
 
     if @source.update(source_params)
       redirect_to @source
@@ -57,6 +64,7 @@ class SourcesController < ApplicationController
 
   def destroy
     @source = Source.find(params[:id])
+    authorize! :destroy, Source
     @source.destroy
 
     redirect_to @source.source_set

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -11,6 +11,8 @@ class Admin < ActiveRecord::Base
   devise :database_authenticatable, :trackable, :validatable, :confirmable,
          :recoverable, :registerable
 
+  enum status: [:reviewer, :editor, :manager]
+
   ##
   # Determine whether to validate the presence of the password.
   #

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -1,0 +1,51 @@
+class AccessPolicy
+  include AccessGranted::Policy
+
+  def configure
+    # Roles are defined in top-to-bottom order, with the highest-privileged
+    # role at the top, inheriting permissions from those below.
+
+    # Example policy for AccessGranted.
+    # For more details check the README at
+    #
+    # https://github.com/chaps-io/access-granted/blob/master/README.md
+    #
+
+    role :manager, proc { |admin| admin.manager? } do
+      can :manage, Admin
+      can :manage, Source
+      can :manage, Guide
+      can :manage, SourceSet
+      can :manage, Image
+      can :manage, Video
+      can :manage, Audio
+      can :manage, Document
+      can :manage, Tag
+      can :manage, Vocabulary
+      can :manage, Author
+    end
+
+    role :editor, proc { |admin| admin.editor? } do
+      can :manage, Source
+      can :manage, Guide
+      can :manage, SourceSet
+      can :manage, Image
+      can :manage, Video
+      can :manage, Audio
+      can :manage, Document
+      can :manage, Tag
+      can :manage, Vocabulary
+      can :manage, Author
+    end
+
+    role :reviewer, proc { |admin| admin.reviewer? } do
+      can :read, Source
+      can :read, Guide
+      can :read, SourceSet
+    end
+  end
+
+  def self.can_manage_content
+  end
+
+end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,9 @@
 <h2>Log in</h2>
 
+<% if flash[:alert] %>
+<div class="flash-alert"><%= flash[:alert] %></div>
+<% end %>
+
 <%= form_for(resource,
              as: resource_name,
              url: session_path(resource_name),

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -14,15 +14,55 @@
              url: registration_path(resource),
              html: { class: 'pss-admin-form' }) do |f| %>
 
-  <%= f.label :email %><br />
-  <%= f.email_field :email, autofocus: true %>
+  <fieldset>
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </fieldset>
 
-  <%= f.label :password %>
-  <%= f.password_field :password, autocomplete: "off" %>
-  <div><i>(leave blank if you don't want to change it)</i></div>
+  <% if current_admin.id == resource.id %>
+  <fieldset>
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: "off" %>
+    <div class="pss-admin-form-comment">
+      <i>(leave blank if you don't want to change it)</i>
+    </div>
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </fieldset>
+  <% else %>
+  <p class="pss-admin-form-doc">
+    To change the password, direct the user to go to the
+    password reset page at
+    <%= Settings.app_scheme + Settings.app_host + new_admin_password_path %>
+  </p>
+  <% end %>
 
-  <%= f.label :password_confirmation %><br />
-  <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  <% if current_admin.manager? %>
+  <fieldset class="status-buttons">
+    <legend>Status</legend>
+    <%= f.radio_button :status, :reviewer,
+                       checked: resource.status == 'reviewer' %>
+    <%= f.label :status_reviewer, "reviewer" %>
+    <%= f.radio_button :status, :editor,
+                       checked: resource.status == 'editor' %>
+    <%= f.label :status_editor, "editor" %>
+    <%= f.radio_button :status, :manager,
+                       checked: resource.status == 'manager' %>
+    <%= f.label :status_manager, "manager" %>
+
+    <dl class="pss-admin-form-doc">
+      <dt><dfn>Reviewer</dfn></dt>
+      <dd>May view all content, including unpublished pages.</dt>
+      <dt><dfn>Editor</dfn></dt>
+      <dd>In addition to above privileges, may create, modify, and delete
+          content.</dd>
+      <dt><dfn>Manager</dfn></dt>
+      <dd>In addition to above privileges, may create, modify, and delete
+          accounts.</dd>
+    </dl>
+
+  </fieldset>
+  <% end %>
 
   <div>
     <%= f.submit "Update", class: 'form-submit' %>

--- a/app/views/shared/_admin_menu.html.erb
+++ b/app/views/shared/_admin_menu.html.erb
@@ -1,23 +1,51 @@
 <div id='admin-menu'>
   <%= link_to 'My Account', edit_registration_path(current_admin) %>
+
+  <% if can? :read, Admin %>
   |
   <%= link_to 'Administrators', registrations_path %>
+  <% end %>
+
+  <% if can? :read, SourceSet %>
   |
   <%= link_to 'Sets', source_sets_path %>
+  <% end %>
+
+  <% if can? :read, Author %>
   |
   <%= link_to 'Authors', authors_path %>
+  <% end %>
+
+  <% if can? :read, Image %>
   |
   <%= link_to 'Images', images_path %>
+  <% end %>
+
+  <% if can? :read, Audio %>
   |
   <%= link_to 'Audios', audios_path %>
+  <% end %>
+
+  <% if can? :read, Video %>
   |
   <%= link_to 'Videos', videos_path %>
+  <% end %>
+
+  <% if can? :read, Document %>
   |
   <%= link_to 'Documents', documents_path %>
+  <% end %>
+
+  <% if can? :read, Tag %>
   |
   <%= link_to 'Tags', tags_path %>
+  <% end %>
+
+  <% if can? :read, Vocabulary %>
   |
   <%= link_to 'Vocabularies', vocabularies_path %>
+  <% end %>
+
   |
   <%= link_to 'Log out', destroy_admin_session_path, method: :delete %>
   </ul>

--- a/db/migrate/20160119215143_add_status_to_admin.rb
+++ b/db/migrate/20160119215143_add_status_to_admin.rb
@@ -1,0 +1,10 @@
+class AddStatusToAdmin < ActiveRecord::Migration
+  def self.up
+    add_column :admins, :status, :integer, default: 0
+    Admin.update_all({status: 2})
+  end
+
+  def self.down
+    remove_column :admins, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160114144803) do
+ActiveRecord::Schema.define(version: 20160119215143) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20160114144803) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
+    t.integer  "status",                 default: 0
   end
 
   add_index "admins", ["confirmation_token"], name: "index_admins_on_confirmation_token", unique: true

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -5,15 +5,41 @@ describe GuidesController, type: :controller do
   let(:resource) { create(:guide_factory) }
   let(:attributes) { attributes_for(:guide_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_guide_factory) }
-  let(:parent) { resource.source_set }
+  let(:parent_model) { resource.source_set }
 
   it_behaves_like 'admin-only route', :new, :edit
 
-  context 'admin logged in' do
+  context 'with the user logged-in' do
     login_admin
 
     it_behaves_like 'basic controller', :show, :update
     it_behaves_like 'nested controller', :index, :create, :destroy
     it_behaves_like 'redirecting controller', :create
+  end
+
+  context 'with the user not logged-in' do
+
+    it_behaves_like 'anonymous user redirector',
+      :new, :edit, :create, :update, :destroy
+
+    describe '#show' do
+
+      context 'with a guide belonging to an unpublished set' do
+        it 'redirects to the sign-in page' do
+          get :show, id: resource.id
+          expect(response).to redirect_to new_admin_session_path
+        end
+      end
+
+      context 'with a guide belonging to a published set' do
+        let(:published_guide) { create(:published_guide_factory) }
+
+        it 'shows the guide' do
+          get :show, id: published_guide.id
+          expect(response).to render_template :show
+        end
+      end
+
+    end
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -37,6 +37,13 @@ describe RegistrationsController, type: :controller do
         # Devise's tests.
       end
 
+      it 'updates the status' do
+        patch :update, id: resource.id,
+              admin: { status: 'manager' }
+        resource.reload
+        expect(resource.status).to eq 'manager'
+      end
+
       context 'with an invalid email address' do
         it 'does not update the record' do
           patch :update, id: resource.id, admin: { email: 'x' }

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -9,7 +9,7 @@ describe SourceSetsController, type: :controller do
 
   it_behaves_like 'admin-only route', :edit, :new
 
-  context 'admin logged in' do
+  context 'with the user logged-in' do
     login_admin
 
     it_behaves_like 'basic controller', :show, :create, :update, :destroy
@@ -66,6 +66,32 @@ describe SourceSetsController, type: :controller do
         get :index
         expect(response).to render_template :index
       end
+    end
+  end
+
+  context 'with the user not logged-in' do
+
+    it_behaves_like 'anonymous user redirector',
+      :new, :edit, :create, :update, :destroy
+
+    describe '#show' do
+
+      context 'with an unpublished set' do
+        it 'redirects to the sign-in page' do
+          get :show, id: resource.id
+          expect(response).to redirect_to new_admin_session_path
+        end
+      end
+
+      context 'with a published set' do
+        let(:published_set) { create(:published_source_set_factory) }
+
+        it 'shows the set' do
+          get :show, id: published_set.id
+          expect(response).to render_template :show
+        end
+      end
+
     end
   end
 end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -5,11 +5,11 @@ describe SourcesController, type: :controller do
   let(:resource) { create(:source_factory) }
   let(:attributes) { attributes_for(:source_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_source_factory) }
-  let(:parent) { resource.source_set }
+  let(:parent_model) { resource.source_set }
 
   it_behaves_like 'admin-only route', :new, :edit
 
-  context 'admin logged in' do
+  context 'with the user logged-in' do
     login_admin
 
     # FIXME: tests in 'basic controller' need to have mocks for
@@ -18,4 +18,30 @@ describe SourcesController, type: :controller do
     it_behaves_like 'nested controller', :index, :create, :destroy
     it_behaves_like 'redirecting controller', :create
   end
+
+  context 'with the user not logged-in' do
+
+    include_examples 'anonymous user redirector',
+      :new, :edit, :create, :update, :destroy
+
+    describe '#show' do
+
+      context 'with a source belonging to an unpublished set' do
+        it 'redirects to the sign-in page' do
+          get :show, id: resource.id
+          expect(response).to redirect_to new_admin_session_path
+        end
+      end
+
+      context 'with a source belonging to a published set' do
+        let(:published_source) { create(:published_source_factory) }
+
+        it 'shows the source' do
+          get :show, id: published_source.id
+          expect(response).to render_template :show
+        end
+      end
+    end
+  end
+
 end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,25 +1,37 @@
 FactoryGirl.define do
-  factory :admin, class: Admin do
-    email 'test@example.org'
-    password 'password'
-    confirmed_at DateTime.now
-    confirmation_sent_at DateTime.now
-  end
-
-  factory :existing_admin_factory, class: Admin do
-    email 'test2@example.org'
+  factory :admin_factory, class: Admin do
+    email 'test1@example.org'
     encrypted_password '$2a$04$1Za0y3arNrlTBH7geX2qXeTQAqFGOkKK9VWh/K9LmT1eG3ZWB/rfC'
     confirmed_at DateTime.now
     confirmation_sent_at DateTime.now
+    status 2
   end
 
   factory :brandnew_admin_factory, class: Admin do
     skip_create
-    email 'test3@example.org'
+    email 'test2@example.org'
+    status 0
   end
 
   factory :unconfirmed_admin_factory, class: Admin do
+    email 'test3@example.org'
+    status 0
+  end
+
+  factory :reviewer_admin_factory, class: Admin do
     email 'test4@example.org'
+    encrypted_password '$2a$04$1Za0y3arNrlTBH7geX2qXeTQAqFGOkKK9VWh/K9LmT1eG3ZWB/rfC'
+    confirmed_at DateTime.now
+    confirmation_sent_at DateTime.now
+    status 0
+  end
+
+  factory :editor_admin_factory, class: Admin do
+    email 'test5@example.org'
+    encrypted_password '$2a$04$1Za0y3arNrlTBH7geX2qXeTQAqFGOkKK9VWh/K9LmT1eG3ZWB/rfC'
+    confirmed_at DateTime.now
+    confirmation_sent_at DateTime.now
+    status 1
   end
 
   factory :invalid_admin_factory, class: Admin do

--- a/spec/factories/guides.rb
+++ b/spec/factories/guides.rb
@@ -9,4 +9,11 @@ FactoryGirl.define do
   factory :invalid_guide_factory, class: Guide do
     name nil
   end
+
+  factory :published_guide_factory, class: Guide do
+    name 'Contemplating Guides'
+    questions 'What makes this guide such a joy to follow?'
+    activity 'Praise the author of this test guide.'
+    association :source_set, factory: :published_source_set_factory
+  end
 end

--- a/spec/factories/source_sets.rb
+++ b/spec/factories/source_sets.rb
@@ -8,6 +8,15 @@ FactoryGirl.define do
     published false
   end
 
+  factory :published_source_set_factory, class: SourceSet do
+    name "A Wizard's Job"
+    description 'This set explores the use of panagrams in 21st-Century America'
+    overview "A wizard's job is to vex chumps quickly in fog."
+    resources 'Here are some additional resources for your consideration.'
+    year 2016
+    published true
+  end
+
   factory :invalid_source_set_factory, class: SourceSet do
     name nil
   end

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -12,4 +12,14 @@ FactoryGirl.define do
   factory :invalid_source_factory, class: Source do
     aggregation nil
   end
+
+  factory :published_source_factory, class: Source do
+    name 'The Quandary'
+    aggregation 'c3702b42c7e3daf5aafe47151184ba33'
+    textual_content 'Flummoxed by job, kvetching W. zaps Iraq.'
+    citation 'As Seen on TV'
+    credits 'By Thomas H. Ince'
+    featured false
+    association :source_set, factory: :published_source_set_factory
+  end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Admin, type: :model do
 
   context 'with a saved, confirmed record' do
-    let(:existing_admin) { create(:existing_admin_factory) }
+    let(:existing_admin) { create(:admin_factory) }
 
     context 'where it IS NOT having password fields updated' do
       it 'determines that the password does not need to be validated' do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,7 +2,7 @@
 module ControllerMacros
   def login_admin
     before(:each) do
-      admin = FactoryGirl.create(:admin)
+      admin = FactoryGirl.create(:admin_factory)
       sign_in admin
     end
   end

--- a/spec/support/shared_examples/admin_only_route.rb
+++ b/spec/support/shared_examples/admin_only_route.rb
@@ -7,15 +7,15 @@
 # This assumes the following variable have been defined in the controller spec,
 # or are passed as a block to this example:
 #   :resource
-#   :parent (optional)
+#   :parent_model (optional)
 #
 shared_examples 'admin-only route' do |*actions|
 
   let(:params) do
     params = { id: resource.id }
-    if defined?(parent)
-      params.merge!({ "#{parent.class.name.underscore}_id".to_sym =>
-        parent.id })
+    if defined?(parent_model)
+      params.merge!({ "#{parent_model.class.name.underscore}_id".to_sym =>
+        parent_model.id })
     end
     params
   end

--- a/spec/support/shared_examples/anon_user_redirects.rb
+++ b/spec/support/shared_examples/anon_user_redirects.rb
@@ -1,0 +1,43 @@
+
+##
+# Examples for methods that should redirect to the login page if requested
+# by a user that it unauthenticated.
+#
+shared_examples 'anonymous user redirector' do |*actions|
+
+  let(:resource_sym) { resource.class.name.underscore.to_sym }
+  let(:signin_url) { "#{Settings.relative_url_root}#{new_admin_session_path}" }
+
+  if actions.include? :create
+    describe '#create' do
+      it 'redirects to the sign-in page' do
+        if defined?(parent_model)
+          parent_id_sym = "#{parent_model.class.name.underscore}_id".to_sym
+          post :create, parent_id_sym => parent_model.id,
+                        resource_sym => attributes
+        else
+          post :create, resource_sym => attributes
+        end
+        expect(response).to redirect_to signin_url
+      end
+    end
+  end
+
+  if actions.include? :update
+    describe '#update' do
+      it 'redirects to the sign-in page' do
+        patch :update, id: resource.id, foo: 'bar'
+        expect(response).to redirect_to signin_url
+      end
+    end
+  end
+
+  if actions.include? :destroy
+    describe '#destroy' do
+      it 'redirects to the sign-in page' do
+        delete :destroy, id: resource.id
+        expect(response).to redirect_to signin_url
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/nested_controller.rb
+++ b/spec/support/shared_examples/nested_controller.rb
@@ -7,21 +7,21 @@
 # This assumes the following variable have been defined in the controller spec,
 # or are passed as a block to this example:
 #   :resource
-#   :parent
+#   :parent_model
 #   :attributes (:create only)
 #   :invalid_attributes (:create only)
 #
 shared_examples 'nested controller' do |*actions|
 
   let(:resource_sym) { resource.class.name.downcase.to_sym }
-  let(:parent_id_sym) { "#{parent.class.name.underscore}_id".to_sym }
+  let(:parent_id_sym) { "#{parent_model.class.name.underscore}_id".to_sym }
 
   if actions.include? :index
     describe '#index' do
 
       it 'redirects to parent' do
-        get :index, parent_id_sym => parent.id
-        expect(response).to redirect_to parent
+        get :index, parent_id_sym => parent_model.id
+        expect(response).to redirect_to parent_model
       end
     end
   end
@@ -30,14 +30,14 @@ shared_examples 'nested controller' do |*actions|
     describe '#create' do
 
       before(:each) do
-        parent
+        parent_model
         resource.class.destroy(resource.class.find(resource.id)) if
           resource.class.where(id: resource.id).present?
       end
 
       it 'creates a new resource' do
         expect do
-          post :create, parent_id_sym => parent.id,
+          post :create, parent_id_sym => parent_model.id,
                         resource_sym => attributes
         end.to change(resource.class, :count).by(1)
       end
@@ -46,7 +46,7 @@ shared_examples 'nested controller' do |*actions|
 
         it 'does not save new resource' do
           expect do
-            post :create, parent_id_sym => parent.id,
+            post :create, parent_id_sym => parent_model.id,
                           resource_sym => invalid_attributes
           end.to change(resource.class, :count).by(0)
         end
@@ -67,7 +67,7 @@ shared_examples 'nested controller' do |*actions|
       it 'redirects to parent' do
         resource
         delete :destroy, id: resource.id
-        expect(response).to redirect_to parent
+        expect(response).to redirect_to parent_model
       end
     end
   end

--- a/spec/support/shared_examples/redirecting_controller.rb
+++ b/spec/support/shared_examples/redirecting_controller.rb
@@ -7,7 +7,7 @@
 # This assumes the following variable have been defined in the controller spec,
 # or are passed as a block to this example:
 #   :resource
-#   :parent (optional for nested controllers)
+#   :parent_model (optional for nested controllers)
 #   :attributes
 #   :invalid_attributes
 #
@@ -16,8 +16,8 @@ shared_examples 'redirecting controller' do |*actions|
 
   let(:params) do
     params = { resource_sym => attributes }
-    params["#{parent.class.name.underscore}_id".to_sym] = parent.id if
-      defined?(parent)
+    params["#{parent_model.class.name.underscore}_id".to_sym] =
+      parent_model.id if defined?(parent_model)
     params
   end
 


### PR DESCRIPTION
Add a permissions system, with administrator roles.

See https://issues.dp.la/issues/8163

The specification was to add a class of view-only users (who can view unpublished sets, but not modify or create them), and a permissions system is necessary to achieve this.
