### PR TITLE
Fix/mobile layout margins

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -400,4 +400,35 @@ input.form-submit {
 
 .carousel-container .source-container {
   margin: 16px;
+
+/* Mobile layout */
+
+@media only screen and (max-width: 680px) and (min-width: 0px) {
+  .primary-source-sets {
+    margin-left: 2.6455%;
+    margin-right: 2.6455%;
+  }
+
+  body .container h1 {
+    padding-left: 0;
+  }
+
+  .layout article {
+    padding: 0;
+    width: 100%;
+  }
+
+  .layout .set article {
+    margin-bottom: 0;
+  }
+
+  .layout aside {
+    padding: 0;
+    margin: 0;
+    width: 100%;
+  }
+
+  .all-sets .module {
+    width: 100%;
+  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,8 +16,8 @@
     <%= render partial: 'shared/jump_links' %>
     <div class='container'>
       <%= render partial: 'shared/header' %>
+      <%= render partial: 'shared/search_panel' %>
       <div class='layout primary-source-sets'>
-        <%= render partial: 'shared/search_panel' %>
         <%= render partial: 'shared/admin_menu' if admin_signed_in? %>
         <%= yield %>
       </div>


### PR DESCRIPTION
This adds an outermost margin for the DOM element `div.primary-source-sets`, which contains main content (not header or footer).  It also moves one DOM element outside of `div.primary-source-sets` b/c it should not have an external margin and does not contain content specific to primary source sets.  Finally, it tweaks some paddings and widths for other DOM elements so that the layout overall looks good with the the new outermost margin.  It has been tested on android phone and iphone.  

This addresses [ticket #8232](https://issues.dp.la/issues/8232).  It has been tested and approved by Franky on staging.