### PR TITLE
carousel showing related sets

### DIFF
--- a/app/assets/javascripts/carousel.js
+++ b/app/assets/javascripts/carousel.js
@@ -11,7 +11,6 @@ $(function() {
       arrows: true,
       slidesToShow: 3,
       slidesToScroll: 3,
-      lazyLoad: 'ondemand',
       responsive: [{
         breakpoint: 1024,
         settings: {
@@ -19,7 +18,7 @@ $(function() {
           slidesToScroll: 2
         }
       }, {
-        breakpoint: 680,
+        breakpoint: 600, //tailored to fit width of set image
         settings: {
           slidesToShow: 1,
           slidesToScroll: 1
@@ -27,6 +26,13 @@ $(function() {
       }]
     });
 
-    $('.slick-slide').outerHeight( $('.slick-track').height() );
+    /*
+     * This executes after everything on the page (including images) have
+     * loaded.
+     */ 
+    $(window).on('load', function() {
+      // Make all items in the carousel the same height.
+      $('.slick-slide').outerHeight( $('.slick-track').height() );
+    });
   });
 });

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -9,6 +9,10 @@
   float: left;
 }
 
+.clear {
+  clear: both;
+}
+
 /*
  * Use js-off to hide elements if javascript is disabled.
  * @see assets/javascripts/style.js
@@ -74,54 +78,47 @@
   height: 100%;
 }
 
-.all-sets .module {
+/* Source set tile */
+
+.set-tile.module {
   border-color: #6592A6;
   padding: 0;
   background-color: white;
   max-width: 440px;
 }
 
-.all-sets img {
+.set-tile img {
   margin: 0;
 }
 
-.all-sets .set-tile {
-  padding: 0;
-  background-color: white;
-  max-width: 440px;
-}
-
-.all-sets img {
-  margin: 0;
-}
-
-.all-sets .set-tile {
-  border-color: #6592A6;
-  background-color: #6592A6;
-}
-
-.all-sets .set-name-container {
+.set-tile .set-name-container {
   padding: 1em;
   background-color: #6592A6;
 }
 
-.all-sets .set-name-container a {
+.set-tile .set-name-container a {
   color: white;
   font-weight: normal;
   font-size: 1.2em;
 }
 
-.all-sets .tag-label {
+/* Tags */
+
+.primary-source-sets .tag-label {
   margin: 0.8em 1em 0.8em 0;
 }
 
-.all-sets .tag-list {
+.primary-source-sets .tag-list {
   background-color: white;
   margin: 0 -0.5em 1.5em 0;
   padding: 0;
 }
 
-.all-sets .tag {
+.primary-source-sets .set .tag-list {
+  margin: 2em 0;
+}
+
+.primary-source-sets .tag {
   display: inline-block;
   float: left;
   border: 1px solid #D2D2D2;
@@ -130,17 +127,18 @@
   font-size: 0.9em;
 }
 
-.all-sets .set-list .tag {
+.primary-source-sets .set-list .tag,
+.primary-source-sets .set .tag {
   background-color: #EDEDED;
   margin-top: 0.3em;
   border: none;
 }
 
-.all-sets .set-list .tag a {
+.primary-source-sets .set-list .tag a {
   display: block;
 }
 
-.all-sets .tag a:hover {
+.primary-source-sets .tag a:hover {
   text-decoration: none;
 }
 
@@ -203,6 +201,10 @@
 
 .set .source-list-container {
   margin-bottom: 2em;
+}
+
+.set .related-sets {
+  margin: 2em 0;
 }
 
 /* Source tile */
@@ -308,8 +310,9 @@ audio {
   padding-bottom: 1em;
 }
 
-.related-sources {
+.related-sources, .related-sets {
   clear: both;
+  margin: 2em 0;
 }
 
 /* Admin interfaces */
@@ -413,7 +416,7 @@ input.form-submit {
 /* Carousels */
 
 .carousel-container {
-  padding: 20px;
+  padding: 0 20px;
   margin: 20px;
 }
 
@@ -429,6 +432,12 @@ input.form-submit {
 
 .carousel-container .source-container {
   margin: 16px;
+}
+
+.carousel-container .set-tile {
+  width: 100%;
+  height: 100%;
+  background-color: #6592A6;
 }
 
 /* Mobile layout */
@@ -460,5 +469,12 @@ input.form-submit {
 
   .all-sets .module {
     width: 100%;
+  }
+}
+
+/* Mobile layout carousel (breakpoint 600px) */
+@media only screen and (max-width: 600px) and (min-width: 0px) {
+  .carousel-item {
+    margin-right: 0;
   }
 }

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -33,6 +33,21 @@ class SourceSet < ActiveRecord::Base
   end
 
   ##
+  # Returns sets with at least two matching tags (not including self).
+  # Results are ordered so that sets with the highest number of matching tags
+  # appear first.
+  #
+  # @return [Array<SourceSet>]
+  def related_sets
+    sets = tags.map { |tag| [tag.source_sets] }.flatten - [self]
+    sets_with_count = sets.each_with_object(Hash.new(0)) do |set, count|
+      count[set] += 1
+    end
+    sets_with_count.delete_if { |_set, count| count < 2 }
+    Hash[sets_with_count.sort_by { |set, count| count }.reverse].keys
+  end
+
+  ##
   # Order SourceSets by a given parameter.
   # If a parameter is not included in the sort_params hash, it will be ignored.
   # By default, it will order by 'recently_added'.

--- a/app/views/source_sets/_set_list.html.erb
+++ b/app/views/source_sets/_set_list.html.erb
@@ -1,41 +1,9 @@
 <div class='set-list'>
   <%= sets.each_slice(3) do |sets_row| %>
     <div class='moduleContainer threeCol'>
-      <% sets_row.each_with_index do |set, i| %>
-        <section class='module'>
-          <% if set.featured_image.present? %>
-            <%= link_to((image_tag base_src + set.featured_image.file_name,
-                                   alt: set.featured_image.alt_text.present? ? 
-                                     set.featured_image.alt_text : set.name),
-                        source_set_path(set)) %>
-          <% end %>
-          <div class='set-name-container'>
-            <%= link_to inline_markdown(set.name), source_set_path(set) %>
-          </div>
-
-          <%# Setting this variable reduces calls to the database %>
-          <% set_tags = set.tags %>
-
-          <ul class='tag-list'>
-
-            <% filters.each do |vocab, tags| %>
-
-              <%# Get tags that are shared between this set and this vocab %>
-              <% display_tags = tags & set_tags %>
-
-              <% if display_tags.present? %>
-
-                  <% display_tags.each do |tag| %>
-                    <li class='tag'>
-                      <% new_params = params.merge(tags: [tag.slug]) %>
-                      <%= link_to tag.label, source_sets_path(new_params) %>
-                    </li>
-                  <% end %>
-              <% end %>
-            <% end %>
-
-          </ul>
-        </section>
+      <% sets_row.each do |set, i| %>
+        <%= render partial: 'source_sets/set_tile',
+                   locals: { set: set, render_tags: true, filters: filters } %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/source_sets/_set_tile.html.erb
+++ b/app/views/source_sets/_set_tile.html.erb
@@ -1,0 +1,36 @@
+<section class='module set-tile'>
+  <div class='set-container'>
+    <% if set.featured_image.present? %>
+      <%= link_to((image_tag base_src + set.featured_image.file_name,
+                             alt: set.featured_image.alt_text.present? ? 
+                               set.featured_image.alt_text : set.name),
+                  source_set_path(set)) %>
+    <% end %>
+    <div class='set-name-container'>
+      <%= link_to inline_markdown(set.name), source_set_path(set) %>
+    </div>
+
+    <% if render_tags %>
+      <%# Setting this variable reduces calls to the database %>
+      <% set_tags = set.tags %>
+
+      <ul class='tag-list'>
+        <% filters.each do |vocab, tags| %>
+
+          <%# Get tags that are shared between this set and this vocab %>
+          <% display_tags = tags & set_tags %>
+
+          <% if display_tags.present? %>
+
+              <% display_tags.each do |tag| %>
+                <li class='tag'>
+                  <% new_params = params.merge(tags: [tag.slug]) %>
+                  <%= link_to tag.label, source_sets_path(new_params) %>
+                </li>
+              <% end %>
+          <% end %>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</section>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -5,10 +5,15 @@
                                           action: 'show',
                                           id: @source_set.slug,
                                           only_path: false,
-                                          trailing_slash: true) %>' /> 
+                                          trailing_slash: true) %>' />
+  <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css' />
+  <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick-theme.css' />
 <% end %>
 
 <% content_for :foot_script do %>
+  <%= javascript_include_tag 'carousel' %>
+  <script type="text/javascript"
+          src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
   <%= render partial: 'shared/analytics' %>
 <% end %>
 
@@ -59,9 +64,48 @@
     </div>
   <% end %>
 
-  <div class='contact-outer-container'>
-    <p>Send feedback about this primary source set or our other educational resources to <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
-  </div>
+  <ul class='tag-list'>
+    <% tags = @source_set.tags %>
+    <% if tags.present? %>
+      <% tags.each do |tag| %>
+        <li class='tag'>
+          <%= link_to tag.label, source_sets_path({ tags: [tag.slug] }) %>
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
+
+  <div class='clear'></div>
+</div>
+
+<div class='related-sets'>
+  <% related = @source_set.related_sets %>
+  <% if related.present? %>
+    <h2>Related sets</h2>
+
+    <div class='carousel-container js-off'>
+      <div class='multiple-items slider carousel'>
+        <% related.each do |set| %>
+          <div class='carousel-item'>
+            <%= render partial: 'source_sets/set_tile',
+                       locals: { set: set, render_tags: false } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <noscript>
+      <ul>
+        <% related.each do |set| %>
+          <li><%= link_to inline_markdown(set.name), source_set_path(set) %></li>
+        <% end %>
+      </ul>
+    </noscript>
+  <% end %>
+</div>
+
+<div class='contact-outer-container'>
+  <p>Send feedback about this primary source set or our other educational resources to <%= mail_to Settings.contact_email, Settings.contact_email %>.</p>
 </div>
 
 <% if admin_signed_in? %>

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -142,4 +142,34 @@ describe SourceSet, type: :model do
       expect(SourceSet.order_by('*****')).to eq([set_b, set_a])
     end
   end
+
+  describe '#related_sets' do
+    let(:a_tag) { create(:tag_factory, label: 'a') }
+    let(:b_tag) { create(:tag_factory, label: 'b') }
+    let(:c_tag) { create(:tag_factory, label: 'c') }
+
+    let(:set_1) { create(:source_set_factory) }
+    let(:set_2) { create(:source_set_factory) }
+    let(:set_3) { create(:source_set_factory) }
+    let(:set_4) { create(:source_set_factory) }
+
+    before do
+      set_1.tags << [a_tag, b_tag, c_tag]
+      set_2.tags << [a_tag, b_tag]
+      set_3.tags << [a_tag, b_tag, c_tag]
+      set_4.tags << [a_tag]
+    end
+
+    it 'returns an Array' do
+      expect(set_1.related_sets).to be_a(Array)
+    end
+
+    it 'returns sets with at least two matching tags' do
+      expect(set_1.related_sets).to contain_exactly(set_2, set_3)
+    end
+
+    it 'orders sets by number of matching tags' do
+      expect(set_1.related_sets.first).to eq(set_3)
+    end
+  end
 end


### PR DESCRIPTION
This adds a carousel on the `source_set#show` view showing related sets.  The purpose of this feature is to encourage users to explore sets similar to one they are already looking at.  Its implementation is similar to the source carousel in [PR#112](https://github.com/dpla/primary-source-sets/pull/112).

Changes include:
* In the `SourceSet` model, a new method gets related sets, which are defined as sets sharing at least two tags.
* A new partial, `_set_tile.html.erb`, contains the HTML representation of a set "tile" (a stylized image and title link to the set), used on both the `source_set#show` and `source_set#index` pages. Some tweaks to the existing views and CSS ensure that it is usable in both places.
* Changes to the JavaScript ensure that the responsive design works with both the set and source carousels, and that all images have finished loading on the page before JavaScript styles are applied.
* As with the source carousel, if JavaScript is disabled in the browser, the user instead sees a hyperlinked list of sources.

Franky and I have tested this branch on staging.

This addresses [ticket #8096](https://issues.dp.la/issues/8096).