### PR TITLE
fix anchor style

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -49,7 +49,7 @@
 
 /* SourceSets index styles */
 
-.all-sets h1 a:link,
+.all-sets h1 a,
 .all-sets h1 a:hover {
   color: #4691b9;
 }


### PR DESCRIPTION
This fixes a CSS mistake introduced in PR#107.  The mistake caused the `h1` element on `source_sets#index`, "Primary Source Sets", to be orange instead of blue.  This was due to a declaration elsewhere in the CSS making all `a` elements orange.  Changing the declaration here from `a:link` to `a` ensures that `h1` will be blue.  This branch has been deployed to staging.