### PR TITLE
remove obsolete tag setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -75,8 +75,6 @@ googleanalytics:
 
 contact_email: email@example.com
 
-display_tags_on_public_ui: false
-
 action_mailer:
   delivery_method: smtp
   smtp_settings:


### PR DESCRIPTION
This removes an obsolete setting from `Settings.yml`.  

This setting helped us to transition to tagging system without in coordination with admins' workflow.  It was used to hide tags from the public until admins had entered all the tag data into the database.  Since then, we have added functionality that allows admins to control which tags are displayed to public users.  All uses of the `display_tags_on_public_ui` setting were removed in [PR#105](https://github.com/dpla/primary-source-sets/pull/105).

This addresses [ticket #8246](https://issues.dp.la/issues/8246).

It relates to [automation PR#147](https://github.com/dpla/automation/pull/147) and [aws PR#35](https://github.com/dpla/aws/pull/35/files).