### PR TITLE
views for reviewers

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -103,11 +103,20 @@
 <% if admin_signed_in? %>
   <h2>Admin info</h2>
 
-  <p>
-    <%= link_to "Edit", edit_guide_path(@guide) %>
-    |
-    <%= link_to "Delete", 
-                 guide_path(@guide), method: :delete,
-                 data: { confirm: "Are you sure you want to delete this guide?" } %>
-  </p>
+  <% unless current_admin.reviewer? %>
+    <p>
+      <%= link_to "Edit", edit_guide_path(@guide) %>
+      |
+      <%= link_to "Delete", 
+                   guide_path(@guide), method: :delete,
+                   data: { confirm: "Are you sure you want to delete this guide?" } %>
+    </p>
+  <% end %>
+
+  <table>
+    <tr>
+      <td><strong>Set: </strong></td>
+      <td><%= link_to inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set)%></td>
+    </tr>
+  </table>
 <% end %>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -91,15 +91,21 @@
   <% if admin_signed_in? %>
 
     <div class='admin-info'>
-
+      
       <h2>Admin Info</h2>
 
-      <p><%= link_to "Create new set", new_source_set_path %></p>
+      <% unless current_admin.reviewer? %>
+        <p><%= link_to "Create new set", new_source_set_path %></p>
+      <% end %>
 
       <h3>Unpublished sets</h3>
 
-      <%= render partial: 'source_sets/set_list',
-                 locals: { sets: @unpublished_sets, filters: filters } %>
+      <% if @unpublished_sets.count > 0 %>
+        <%= render partial: 'source_sets/set_list',
+                   locals: { sets: @unpublished_sets, filters: filters } %>
+      <% else %>
+        <p>There are currently no unpublished sets.</p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -67,28 +67,30 @@
 <% if admin_signed_in? %>
   <h2>Admin info</h2>
 
-  <p>
-    <%= link_to "Edit", edit_source_set_path(@source_set) %>
-    |
-    <%= link_to "Delete", source_set_path(@source_set), method: :delete,
-                   data: { confirm: "Are you sure you want to delete this set?" } %>
-  </p>
+  <% unless current_admin.reviewer? %>
+    <p>
+      <%= link_to "Edit", edit_source_set_path(@source_set) %>
+      |
+      <%= link_to "Delete", source_set_path(@source_set), method: :delete,
+                     data: { confirm: "Are you sure you want to delete this set?" } %>
+    </p>
+  <% end %>
 
   <table>
     <tr>
-      <td><strong>SEO description </strong></td>
+      <td><strong>SEO description: </strong></td>
       <td><%= @source_set.description %></td>
     </tr>
     <tr>
-      <td><strong>Published </strong></td>
+      <td><strong>Published: </strong></td>
       <td><%= @source_set.published %></td>
     </tr>
     <tr>
-      <td><strong>Year </strong></td>
+      <td><strong>Year: </strong></td>
       <td><%= @source_set.year %></td>
     </tr>
     <tr>
-      <td><strong>Featured image </strong></td>
+      <td><strong>Featured image: </strong></td>
       <td>
         <% if @source_set.featured_image.present? %>
           <%= link_to @source_set.featured_image.file_name, image_path(@source_set.featured_image) %>
@@ -96,7 +98,7 @@
       </td>
     </tr>
     <tr>
-      <td><strong>Tags</strong></td>
+      <td valign="top"><strong>Tags:</strong></td>
       <td>
         <% @source_set.tags.each do |tag| %>
           <%= link_to tag.label, tag_path(tag) %><br/>
@@ -105,10 +107,12 @@
     </tr>
   </table>
 
-  <p><%= link_to "Add new tag", new_tag_path(source_set_id: @source_set.id) %></p>
+  <% unless current_admin.reviewer? %>
+    <p><%= link_to "Add new tag", new_tag_path(source_set_id: @source_set.id) %></p>
 
-  <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
+    <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
 
-  <p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
+    <p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
+  <% end %>
 
 <% end %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -44,21 +44,23 @@
 <% if admin_signed_in? %>
   <h2>Admin info</h2>
 
-  <p>
-    <%= link_to "Edit", edit_source_path(@source) %>
-    |
-    <%= link_to "Delete", 
-                 source_path(@source), method: :delete,
-                 data: { confirm: "Are you sure you want to delete this source?" } %>
-  </p>
+  <% unless current_admin.reviewer? %>
+    <p>
+      <%= link_to "Edit", edit_source_path(@source) %>
+      |
+      <%= link_to "Delete", 
+                   source_path(@source), method: :delete,
+                   data: { confirm: "Are you sure you want to delete this source?" } %>
+    </p>
+  <% end %>
 
   <table>
     <tr>
-      <td><strong>Set </strong></td>
+      <td><strong>Set: </strong></td>
       <td><%= link_to inline_markdown(@source.source_set.name), source_set_path(@source.source_set)%></td>
     </tr>
     <tr>
-      <td><strong>DPLA item URI </strong></td>
+      <td><strong>DPLA item URI: </strong></td>
       <td><%= link_to frontend_path('item/' + @source.aggregation), frontend_path(@source.aggregation) %></td>
     </tr>
     <tr>
@@ -68,51 +70,53 @@
   </table>
 
 
-  <h3>Media assets</h2>
+  <% unless current_admin.reviewer? %>
+    <h3>Media assets</h2>
 
-  <p>
-    <%= link_to "Add new image", new_image_path(source_id: @source.id) %>
-    |
-    <%= link_to "Add new document", new_document_path(source_id: @source.id) %>
-    |
-    <%= link_to "Add new audio", new_audio_path(source_id: @source.id) %>
-    |
-    <%= link_to "Add new video", new_video_path(source_id: @source.id) %>
-  </p>
+    <p>
+      <%= link_to "Add new image", new_image_path(source_id: @source.id) %>
+      |
+      <%= link_to "Add new document", new_document_path(source_id: @source.id) %>
+      |
+      <%= link_to "Add new audio", new_audio_path(source_id: @source.id) %>
+      |
+      <%= link_to "Add new video", new_video_path(source_id: @source.id) %>
+    </p>
 
-  <table>
+    <table>
 
-    <% if @source.main_asset.present? %>
-      <tr>
-        <td><strong>Main media asset (<%= @source.main_asset.class.name %>)</strong></td>
-        <td><%= @file_base_or_name %></td>
-        <td><%= link_to "View", polymorphic_path(@source.main_asset) %></td>
-        <td><%= link_to "Delete", polymorphic_path(@source.main_asset),
-                        method: :delete,
-                        data: { confirm: "Are you sure you want to delete #{@file_base_or_name}?" } %></td>
-      </tr>
-    <% end %>
+      <% if @source.main_asset.present? %>
+        <tr>
+          <td><strong>Main media asset (<%= @source.main_asset.class.name %>): </strong></td>
+          <td><%= @file_base_or_name %></td>
+          <td><%= link_to "View", polymorphic_path(@source.main_asset) %></td>
+          <td><%= link_to "Delete", polymorphic_path(@source.main_asset),
+                          method: :delete,
+                          data: { confirm: "Are you sure you want to delete #{@file_base_or_name}?" } %></td>
+        </tr>
+      <% end %>
 
-    <% if @source.thumbnails.present? %>
-      <tr>
-        <td><strong>Thumbnail </strong></td>
-        <td><%= @source.thumbnails.first.file_name %></td>
-        <td><%= link_to "View", image_path(@source.thumbnails.first) %></td>
-        <td><%= link_to "Delete", image_path(@source.thumbnails.first),
-                        method: :delete,
-                        data: { confirm: "Are you sure you want to delete #{@source.thumbnails.first.file_name}?" } %></td>
-      </tr>
-    <% end %>
+      <% if @source.thumbnails.present? %>
+        <tr>
+          <td><strong>Thumbnail: </strong></td>
+          <td><%= @source.thumbnails.first.file_name %></td>
+          <td><%= link_to "View", image_path(@source.thumbnails.first) %></td>
+          <td><%= link_to "Delete", image_path(@source.thumbnails.first),
+                          method: :delete,
+                          data: { confirm: "Are you sure you want to delete #{@source.thumbnails.first.file_name}?" } %></td>
+        </tr>
+      <% end %>
 
-    <% if @source.small_images.present? %>
-      <tr>
-        <td><strong>Small image </strong></td>
-        <td><%= @source.small_images.first.file_name %></td>
-        <td><%= link_to "View", image_path(@source.small_images.first) %></td>
-        <td><%= link_to "Delete", image_path(@source.small_images.first),
-                        method: :delete,
-                        data: { confirm: "Are you sure you want to delete #{@source.small_images.first.file_name}?" } %></td>
-      </tr>
-    <% end %>
-  </table>
+      <% if @source.small_images.present? %>
+        <tr>
+          <td><strong>Small image: </strong></td>
+          <td><%= @source.small_images.first.file_name %></td>
+          <td><%= link_to "View", image_path(@source.small_images.first) %></td>
+          <td><%= link_to "Delete", image_path(@source.small_images.first),
+                          method: :delete,
+                          data: { confirm: "Are you sure you want to delete #{@source.small_images.first.file_name}?" } %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
 <% end %>

--- a/spec/views/guides/show.html.erb_spec.rb
+++ b/spec/views/guides/show.html.erb_spec.rb
@@ -15,4 +15,43 @@ describe 'guides/show.html.erb', type: :view do
     render
     expect(rendered).to include(guide.name)
   end
+
+  context 'logged in manager' do
+    before do
+      admin = create(:admin_factory)
+      sign_in admin
+    end
+
+    it 'links to guide#edit' do
+      render
+      expect(rendered)
+        .to include("<a href=\"#{edit_guide_path(guide)}\"")
+    end
+  end
+
+  context 'logged in editor' do
+    before do
+      admin = create(:editor_admin_factory)
+      sign_in admin
+    end
+
+    it 'links to guide#edit' do
+      render
+      expect(rendered)
+        .to include("<a href=\"#{edit_guide_path(guide)}\"")
+    end
+  end
+
+  context 'logged in reviewer' do
+    before do
+      admin = create(:reviewer_admin_factory)
+      sign_in admin
+    end
+
+    it 'does not link to guide#edit' do
+      render
+      expect(rendered)
+        .not_to include("<a href=\"#{edit_guide_path(guide)}\"")
+    end
+  end
 end

--- a/spec/views/source_sets/index.html.erb_spec.rb
+++ b/spec/views/source_sets/index.html.erb_spec.rb
@@ -20,4 +20,55 @@ describe 'source_sets/index.html.erb', type: :view do
     render
     expect(rendered).not_to include('Moomin')
   end
+
+  context 'logged in manager' do
+    before do
+      admin = create(:admin_factory)
+      sign_in admin
+    end
+
+    it 'shows unpublished sets' do
+      render
+      expect(rendered).to include('Moomin')
+    end
+
+    it 'links to source_set#new' do
+      render
+      expect(rendered).to include("<a href=\"#{new_source_set_path}\"")
+    end
+  end
+
+  context 'logged in editor' do
+    before do
+      admin = create(:editor_admin_factory)
+      sign_in admin
+    end
+
+    it 'shows unpublished sets' do
+      render
+      expect(rendered).to include('Moomin')
+    end
+
+    it 'links to source_set#new' do
+      render
+      expect(rendered).to include("<a href=\"#{new_source_set_path}\"")
+    end
+  end
+
+  context 'logged in reviewer' do
+    before do
+      admin = create(:reviewer_admin_factory)
+      sign_in admin
+    end
+
+    it 'shows unpublished sets' do
+      render
+      expect(rendered).to include('Moomin')
+    end
+
+    it 'does not link to source_set#new' do
+      render
+      expect(rendered).not_to include("<a href=\"#{new_source_set_path}\"")
+    end
+  end
 end

--- a/spec/views/source_sets/show.html.erb_spec.rb
+++ b/spec/views/source_sets/show.html.erb_spec.rb
@@ -26,4 +26,58 @@ describe 'source_sets/show.html.erb', type: :view do
     render
     expect(rendered).to include(guide.name)
   end
+
+  context 'logged in manager' do
+    before do
+      admin = create(:admin_factory)
+      sign_in admin
+    end
+
+    it 'shows year' do
+      render
+      expect(rendered).to include(source_set.year.to_s)
+    end
+
+    it 'links to source_set#edit' do
+      render
+      expect(rendered)
+        .to include("<a href=\"#{edit_source_set_path(source_set)}\"")
+    end
+  end
+
+  context 'logged in editor' do
+    before do
+      admin = create(:editor_admin_factory)
+      sign_in admin
+    end
+
+    it 'shows year' do
+      render
+      expect(rendered).to include(source_set.year.to_s)
+    end
+
+    it 'links to source_set#edit' do
+      render
+      expect(rendered)
+        .to include("<a href=\"#{edit_source_set_path(source_set)}\"")
+    end
+  end
+
+  context 'logged in reviewer' do
+    before do
+      admin = create(:reviewer_admin_factory)
+      sign_in admin
+    end
+
+    it 'shows year' do
+      render
+      expect(rendered).to include(source_set.year.to_s)
+    end
+
+    it 'does not link to source_set#edit' do
+      render
+      expect(rendered)
+        .not_to include("<a href=\"#{edit_source_set_path(source_set)}\"")
+    end
+  end
 end

--- a/spec/views/sources/show.html.erb_spec.rb
+++ b/spec/views/sources/show.html.erb_spec.rb
@@ -15,4 +15,43 @@ describe 'sources/show.html.erb', type: :view do
     render
     expect(rendered).to include(source.aggregation)
   end
+
+  context 'logged in manager' do
+    before do
+      admin = create(:admin_factory)
+      sign_in admin
+    end
+
+    it 'links to source#edit' do
+      render
+      expect(rendered)
+        .to include("<a href=\"#{edit_source_path(source)}\"")
+    end
+  end
+
+  context 'logged in editor' do
+    before do
+      admin = create(:editor_admin_factory)
+      sign_in admin
+    end
+
+    it 'links to source#edit' do
+      render
+      expect(rendered)
+        .to include("<a href=\"#{edit_source_path(source)}\"")
+    end
+  end
+
+  context 'logged in reviewer' do
+    before do
+      admin = create(:reviewer_admin_factory)
+      sign_in admin
+    end
+
+    it 'does not link to source#edit' do
+      render
+      expect(rendered)
+        .not_to include("<a href=\"#{edit_source_path(source)}\"")
+    end
+  end
 end


### PR DESCRIPTION
This introduces views specific to reviewers.  Reviewers are a class of admins who need to see unpublished sets (and their associated sources and guides), but do not need access to edit/delete functions. This filters out links to these pages on set, source, and guide views for reviewers.

Note that reviewers already cannot access edit or delete routes, and if they try they will be redirected to more benign pages. But to avoid confusion, it would be best if link to edit/delete pages didn't appear to reviewers at all.  

There are also a couple small changes to the views to clarify information for reviewers, who do not have intimate knowledge of current workflows.

Finally, this adds tests for manager, editor, and reviewer admins for the associated views.

This addresses [ticket #8263](https://issues.dp.la/issues/8263).  It has been approved by Franky on staging.