### PR TITLE
back link and link to guide on source#show

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -315,6 +315,11 @@ audio {
   margin: 2em 0;
 }
 
+.related-guides {
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+
 /* Admin interfaces */
 
 input.form-submit {

--- a/app/helpers/sources_helper.rb
+++ b/app/helpers/sources_helper.rb
@@ -13,4 +13,38 @@ module SourcesHelper
       render partial: 'video'
     end
   end
+
+  ##
+  # Render a back link to the referring page if the referring page is a guide or
+  # set.  Links from guides or sets to sources may be created by admins, so the
+  # applicaiton cannot expect that back URI's can be included in params.
+  # Therefore, it is necessary to parse the referring URI to see if it is a
+  # guide or set, and render a back link accordingly.
+  #
+  # @return [String] HTML back link
+  def render_back_link
+    return unless request.referer.present?
+    uri = URI(request.referer)
+    # return if referrer is an offsite link
+    return unless uri.host == request.host
+
+    uri_path = uri.path
+    # return if referrer does not have relative url root
+    return unless uri_path.start_with?(Settings.relative_url_root)
+
+    uri_path.slice!(Settings.relative_url_root)
+    path = Rails.application.routes.recognize_path(uri_path) rescue nil
+
+    return unless path.present?
+    return unless path[:controller] == 'source_sets' || 'guides'
+    return unless path[:action] == 'show'
+
+    link_to "« back to #{path_label[path[:controller]]}", request.referer
+  end
+
+  private
+
+  def path_label
+    { 'source_sets' => 'set', 'guides' => 'guide' }
+  end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,5 +1,6 @@
 class Source < ActiveRecord::Base
   belongs_to :source_set
+  has_many :guides, through: :source_set
   has_many :attachments, dependent: :destroy
 
   has_many :videos, through: :attachments,

--- a/app/views/shared/_search_panel.html.erb
+++ b/app/views/shared/_search_panel.html.erb
@@ -1,5 +1,10 @@
 <section class='searchRow'>
-  <div class='searchRowLeft'></div>
+  <div class='searchRowLeft'>
+    <% if controller.controller_name == 'sources' &&
+      controller.action_name == 'show' %>
+      <%= render_back_link %>
+    <% end %>
+  </div>
   <div class='searchRowRight'>
     <%= link_to '', class: 'search-btn' do %>
       <span class='icon-man-glass' aria-hidden='true'></span>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -71,6 +71,15 @@
   </noscript>
 </div>
 
+<div class='related-guides'>
+  <% guides = @source.guides %>
+  <h2>Teaching Guide<%= 's' if guides.count > 1 %></h2>
+  <p>
+    This source appears in 
+    <%= raw guides.collect { |guide| link_to guide.name, guide }.to_sentence %>.
+  </p>
+</div>
+
 <% if admin_signed_in? %>
   <h2>Admin info</h2>
 

--- a/spec/helpers/source_helper_spec.rb
+++ b/spec/helpers/source_helper_spec.rb
@@ -21,4 +21,55 @@ describe SourcesHelper, type: :helper do
                     '</div>')
     end
   end
+
+  describe '#render_back_link' do
+
+    let(:guide) { create(:guide_factory) }
+
+    before(:each) do
+      allow(controller.request).to receive(:host).and_return 'example.com'
+    end
+
+    it 'renders an HTML link' do
+      ref = "http://example.com#{Settings.relative_url_root}/guides/#{guide.id}"
+      allow(controller.request).to receive(:referer).and_return ref
+      expect(helper.render_back_link)
+        .to eq "<a href=\"#{ref}\">« back to guide</a>"
+    end
+
+    it 'does not render if referer is not present' do
+      allow(controller.request).to receive(:referer).and_return nil
+      expect(helper.render_back_link).to eq nil
+    end
+
+    it 'does not render if referer has outside host' do
+      ref = "http://outside.com#{Settings.relative_url_root}/guides/#{guide.id}"
+      allow(controller.request).to receive(:referer).and_return ref
+      expect(helper.render_back_link).to eq nil
+    end
+
+    it 'does not render if referer has outside relative root' do
+      ref = "http://example.com/outside_relative_root/guides/#{guide.id}"
+      allow(controller.request).to receive(:referer).and_return ref
+      expect(helper.render_back_link).to eq nil
+    end
+
+    it 'does not render if referrer has no relative root' do
+      ref = "http://example.com/"
+      allow(controller.request).to receive(:referer).and_return ref
+      expect(helper.render_back_link).to eq nil
+    end
+
+    it 'does not render if referer controller is neither sets nor guides' do
+      ref = "http://example.com#{Settings.relative_url_root}/videos"
+      allow(controller.request).to receive(:referer).and_return ref
+      expect(helper.render_back_link).to eq nil
+    end
+
+    it 'does not render if referer action is not show' do
+      ref = "http://example.com#{Settings.relative_url_root}/sets"
+      allow(controller.request).to receive(:referer).and_return ref
+      expect(helper.render_back_link).to eq nil
+    end
+  end
 end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -8,6 +8,10 @@ describe Source, type: :model do
     expect(Source.reflect_on_association(:source_set).macro).to eq :belongs_to
   end
 
+  it 'has many guides' do
+    expect(Source.reflect_on_association(:guides).macro).to eq :has_many
+  end
+
   it 'has many attachments' do
     expect(Source.reflect_on_association(:attachments).macro).to eq :has_many
   end


### PR DESCRIPTION
This introduces a back link on the `source#show` page.  If the user come to a `source#show` page from a set or guide, the back link directs them back to the set or guide.  

We expect that users looking through a set or reading through a guide will need to do a lot of clicking back and forth between the set or guide and the sources contained within them.  The back links should facilitate this type of user experience. The back links are also operationally and stylistically akin to those on DPLA item pages.

I had initially considered including `back_uri`as a parameter of the `source#show` URL, a la:
 
    http://dp.la/item/eed4628bb2544f92665632e85d350963?back_uri=http%3A%2F%2Fdp.la%2Fsearch%3Futf8%3D%25E2%259C%2593%26q%3Dhamster

However, links _to_ `source#show` _from_ guides (and possibly sets) are included in user-generated text blocks.  See for examples the links on [this guide](http://dp.la/primary-source-sets/guides/teaching-guide-exploring-the-beginnings-of-rock-n-roll) under the "Discussion questions" section.  This text (including the links) were written by an admin and submitted via a form.  Therefore, we cannot count on these links including a `back_uri` parameter.  

In order to create a reliable, consistent fulfillment of the requirement, this instead parses the referrer data in the HTTP request.  If the referrer is a set or guide, the back link is rendered.

This also includes a permanent link to any associated teaching guides on the `source#show` view, as per feedback from Franky when the feature was tested on staging.

This addresses [ticket #8269](https://issues.dp.la/issues/8269).