### PR TITLE
order sets by published date

### DIFF
--- a/db/migrate/20160304170216_add_published_at_to_source_sets.rb
+++ b/db/migrate/20160304170216_add_published_at_to_source_sets.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToSourceSets < ActiveRecord::Migration
+  def change
+    add_column :source_sets, :published_at, :datetime
+  end
+end

--- a/db/migrate/20160304170852_set_published_at_values.rb
+++ b/db/migrate/20160304170852_set_published_at_values.rb
@@ -1,0 +1,5 @@
+class SetPublishedAtValues < ActiveRecord::Migration
+  def self.up
+    SourceSet.where('published = ?', true).update_all('published_at=created_at')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160119215143) do
+ActiveRecord::Schema.define(version: 20160304170852) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -122,14 +122,15 @@ ActiveRecord::Schema.define(version: 20160119215143) do
 
   create_table "source_sets", force: true do |t|
     t.string   "name"
-    t.boolean  "published",                 default: false
-    t.text     "description", limit: 65535
-    t.text     "overview",    limit: 65535
-    t.text     "resources",   limit: 65535
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
+    t.boolean  "published",                  default: false
+    t.text     "description",  limit: 65535
+    t.text     "overview",     limit: 65535
+    t.text     "resources",    limit: 65535
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.string   "slug"
     t.integer  "year"
+    t.datetime "published_at"
   end
 
   create_table "source_sets_tags", force: true do |t|

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -112,15 +112,17 @@ describe SourceSet, type: :model do
 
   describe '#order_by' do
 
-    let(:set_a) { create(:source_set_factory, year: 1920) }
-    let(:set_b) { create(:source_set_factory, year: 1930) }
+    let(:set_a) { create(:source_set_factory, year: 1920, published: true,
+                         published_at: Time.new(2015)) }
+    let(:set_b) { create(:source_set_factory, year: 1930, published: true,
+                         published_at: Time.new(2016)) }
 
     before(:each) do
       set_a
       set_b
     end
 
-    it 'orders by most recently created' do
+    it 'orders by most recently published' do
       expect(SourceSet.order_by('recently_added')).to eq([set_b, set_a])
     end
 
@@ -134,7 +136,7 @@ describe SourceSet, type: :model do
         .to eq([set_b, set_a])
     end
 
-    it 'defaults to ordering by most recently created' do
+    it 'defaults to ordering by most recently published' do
       expect(SourceSet.order_by(nil)).to eq([set_b, set_a])
     end
 
@@ -170,6 +172,28 @@ describe SourceSet, type: :model do
 
     it 'orders sets by number of matching tags' do
       expect(set_1.related_sets.first).to eq(set_3)
+    end
+  end
+
+  describe '#check_publish_date' do
+    it 'persists publication time when a set is published' do
+      source_set.published = true
+      source_set.save
+      expect(source_set.reload.published_at).not_to be nil
+    end
+
+    it 'nulls the publication time when a set is unpublished' do
+      published_set.published = false
+      published_set.save
+      expect(published_set.reload.published_at).to be nil
+    end
+
+    it 'does not change the publication time when a published set is edited' do
+      time = Time.new(2015)
+      set = create(:source_set_factory, published: true, published_at: time)
+      set.name = "New name"
+      set.save
+      expect(set.reload.published_at).to eq time
     end
   end
 end


### PR DESCRIPTION
This replaces the ability to sort sets by their created date with the ability to sort sets by their published date.  This will make management of sets easier for admins.

* A `datetime` column, `published_at`, is added to the `source_sets` table.
* The value for the `published_at` column is set to the current value of the `created_at` column _if sets are already published_.  This will preserve the current sort order in production.  We do not currently have rspec tests for migrations (maybe something to look into for the future), but I tested this locally to ensure that it works as expected.
* A new `before_save` method is added to the `SourceSet` model to handle persistence of the publication timestamp.  If the set is being published upon save, the publication timestamp is set to the current `datetime`.  If a previously-published set is being otherwise edited, the publication timestamp is _not_ changed.  If a set is being un-published, the publication timestamp is cleared.
* The `order_by` method in `SourceSet` is changed to sort by `published_at` instead of `created_at`.

This addresses [ticket #8236](https://issues.dp.la/issues/8236).