### PR TITLE
posters for sets & guides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem 'zencoder', '~>2.5'
 gem 'navigasmic', '~>1.0'
 gem 'turnout', '~>2.0'
 gem 'access-granted', '~> 1.0.0'
+# As of jasmine-jquery-rails v2.0.3, jasmine-jquery-rails is not compatible with
+# rake 11.0.0
+gem 'rake', '< 11.0'
 
 group :test, :development do
   gem 'rspec-core', '~> 3.3.2'

--- a/app/assets/javascripts/poster.js
+++ b/app/assets/javascripts/poster.js
@@ -1,0 +1,35 @@
+$(function() {
+  $(document).ready(function() {
+    // Render the poster after all images have finished loading.
+    $(window).on('load', function(){
+      height = 0;
+
+      $('.left img').each(function(){
+
+        // hide lefthand images (thumbnails) if width less than 110px
+        if($(this).width() < 110) {
+          $(this).hide();
+        }
+
+        // resize lefthand images so width = 110px
+        $(this).width(110);
+
+        height += $(this).height();
+      });
+
+      console.log(height);
+
+      /*
+       * If the height of all the lefthand images isn't enough to fill the
+       * space, repeat the the images.
+       */
+      while (height > 0 && height < 500) {
+        var html = $('.left').html();
+        $('.left').html(html + html);
+        height = height * 2;
+      }
+
+      $('.poster').css('visibility', 'visible');
+    });
+  });
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,5 +18,6 @@
  *= require_directory ./frontend
  *= require frontend_overrides.css
  *= require primary_source_sets.css
+ #= require poster.css
  *= require_self
  */

--- a/app/assets/stylesheets/poster.css
+++ b/app/assets/stylesheets/poster.css
@@ -1,0 +1,82 @@
+.poster {
+  width: 800px;
+  height: 450px;
+  background-color: #6792A5;
+  color: white;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  overflow: hidden;
+  border: 3px solid #4D6E7C;
+  box-sizing: border-box;
+  visibility: hidden;
+  margin-top: 12px;
+}
+
+.poster .right {
+  width: 470px;
+  height: 450px;
+  position: absolute;
+  left: 240px;
+}
+
+.poster .title {
+  position: absolute;
+  bottom: 290px;
+}
+
+.poster h1 {
+  font-size: 28px;
+  color: white;
+  font-weight: bold;
+}
+
+.poster .main-image {
+  position: absolute;
+  bottom: 130px;
+  border: 3px solid #4D6E7C;
+}
+
+.poster .logo {
+  position: absolute;
+  bottom: 20px;
+  overflow: hidden;
+  height: 39px;
+  left: 5px;
+}
+
+.poster .logo img {
+  position: absolute;
+  left: 141px;
+  background-color: white;
+  border: 2px solid white;
+}
+
+.poster .left {
+  width: 116px;
+  position: absolute;
+  height: 1000px;
+  left: 70px;
+  top: -50px;
+  background-color: #4D6E7C;
+}
+
+.poster .left img {
+  margin-bottom: 3px;
+  margin-left: 3px;
+  margin-right: 3px;
+}
+
+.poster .left p {
+  margin-top: 50px;
+}
+
+.poster .border {
+  position: absolute;
+  background-color: black;
+  height: 3px;
+  width: 120px;
+  z-index: 1000;
+  left: 90px;
+  right: 0;
+}

--- a/app/controllers/posters_controller.rb
+++ b/app/controllers/posters_controller.rb
@@ -1,0 +1,22 @@
+##
+# Handles requests for posters, which represent source sets.
+#
+# @see SourceSet
+class PostersController < ApplicationController
+  before_action :authenticate_admin!
+
+  def index
+    @source_sets = SourceSet.all
+    @guides = Guide.all
+  end
+
+  def show
+    @type = params[:type]
+    if (@type == 'set')
+      @source_set = SourceSet.friendly.find(params[:id])
+    elsif (@type == 'guide')
+      @guide = Guide.friendly.find(params[:id])
+      @source_set = @guide.source_set
+    end
+  end
+end

--- a/app/views/posters/index.html.erb
+++ b/app/views/posters/index.html.erb
@@ -1,0 +1,29 @@
+<h1>Posters</h1>
+
+<p>Posters are static image representations of sets and guides.  They can be used for marketing.</p>
+
+<h2>Source sets</h2>
+<% if @source_sets.present? %>
+  <ul>
+    <% @source_sets.each do |source_set| %>
+      <li>
+        <%= link_to inline_markdown(source_set.name), poster_path(source_set, type: 'set') %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>There are currently no set posters.</p>
+<% end %>
+
+<h2>Guides</h2>
+<% if @guides.present? %>
+  <ul>
+    <% @guides.each do |guide| %>
+      <li>
+        <%= link_to inline_markdown(guide.name), poster_path(guide, type: 'guide') %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>There are currently no guide posters.</p>
+<% end %>

--- a/app/views/posters/show.html.erb
+++ b/app/views/posters/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for :foot_script do %>
+  <%= javascript_include_tag 'poster', defer: 'defer' %>
+<% end %>
+
+<noscript>You cannot render a poster because your browser does not support JavaScript.</noscript>
+
+<div class='poster'>
+  <div class='right'>
+    <div class='title'>
+      <% if @type == 'set' %>
+        <h1>Primary Source Set: <%= inline_markdown(@source_set.name) %></h2>
+      <% elsif @type == 'guide' %>
+        <h1><%= inline_markdown(@guide.name) %></h2>
+      <% end %>
+    </div>  
+    <div class='main-image'>
+      <% if @source_set.featured_image.present? %>
+        <%= image_tag base_src + @source_set.featured_image.file_name %>
+      <% else %>
+        Please add a featured image to the set.
+      <% end %>
+    </div>
+    <div class='logo'>
+      <%= image_tag(branding_img('logo.png')) %>
+    </div>
+  </div>
+  <div class='left'>
+    <% if @source_set.sources.present? %>
+      <% @source_set.sources.each do |source| %>
+        <% if source.thumbnail.present? && source.thumbnail.file_name.present? %>
+          <%= image_tag(base_src + source.thumbnail.file_name) %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p>Please add at least one thumbnail to the set with a width of at least 110px.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_admin_menu.html.erb
+++ b/app/views/shared/_admin_menu.html.erb
@@ -46,6 +46,11 @@
   <%= link_to 'Vocabularies', vocabularies_path %>
   <% end %>
 
+  <% if can? :read, SourceSet %>
+  |
+  <%= link_to 'Posters', posters_path %>
+  <% end %>
+
   |
   <%= link_to 'Log out', destroy_admin_session_path, method: :delete %>
   </ul>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,6 +12,7 @@ Rails.application.config.assets.precompile += %w( form.js )
 Rails.application.config.assets.precompile += %w( style.js )
 Rails.application.config.assets.precompile += %w( openseadragon.js )
 Rails.application.config.assets.precompile += %w( results-bar.js )
+Rails.application.config.assets.precompile += %w( poster.js )
 
 # Precompile assets from gems
 Rails.application.config.assets.precompile += %w( dpla-colors.css dpla-fonts.css )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   resources :audio_notifications, only: [:create]
   resources :tags
   resources :vocabularies
+  resources :posters, only: [:index, :show]
 
   root 'source_sets#index'
 end

--- a/spec/controllers/posters_controller_spec.rb
+++ b/spec/controllers/posters_controller_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe PostersController, type: :controller do
+
+  let(:source_set) { create(:source_set_factory) }
+  let(:guide) { create(:guide_factory) }
+
+  context 'admin not logged in' do
+    describe '#index' do
+      it 'redirects to admin sign-in path' do
+        path = "#{Settings.relative_url_root}#{new_admin_session_path}"
+        get :index
+        expect(response).to redirect_to path
+      end
+    end
+
+    describe '#show' do
+      it 'redirect to admin sign-in path' do
+        path = "#{Settings.relative_url_root}#{new_admin_session_path}"
+        get :show, id: guide.slug, type: 'guide'
+        expect(response).to redirect_to path
+      end
+    end
+  end
+
+  context 'logged in admin' do
+    login_admin
+
+    describe '#index' do
+      it 'sets @source_sets variable' do
+        get :index
+        expect(assigns(:source_sets)).to include source_set
+      end
+
+      it 'sets @guides variable' do
+        get :index
+        expect(assigns(:guides)).to include guide
+      end
+
+      it 'renders the :index view' do
+        get :index
+        expect(response).to render_template :index
+      end
+    end
+
+    describe '#show' do
+      before do
+        source_set.guides << [guide]
+      end
+
+      it 'sets @type variable' do
+        get :show, id: guide.slug, type: 'guide'
+        expect(assigns(:type)).to eq 'guide'
+      end
+
+      it 'sets @source_set variable' do
+        get :show, id: guide.slug, type: 'guide'
+        expect(assigns(:source_set)).to eq source_set
+      end
+
+      it 'sets @guide variable' do
+        get :show, id: guide.slug, type: 'guide'
+        expect(assigns(:guide)).to eq guide
+      end
+
+      it 'renders the show view' do
+        get :show, id: guide.slug, type: 'guide'
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/views/posters/index.html.erb_spec.rb
+++ b/spec/views/posters/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe 'posters/index.html.erb', type: :view do
+  it_behaves_like 'renderable view'
+end

--- a/spec/views/posters/show.html.erb_spec.rb
+++ b/spec/views/posters/show.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'source_sets/show.html.erb', type: :view do
+
+  let(:source_set) { create(:source_set_factory) }
+
+  before do
+    assign(:source_set, source_set)
+    assign(:type, 'set')
+  end
+
+  describe 'posters/show.html.erb', type: :view do
+    it_behaves_like 'renderable view'
+  end
+end


### PR DESCRIPTION
This introduces a new feature, "posters", which are static image representations of sets and guides to be used for marketing.  Static images include names of sets or guides, their associated images, and the DPLA logo.  Specifically, these images will be used when submitting sets and guides to PBS learning media.  Admins will screenshot the images for local use.  While this is admittedly not ideal, we are saving time by not trying to implement HTML to image file functionality.

There are new routes, controllers, and views, but no new models as all the data needed to construct the posters are in `SourceSet` and `Guide`.  JavaScript is used for dynamic styling.  Posters are only visible to admins.

A sample poster:

<img width="814" alt="screen shot 2016-03-07 at 4 32 01 pm" src="https://cloud.githubusercontent.com/assets/3615206/13584013/68af5fbc-e482-11e5-9354-4843636e40ac.png">

