### PR TITLE
fix helper test

### DIFF
--- a/spec/helpers/source_sets_helper_spec.rb
+++ b/spec/helpers/source_sets_helper_spec.rb
@@ -68,11 +68,9 @@ describe SourceSetsHelper, type: :helper do
   end
 
   describe '#selected_slugs_not_in' do
-    # FIXME: spec not passing, although testing on UI indicates that method is
-    # working as expected
-    xit 'returns slugs of given tags that are in params' do
-      assign(:tags, [tag_a])
-      expect(helper.selected_slugs_not_in([tag_a, tag_b])).to eq [tag_b.slug]
+    it 'returns slugs of given tags that are not in params' do
+      assign(:tags, [tag_a, tag_b])
+      expect(helper.selected_slugs_not_in([tag_a, tag_c])).to eq [tag_b.slug]
     end
   end
 


### PR DESCRIPTION
This fixes a helper test that was previously failing.  The helper method itself worked fine, the test was just incorrectly written.

This addresses [task #8244](https://issues.dp.la/issues/8244).