### PR TITLE
hide resort button when filter selected

### DIFF
--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -43,6 +43,9 @@
           <%= select_tag('tags[]',
                        options_for_select(tag_filter_options(tags),
                                           selected_slugs_in(tags))) %>
+
+          <noscript><%= submit_tag 'Re-sort', name: nil %></noscript>
+
         <% else %>
           <%# render pill tags %>
           <ul class='tag-list inline-block'>
@@ -55,9 +58,6 @@
             <% end %>
           </ul>
         <% end %>
-
-        <noscript><%= submit_tag 'Re-sort', name: nil %></noscript>
-
       <% end %>
     <% end %>
 


### PR DESCRIPTION
This corrects a mistake in the `source_set#index` view.  The mistake occurred with a filter tag was included in the URL and the browser's JavaScript was disabled.  Before the, "Re-sort" continued to be visible even though the drop-down menu was hidden (see screenshot below).  This was confusing, and inconsistent with parallel behavior when JavaScript is enabled.  Now, the "Re-sort" button only shows if the dropdown menu is also visible.

<img width="255" alt="screen shot 2016-02-22 at 10 04 02 am" src="https://cloud.githubusercontent.com/assets/3615206/13338634/b9d97d2c-dbf0-11e5-8622-f2da22eeff67.png">

I tested this in my local browser and it is working as expected.

This addresses [task 8286](https://issues.dp.la/issues/8286).