### PR TITLE
carousel showing more sources on source#show view

### DIFF
--- a/app/assets/javascripts/carousel.js
+++ b/app/assets/javascripts/carousel.js
@@ -1,0 +1,32 @@
+$(function() {
+  $(document).ready(function() {
+
+    /* 
+     * Initiate slick slider carousel. Slick is an external javascript library.
+     * @see config/initializers/assets.rb
+     * https://github.com/kenwheeler/slick
+     */
+    $('.carousel').slick({
+      infinite: true,
+      arrows: true,
+      slidesToShow: 3,
+      slidesToScroll: 3,
+      lazyLoad: 'ondemand',
+      responsive: [{
+        breakpoint: 1024,
+        settings: {
+          slidesToShow: 2,
+          slidesToScroll: 2
+        }
+      }, {
+        breakpoint: 680,
+        settings: {
+          slidesToShow: 1,
+          slidesToScroll: 1
+        }
+      }]
+    });
+
+    $('.slick-slide').outerHeight( $('.slick-track').height() );
+  });
+});

--- a/app/assets/javascripts/style.js
+++ b/app/assets/javascripts/style.js
@@ -3,6 +3,14 @@
  */
 (function() {
 
+  /*
+   * Remove 'js-off' classes from DOM elements.  The 'js-off' class is used to
+   * hide DOM elements when javascript is disabled.
+   */
+   $(document).ready(function() {
+    $('.js-off').removeClass('js-off');
+   });
+
   $(document).ready(function() {
     setAsideHeight();
     setNameContainerHeight();

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -9,6 +9,14 @@
   float: left;
 }
 
+/*
+ * Use js-off to hide elements if javascript is disabled.
+ * @see assets/javascripts/style.js
+ */
+.js-off {
+  display: none;
+}
+
 .primary-source-sets aside {
   margin-left: 1em;
   margin-bottom: 1em;
@@ -197,28 +205,29 @@
   margin-bottom: 2em;
 }
 
-.set .source-list-container .module {
+/* Source tile */
+
+.source-tile {
   background-color: #f0f3f4;
   border: none;
+  width: 100%;
+  height: 100%;
 }
 
-.set .thumbnail-container  {
+.source-tile .thumbnail-container  {
   height: 160px;
   width: 100%;
-}
-
-.set .thumbnail-container {
   text-align: center;
   margin-bottom: 1.5em;
 }
 
-.set .align-helper {
+.source-tile .align-helper {
   display: inline-block;
   height: 100%;
   vertical-align: middle;
 }
 
-.set .thumbnail-container img {
+.source-tile .thumbnail-container img {
   margin: 0px auto;
   display: inline-block;
   vertical-align: middle;
@@ -226,7 +235,7 @@
   max-width: 160px;
 }
 
-.set .source-name-container {
+.source-tile .source-name-container {
   text-align: left;
 }
 
@@ -299,6 +308,10 @@ audio {
   padding-bottom: 1em;
 }
 
+.related-sources {
+  clear: both;
+}
+
 /* Admin interfaces */
 
 input.form-submit {
@@ -366,4 +379,25 @@ input.form-submit {
 .imgsize_label {
   display: inline;
   margin-right: .5em;
+}
+
+/* Carousels */
+
+.carousel-container {
+  padding: 20px;
+  margin: 20px;
+}
+
+.carousel-item {
+  padding: 8px;
+  margin-right: 12px;
+}
+
+.slick-prev:before, .slick-next:before,
+.slick-prev:after, .slick-next:after { 
+    color: #DD4E00 !important;
+}
+
+.carousel-container .source-container {
+  margin: 16px;
 }

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -35,6 +35,8 @@ class Source < ActiveRecord::Base
 
   validates :aggregation, presence: true
 
+  default_scope { order('created_at ASC') }
+
   ##
   # Gets all assets associated with source through attachments table.
   # @return Array<ActiveRecord::Base>
@@ -62,5 +64,19 @@ class Source < ActiveRecord::Base
 
   def display_name
     name.present? ? name : aggregation
+  end
+
+  ##
+  # Get all other sources associated with this source's source_set.
+  # The source that would appear after the current source in a default database
+  # query is first in the return array.
+  #
+  # @example:
+  #   <Source id: 3>.related_sources =>
+  #      [<Source id: 4>, <Source id: 1>, <Source id: 2>]
+  #
+  # @return [Array<Source>]
+  def related_sources
+    source_set.sources.split { |s| s.id == id }.reverse.flatten
   end
 end

--- a/app/views/source_sets/_source_list.html.erb
+++ b/app/views/source_sets/_source_list.html.erb
@@ -1,25 +1,10 @@
 <% if @source_set.sources.present? %>
   <div class='source-list-container'>
-    <% @source_set.sources.order('created_at ASC').each_slice(3) do |sources_row| %>
+    <% @source_set.sources.each_slice(3) do |sources_row| %>
       <div class='moduleContainer threeCol'>
         <% sources_row.each_with_index do |source, i| %>
-          <section class='module'>
-            <div class='source-container'>
-              <div class='thumbnail-container'>
-                <% if source.thumbnail.present? %>
-                  <span class='align-helper'></span>
-                  <%= link_to((image_tag base_src + source.thumbnail.file_name,
-                                         alt: source.thumbnail.alt_text.present? ? 
-                                           source.thumbnail.alt_text : source.name),
-                               source_path(source)) %>
-                <% end %>
-              </div>
-              <div class='source-name-container'>
-                <%= link_to inline_markdown(source.display_name),
-                            source_path(source) %>
-              </div>
-            </div>
-          </section>
+          <%= render partial: 'sources/source_tile',
+                     locals: { source: source } %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/sources/_source_tile.html.erb
+++ b/app/views/sources/_source_tile.html.erb
@@ -1,0 +1,17 @@
+<section class='module source-tile'>
+  <div class='source-container'>
+    <div class='thumbnail-container'>
+      <% if source.thumbnail.present? %>
+        <span class='align-helper'></span>
+        <%= link_to((image_tag base_src + source.thumbnail.file_name,
+                               alt: source.thumbnail.alt_text.present? ? 
+                                 source.thumbnail.alt_text : source.name),
+                     source_path(source)) %>
+      <% end %>
+    </div>
+    <div class='source-name-container'>
+      <%= link_to inline_markdown(source.display_name),
+                  source_path(source) %>
+    </div>
+  </div>
+</section>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -5,11 +5,16 @@
                                           action: 'show',
                                           id: @source.id,
                                           only_path: false,
-                                          trailing_slash: true) %>' /> 
+                                          trailing_slash: true) %>' />
+  <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css' />
+  <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick-theme.css' />
 <% end %>
 
 <% content_for :foot_script do %>
   <%= javascript_include_tag 'lightbox' %>
+  <%= javascript_include_tag 'carousel' %>
+  <script type="text/javascript"
+          src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
   <%= render partial: 'shared/analytics' %>
 <% end %>
 
@@ -39,6 +44,31 @@
   <div class='textual-content'>
     <%= markdown(@source.textual_content) %>
   </div>
+</div>
+
+<div class='related-sources'>
+  <h2>More sources from this set:</h1>
+  
+  <div class='carousel-container js-off'>
+    <div class='multiple-items slider carousel'>
+      <% @source.related_sources.each do |source| %>
+        <div class='carousel-item'>
+          <%= render partial: 'sources/source_tile',
+                     locals: { source: source } %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <noscript>
+    <ul>
+      <% @source.related_sources.each do |source| %>
+        <li> 
+          <%= link_to inline_markdown(source.display_name), source_path(source) %>
+        </li>
+      <% end %>
+    </ul>
+  </noscript>
 </div>
 
 <% if admin_signed_in? %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,7 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 Rails.application.config.assets.precompile += %w( avupload.js )
+Rails.application.config.assets.precompile += %w( carousel.js )
 Rails.application.config.assets.precompile += %w( docupload.js )
 Rails.application.config.assets.precompile += %w( imgupload.js )
 Rails.application.config.assets.precompile += %w( form.js )

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -32,6 +32,12 @@ describe Source, type: :model do
     expect(Source.new(aggregation: nil)).not_to be_valid
   end
 
+  it 'orders by created date' do
+    source_1 = source
+    source_2 = create(:source_factory, name: 'source 2')
+    expect(Source.all).to eq [source_1, source_2]
+  end
+
   context 'with related assets' do
 
     let(:source) do
@@ -144,6 +150,17 @@ describe Source, type: :model do
           expect(nameless_source.display_name).to eq nameless_source.aggregation
         end
       end
+    end
+  end
+
+  describe '#related_sources' do
+    it 'returns related sources in correct order' do
+      source_1 = source
+      source_2 = create(:source_factory, name: 'source 2')
+      source_3 = create(:source_factory, name: 'source 2')
+      source_set = create(:source_set_factory)
+      source_set.sources << [source_1, source_2, source_3]
+      expect(source_2.related_sources).to eq [source_3, source_1]
     end
   end
 end


### PR DESCRIPTION
This introduces a carousel on the `source#show` view that links to other sources from the same set.

The carousel is created using the [slick](https://github.com/kenwheeler/slick) JavaScript library.  The carousel is responsive, displaying a different number of sources depending on screen size.

The `source` model has an instance method, `related_sources`, that returns all of the _other_ sources from this source's associated set.  The `source` model also has a default sort order (before, the sort order was defined in the view, which could lead to inconsistencies in the application).

A new partial, `_source_tile.html.erb`, contains the HTML representation of a source "tile" (a stylized thumbnail and title link to the source), used on both the `source#show` and `source#index` pages.  Some tweaks to the CSS ensure that it is usable in both places.

If JavaScript is disabled in the browser, the user instead sees a hyperlinked list of sources.  A CSS class, `js-off`, can be applied to HTML elements that should be hidden if JavaScript is disabled.  If JavaScript is enabled, a function removes the `js-off` class from all HTML elements when the page loads.

This has been deployed to staging for testing purposes, and approved by Franky.

This addresses [ticket #7924](https://issues.dp.la/issues/7934).