### PR TITLE
expansible checkbox menus on admin form

### DIFF
--- a/app/assets/javascripts/form.js
+++ b/app/assets/javascripts/form.js
@@ -1,3 +1,7 @@
+/*
+ * JavaScript related to admin forms.
+ */
+
 (function() {
 
   $(document).ready(function() {
@@ -5,16 +9,40 @@
     $('.asset_check_box').click(function() {
       $('.asset_check_box').prop('checked', false);
       $(this).prop('checked', true);
-    })
+    });
 
     $('.thumbnail_check_box').click(function() {
       $('.thumbnail_check_box').prop('checked', false);
       $(this).prop('checked', true);
-    })
+    });
 
     $('.small_image_check_box').click(function() {
       $('.small_image_check_box').prop('checked', false);
       $(this).prop('checked', true);
-    })
+    });
+
+    /* 
+     * Show link to show/hide expansible content. Hide expansible content.
+     * By default, the link is hidden and and the content is shown to make it
+     * usable for those with JavaScript disabled.
+     */
+    $('.expand-control').html('show').show();
+    $('.expand-content').hide();
+
+    /* 
+     * Show/hide function for expansible content.
+     * .expand-control is a DOM element that users can click to show or hide
+     * sections of content.
+     */
+    $('.expand-control').click(function() {
+      var content = $(this).closest('.expansible').find('.expand-content');
+      if(content.is(':visible')) {
+        content.hide('slow');
+        $(this).html('show');
+      } else {
+        content.show('slow');
+        $(this).html('hide');
+      }
+    });
   });
 })();

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -339,6 +339,10 @@ input.form-submit {
   background-color: #E6A425;
 }
 
+.pss-admin-form input.form-submit {
+  margin-top: 1em;
+}
+
 .pss-admin-form input[type=radio] {
   margin-right: .25em;
 }
@@ -380,6 +384,30 @@ input.form-submit {
   display: inline;
   margin-right: .5em;
 }
+
+.pss-admin-form h2 {
+  margin-bottom: 2em;
+  margin-top: 2em;
+}
+
+.pss-admin-form label {
+  font-weight: bold;
+}
+
+.pss-admin-form .expansible h2,
+.pss-admin-form .expansible label {
+  font-weight: normal;
+  display: inline;
+}
+
+.pss-admin-form .expansible .expand-control {
+  padding-left: .5em;
+  margin-bottom: 1em;
+  display: none;
+}
+
+.pss-admin-form .expansible .expand-content {
+  margin-bottom: 1em;
 
 /* Carousels */
 

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -15,12 +15,12 @@
   <% end %>
  
   <p>
-    <strong><%= f.label "Name (required)" %></strong><br/>
+    <strong><%= f.label "Name (required)" %></strong>
     <%= f.text_field :name %>
   </p>
 
   <p>
-    <strong><%= f.label :affiliation %></strong><br/>
+    <strong><%= f.label :affiliation %></strong>
     <%= f.text_field :affiliation %>
   </p>
   

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -17,29 +17,37 @@
   <%= f.submit 'Submit', class: 'form-submit' %>
 
   <p>
-    <strong><%= f.label "Name (required)" %></strong><br/>
+    <strong><%= f.label "Name (required)" %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
 
   <p>
-    <strong><%= f.label :questions %></strong><br/>
+    <strong><%= f.label :questions %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_area :questions %>
   </p>
 
   <p>
-    <strong><%= f.label :activity %></strong><br/>
+    <strong><%= f.label :activity %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_area :activity %>
   </p>
 
-  <p>
-    <strong><%= f.label :author %></strong><br />
-    <%= f.collection_check_boxes(:author_ids, Author.all, :id, :name) do |b| %>
-      <%= b.label { b.check_box + b.text } %><br />
-    <% end %>
-  </p>
+  <div class='expansible'>
+    <h2><%= f.label :author %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% authors = Author.all %>
+      <% if authors.present? %>
+        <%= f.collection_check_boxes(:author_ids, authors, :id, :name) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no authors.</p>
+      <% end %>
+    </div>
+  </div>
 
   <%= f.submit 'Submit', class: 'form-submit' %>
 

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <h1>Edit teaching guide</h1>
 
 <p>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <p><%= link_to "Back to set", source_set_path(@source_set) %></p>
 
 <h1>New teaching guide for <%= inline_markdown(@source_set.name) %></h1>

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -17,7 +17,7 @@
   <%= f.submit 'Submit', class: 'form-submit' %>
  
   <p>
-    <strong><%= f.label "Name (required)" %></strong><br/>
+    <strong><%= f.label "Name (required)" %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
@@ -25,6 +25,7 @@
   <p>
     <strong><%= f.label :published, style: 'display:inline' %></strong>
     <%= f.check_box :published %><br />
+    <em>If published, set will be visible to the public.</em>
   </p>
 
   <p>
@@ -35,36 +36,52 @@
   </p>
  
   <p>
-    <strong><%= f.label 'SEO description' %></strong><br/>
+    <strong><%= f.label 'SEO description' %></strong>
     <em>Example: "This collection uses primary sources to explore the French and Indian War."</em><br/>
     <%= f.text_area :description %>
   </p>
 
   <p>
-    <strong><%= f.label :overview %></strong><br/>
+    <strong><%= f.label :overview %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_area :overview %>
   </p>
 
   <p>
-    <strong><%= f.label :resources_for_research %></strong><br/>
+    <strong><%= f.label :resources_for_research %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_area :resources %>
   </p>
 
-  <p>
-    <strong><%= f.label :author %></strong><br />
-    <%= f.collection_check_boxes(:author_ids, Author.all, :id, :name) do |b| %>
-      <%= b.label { b.check_box + b.text } %><br />
-    <% end %>
-  </p>
+  <div class='expansible'>
+    <h2><%= f.label :author %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% authors = Author.all %>
+      <% if authors.present? %>
+        <%= f.collection_check_boxes(:author_ids, authors, :id, :name) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no authors.</p>
+      <% end %>
+    </div>
+  </div>
 
-  <p>
-    <strong><%= f.label :tag %></strong><br />
-    <%= f.collection_check_boxes(:tag_ids, Tag.all, :id, :label) do |b| %>
-      <%= b.label { b.check_box + b.text } %><br />
-    <% end %>
-  </p>
+  <div class='expansible'>
+    <h2><%= f.label :tag %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% tags = Tag.all %>
+      <% if tags.present? %>
+        <%= f.collection_check_boxes(:tag_ids, tags, :id, :label) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no tags.</p>
+      <% end %>
+    </div>
+  </div>
  
   <%= f.submit 'Submit', class: 'form-submit' %>
  

--- a/app/views/source_sets/edit.html.erb
+++ b/app/views/source_sets/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <h1>Edit set</h1>
 
 <p>

--- a/app/views/source_sets/new.html.erb
+++ b/app/views/source_sets/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <h1>New set</h1>
 
 <%= render "form" %>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -17,79 +17,118 @@
   <%= f.submit 'Submit', class: 'form-submit' %>
 
   <p>
-    <strong><%= f.label "DPLA id (required)" %></strong><br/>
+    <strong><%= f.label "DPLA id (required)" %></strong>
     <em>Example: ebc07432a6ba4f864daaddc4ad0a68f9</em><br/>
     <%= f.text_field :aggregation %>
   </p>
 
   <p>
-    <strong><%= f.label :caption %></strong><br/>
+    <strong><%= f.label :caption %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for text formatting.</em><br/>
     <%= f.text_field :name %>
   </p>
 
   <p>
-    <strong><%= f.label :citation %></strong><br/>
+    <strong><%= f.label :citation %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
     <%= f.text_area :citation %>
   </p>
 
   <p>
-    <strong><%= f.label :credits %></strong><br/>
+    <strong><%= f.label :credits %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
     <%= f.text_area :credits %>
   </p>
 
   <p>
-    <strong><%= f.label 'Description / transcription' %></strong><br/>
+    <strong><%= f.label 'Description / transcription' %></strong>
     <em>Use <a href=https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Markdown+guide>Markdown</a> for formatting.</em><br/>
     <%= f.text_area :textual_content %>
   </p>
 
   <p>
-    <strong><%= f.label :featured %></strong><%= f.check_box :featured %><br />
+    <strong><%= f.label :featured, style: 'display:inline' %></strong>
+    <%= f.check_box :featured %><br />
     <em>If checked, this source's small image will be the featured image for the set.</em><br/>
   </p>
 
-  <h2>Main media asset</h2>
+  <div class='expansible'>
+    <h2>Main media asset</h2>
+    <a class='expand-control'>show</a>
 
-  <p>
-    <strong><%= f.label :large_image %></strong><br />
-    <%= f.collection_check_boxes(:image_ids, Image.where(size: 'large').order('file_name'), :id, :file_name) do |b| %>
-      <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
-    <% end %>
-  </p>
+    <div class='expand-content'>
+ 
+      <h3><%= f.label :large_image %></h3>
+      <% large_image = Image.where(size: 'large').order('file_name') %>
+      <% if large_image.present? %>
+        <%= f.collection_check_boxes(:image_ids, large_image, :id, :file_name) do |b| %>
+          <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no large images.</p>
+      <% end %>
 
-  <p>
-    <strong><%= f.label :audio %></strong><br />
-    <%= f.collection_check_boxes(:audio_ids, Audio.all.order('file_base'), :id, :file_base) do |b| %>
-      <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
-    <% end %>
-  </p>
+      <h3><%= f.label :audio %></h3>
+      <% audios = Audio.all.order('file_base') %>
+      <% if audios.present? %>
+        <%= f.collection_check_boxes(:audio_ids, audios, :id, :file_base) do |b| %>
+          <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no audios.</p>
+      <% end %>
 
-  <p>
-    <strong><%= f.label :video %></strong><br />
-    <%= f.collection_check_boxes(:video_ids, Video.all.order('file_base'), :id, :file_base) do |b| %>
-      <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
-    <% end %>
-  </p>
+      <h3><%= f.label :video %></h3>
+      <% videos = Video.all.order('file_base') %>
+      <% if videos.present? %>
+        <%= f.collection_check_boxes(:video_ids, videos, :id, :file_base) do |b| %>
+          <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no videos.</p>
+      <% end %>
 
-  <p>
-    <strong><%= f.label :document %></strong><br />
-    <%= f.collection_check_boxes(:document_ids, Document.all.order('file_name'), :id, :file_name) do |b| %>
-      <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
-    <% end %>
-  </p>
+      <h3><%= f.label :document %></h3>
+      <% documents = Document.all.order('file_name') %>
+      <% if documents.present? %>
+        <%= f.collection_check_boxes(:document_ids, documents, :id, :file_name) do |b| %>
+          <%= b.label { b.check_box(class: "asset_check_box") + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no documents.</p>
+      <% end %>
+    </div>
+  </div>
 
-  <h2><%= f.label :thumbnail %></h2>
-  <%= f.collection_check_boxes(:image_ids, Image.where(size: 'thumbnail').order('file_name'), :id, :file_name) do |b| %>
-    <%= b.label { b.check_box(class: "thumbnail_check_box") + b.text } %><br />
-  <% end %>
+  <div class='expansible'>
+    <h2><%= f.label :thumbnail %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% thumbnails = Image.where(size: 'thumbnail').order('file_name') %>
+      <% if thumbnails.present? %>
+        <%= f.collection_check_boxes(:image_ids, thumbnails, :id, :file_name) do |b| %>
+          <%= b.label { b.check_box(class: "thumbnail_check_box") + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no thumbnails.</p>
+      <% end %>
+    </div>
+  </div>
 
-  <h2><%= f.label :small_image %></h2>
-  <%= f.collection_check_boxes(:image_ids, Image.where(size: 'small').order('file_name'), :id, :file_name) do |b| %>
-    <%= b.label { b.check_box(class: "small_image_check_box") + b.text } %><br />
-  <% end %>
+  <div class='expansible'>
+    <h2><%= f.label :small_image %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% small_images = Image.where(size: 'small').order('file_name') %>
+      <% if small_images.present? %>
+        <%= f.collection_check_boxes(:image_ids, small_images, :id, :file_name) do |b| %>
+          <%= b.label { b.check_box(class: "small_image_check_box") + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no small images.</p>
+      <% end %>
+    </div>
+  </div>
 
   <%= f.submit 'Submit', class: 'form-submit' %>
 

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -19,28 +19,44 @@
   </p>
  
   <p>
-    <strong><%= f.label "Label (required)" %></strong><br/>
+    <strong><%= f.label "Label (required)" %></strong>
     <%= f.text_field :label %>
   </p>
 
   <p>
-    <strong><%= f.label :uri %></strong><br/>
+    <strong><%= f.label :uri %></strong>
     <%= f.text_field :uri %>
   </p>
 
-  <p>
-    <strong><%= f.label :vocabularies %></strong><br />
-    <%= f.collection_check_boxes(:vocabulary_ids, Vocabulary.all, :id, :name) do |b| %>
-      <%= b.label { b.check_box + b.text } %><br />
-    <% end %>
-  </p>
+  <div class='expansible'>
+    <h2><%= f.label :vocabularies %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% vocabularies = Vocabulary.all %>
+      <% if vocabularies.present? %>
+        <%= f.collection_check_boxes(:vocabulary_ids, vocabularies, :id, :name) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no vocabularies.</p>
+      <% end %>
+    </div>
+  </div>
 
-  <p>
-    <strong><%= f.label :source_sets %></strong><br />
-    <%= f.collection_check_boxes(:source_set_ids, SourceSet.all, :id, :name) do |b| %>
-      <%= b.label { b.check_box + b.text } %><br />
-    <% end %>
-  </p>
+  <div class='expansible'>
+    <h2><%= f.label :source_sets %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% source_sets = SourceSet.all %>
+      <% if source_sets.present? %>
+        <%= f.collection_check_boxes(:source_set_ids, source_sets, :id, :name) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no source sets.</p>
+      <% end %>
+    </div>
+  </div>
   
   <p>
     <%= f.submit 'Submit', class: 'form-submit' %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <h1>Edit tag</h1>
 
 <p>

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <p><%= link_to "Back to tags", tags_path %></p>
 
 <h1>New tag</h1>

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -19,7 +19,7 @@
   </p>
  
   <p>
-    <strong><%= f.label "Name (required)" %></strong><br/>
+    <strong><%= f.label "Name (required)" %></strong>
     <%= f.text_field :name %>
   </p>
 
@@ -29,12 +29,20 @@
     <em>If Filter is checked, users will be able to filter sets using this vocabulary.</em>
   </p>
 
-  <p>
-    <strong><%= f.label :tags %></strong><br />
-    <%= f.collection_check_boxes(:tag_ids, Tag.all, :id, :label) do |b| %>
-      <%= b.label { b.check_box + b.text } %><br />
-    <% end %>
-  </p>
+  <div class='expansible'>
+    <h2><%= f.label :tags %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% tags = Tag.all %>
+      <% if tags.present? %>
+        <%= f.collection_check_boxes(:tag_ids, tags, :id, :label) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no tags.</p>
+      <% end %>
+    </div>
+  </div>
   
   <p>
     <%= f.submit 'Submit', class: 'form-submit' %>

--- a/app/views/vocabularies/edit.html.erb
+++ b/app/views/vocabularies/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <h1>Edit vocabulary</h1>
 
 <p>

--- a/app/views/vocabularies/new.html.erb
+++ b/app/views/vocabularies/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <p><%= link_to "Back to vocabularies", vocabularies_path %></p>
 
 <h1>New vocabulary</h1>


### PR DESCRIPTION
On the admin new/edit forms for source_sets, sources, guides, tags, and vocabularies, there are checkbox menus that allow admins to assert relationships with other objects (ie. the vocabularies form has a checkbox menu of all tags, so that admins can check which ones should belong to the vocabulary).  These checkbox menus can be long and unwieldy, making the user experience quite unpleasant. 

This PR introduces links to show/hide the checkbox menus.  It also provides the user with a message if there are no associated objects to choose from.

This PR also deletes some unnecessary <br/> tags on the forms that to tighten up whitespace and make it easier to understand which labels are associated with which input boxes.

The UI experience has been tested locally and on staging.

This addresses [ticket #8395](https://issues.dp.la/issues/8295).