### PR TITLE
rename publish methods and remove un-needed self statement

### DIFF
--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -11,9 +11,8 @@ class SourceSetsController < ApplicationController
   def index
     @tags = get_tags_from_params
     @order = params[:order]
-    @published_sets = SourceSet.published_sets.order_by(@order).with_tags(@tags)
-    @unpublished_sets = SourceSet.unpublished_sets.order_by(@order)
-                                 .with_tags(@tags)
+    @published_sets = SourceSet.published.order_by(@order).with_tags(@tags)
+    @unpublished_sets = SourceSet.unpublished.order_by(@order).with_tags(@tags)
   end
 
   def show

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -24,12 +24,12 @@ class SourceSet < ActiveRecord::Base
     small_images.first
   end
 
-  def self.published_sets
-    self.where(published: true)
+  def self.published
+    where(published: true)
   end
 
-  def self.unpublished_sets
-    self.where(published: false)
+  def self.unpublished
+    where(published: false)
   end
 
   ##

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -13,7 +13,7 @@
 <% if admin_signed_in? %>
   <% filters = filters_for_sets(SourceSet.all) %>
 <% else %>
-  <% filters = filters_for_sets(SourceSet.published_sets) %>
+  <% filters = filters_for_sets(@published_sets) %>
 <% end %>
 
 <div class='all-sets'>

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -71,15 +71,15 @@ describe SourceSet, type: :model do
     end
   end
 
-  describe '#published_sets' do
+  describe '#published' do
     it 'returns published sets' do
-      expect(SourceSet.published_sets).to contain_exactly(published_set)
+      expect(SourceSet.published).to contain_exactly(published_set)
     end
   end
 
-  describe '#unpublished_sets' do
+  describe '#unpublished' do
     it 'returns unpublished sets' do
-      expect(SourceSet.unpublished_sets).to contain_exactly(source_set)
+      expect(SourceSet.unpublished).to contain_exactly(source_set)
     end
   end
 
@@ -99,8 +99,8 @@ describe SourceSet, type: :model do
           .to contain_exactly(published_set)
       end
 
-      it 'works in conjuction with published_sets' do
-        expect(SourceSet.published_sets.with_tags([a_tag]))
+      it 'works in conjuction with published' do
+        expect(SourceSet.published.with_tags([a_tag]))
           .to contain_exactly(published_set)
       end
 

--- a/spec/views/source_sets/index.html.erb_spec.rb
+++ b/spec/views/source_sets/index.html.erb_spec.rb
@@ -5,8 +5,8 @@ describe 'source_sets/index.html.erb', type: :view do
   before do
     create(:source_set_factory, name: 'Moomin')
     create(:source_set_factory, name: 'Snorkmaiden', published: true)
-    assign(:published_sets, SourceSet.published_sets)
-    assign(:unpublished_sets, SourceSet.unpublished_sets)
+    assign(:published_sets, SourceSet.published)
+    assign(:unpublished_sets, SourceSet.unpublished)
   end
 
   it_behaves_like 'renderable view'


### PR DESCRIPTION
This does a small refactor on two methods in the `source_set` model.  It removes redundant `self` statements and renames them to be more true to rails conventions.  I have tested this in my browser.