### PR TITLE
replace css closing brackets

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -408,6 +408,7 @@ input.form-submit {
 
 .pss-admin-form .expansible .expand-content {
   margin-bottom: 1em;
+}
 
 /* Carousels */
 
@@ -428,6 +429,7 @@ input.form-submit {
 
 .carousel-container .source-container {
   margin: 16px;
+}
 
 /* Mobile layout */
 


### PR DESCRIPTION
This replaces two css closing brackets that were accidentally deleted when resolving merge conflicts.

This addresses [ticket #8317](https://issues.dp.la/issues/8317).