### PR TITLE
Add URI validation and helper text to tag & vocab forms

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,6 +3,7 @@ class Tag < ActiveRecord::Base
   has_and_belongs_to_many :source_sets
   has_and_belongs_to_many :vocabularies
   validates :label, presence: true, uniqueness: true
+  validates :uri, format: { with: URI.regexp }, if: proc { |a| a.uri.present? }
 
   ##
   # FriendlyId generates a human-readable slug to be used in the URL, in place

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -24,7 +24,8 @@
   </p>
 
   <p>
-    <strong><%= f.label :uri %></strong>
+    <strong><%= f.label(:uri, 'URI') %></strong>
+    <em>If this tag correlates to a term from a controlled vocabulary with a permanent URI, you can add it here.</em><br/>
     <%= f.text_field :uri %>
   </p>
 

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,5 +1,7 @@
 <h1>Tags</h1>
 
+<p>Tags are descriptive words or phrases that can be applied to sets. Tags are organized into <%= link_to 'vocabularies', vocabularies_path %>, which can be used to filter sets.</p>
+
 <p><%= link_to "Create new tag", new_tag_path %></p>
 
 <table>

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -1,5 +1,7 @@
 <h1>Vocabularies</h1>
 
+<p>Vocabularies are collections of <%= link_to 'tags', tags_path %>.  Vocabularies can be used to filter sets.</p>
+
 <p><%= link_to "Create new vocabulary", new_vocabulary_path %></p>
 
 <table>

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -21,6 +21,14 @@ describe Tag, type: :model do
     expect(Tag.new(label: 'non-unique-label')).not_to be_valid
   end
 
+  it 'is invalid without correctly formatted URI' do
+    expect(Tag.new(label: 'label', uri: 'not a uri')).not_to be_valid
+  end
+
+  it 'is valid if URI is nil' do
+    expect(Tag.new(label: 'label', uri: nil)).to be_valid
+  end
+
   it 'has a slug' do
     expect(Tag.create(label: 'Little My').slug).to eq 'little-my'
   end


### PR DESCRIPTION
This adds helpful text to `tag` and `vocab` forms explaining what tags, vocabularies, and tag URIs are.  It also changes the expected data type for the form form `text` to `uri`.  This will perform a build-in validation to make sure the the user-submitted data is a properly-structured URI.  If the user does not enter a URI, the interface shows a tooltip saying they need to enter a URI (screenshot below).

<img width="522" alt="screen shot 2016-03-03 at 4 42 36 pm" src="https://cloud.githubusercontent.com/assets/3615206/13510544/ff4c530c-e15e-11e5-930d-b78ca26fa996.png">

This addresses [ticket #8229](https://issues.dp.la/issues/8229).

