### PR TITLE
Allow admins to order tags within vocabularies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'therubyracer',  '~> 0.12.2', platforms: :ruby
 gem 'sass-rails', '~> 4.0.3'
 gem 'jquery-rails', '~> 3.1.3'
+gem 'jquery-ui-rails', '~> 5.0'
 gem 'config', '~> 1.0.0'
 gem 'redcarpet', '~> 3.3'
 gem 'friendly_id', '~> 5.1.0'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,6 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery-ui/sortable
 //= require jquery_ujs
 //= require nav-menu-effects

--- a/app/assets/javascripts/poster.js
+++ b/app/assets/javascripts/poster.js
@@ -17,8 +17,6 @@ $(function() {
         height += $(this).height();
       });
 
-      console.log(height);
-
       /*
        * If the height of all the lefthand images isn't enough to fill the
        * space, repeat the the images.

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -1,0 +1,22 @@
+/*
+ * Handles sortable sequences functionality.
+ * @see app/views/vocabularies/show.html.erb
+ */
+$(function() {
+  $(document).ready(function() {
+    $('#sequences').sortable({
+      /*
+       * When sortable sequence list is updated, send a POST request to
+       * sequences#sort containing the ids of all sequences in their new order.
+       */
+      update: function() {
+        $.ajax({
+          url: pss_sequences_sort_path, //defined in view
+          type: 'post',
+          data: $('#sequences').sortable('serialize'),
+          dataType: 'script'
+        });
+      }
+    });
+  });
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,6 +18,7 @@
  *= require_directory ./frontend
  *= require frontend_overrides.css
  *= require primary_source_sets.css
- #= require poster.css
+ *= require poster.css
+ *= require jquery-ui/sortable
  *= require_self
  */

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -418,6 +418,32 @@ input.form-submit {
   margin-bottom: 1em;
 }
 
+#sequences {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+#sequences li {
+  margin: 0 3px 3px 3px;
+  padding: 0.4em;
+  padding-left: 1.5em;
+}
+
+#sequences li span {
+  position: absolute;
+  margin-left: -1.3em;
+  margin-top: 2px;
+}
+
+#sequences li a {
+  color: #2795b6;
+}
+
+#sequences li a:hover {
+  color: black;
+}
+
 /* Carousels */
 
 .carousel-container {

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -1,0 +1,15 @@
+##
+# Handles HTTP requests for tags_vocabularies
+#
+# @see Sequence
+class SequencesController < ApplicationController
+  before_action :authenticate_admin!
+
+  # Custom POST route that updates the positions for a group of sequences.
+  def sort
+    params[:sequence].each_with_index do |id, index|
+      Sequence.where(id: id).update_all(position: index)
+    end
+    render nothing: true
+  end
+end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,0 +1,47 @@
+##
+# The Sequence model correlates to the sequences table, a join table between
+# tags and vocuabularies. This table includes the sequential position in which
+# tags appear within vocabularies.
+class Sequence < ActiveRecord::Base
+  belongs_to :tag
+  belongs_to :vocabulary
+  before_save :set_position
+  before_destroy :amend_positions
+  default_scope { order('position ASC') }
+
+  private
+
+  ##
+  # If self does not have a position, set its position to one greater than the
+  # current higest position for its vocabulary.  This will ensure that positions
+  # operate correctly as a sequential list.
+  #
+  # Note that if a value for position is present, this does not check whether or
+  # not the position is correctly incremented b/c it would interfere with
+  # methods such as :amend_positions. There is no way in the current user
+  # interface to set an incorrectly incremented position; however this could be
+  # done through the command line.  An incorrectly incremented position may
+  # cause the sequence to display in an inconsistent order, but should not cause
+  # any errors.
+  def set_position
+    if position.nil?
+      max_position = self.class.where('vocabulary_id = ?', vocabulary_id)
+                         .maximum(:position)
+      self.position = max_position.present? ? max_position + 1 : 0
+    end
+  end
+
+  ##
+  # Get all Sequences from the same vocabulary with a higher position.
+  # Reduce the position of all these Sequences by 1.
+  # This will ensure that positions operate correctly as a sequential list, with
+  # no gaps.
+  def amend_positions
+    sequences = self.class.where('vocabulary_id = ?', vocabulary_id)
+                    .where('position > ?', position)
+    sequences.each do |sequence|
+      sequence.decrement(:position)
+      sequence.save
+    end
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,8 @@
 class Tag < ActiveRecord::Base
   extend FriendlyId
   has_and_belongs_to_many :source_sets
-  has_and_belongs_to_many :vocabularies
+  has_many :sequences, dependent: :destroy
+  has_many :vocabularies, through: :sequences
   validates :label, presence: true, uniqueness: true
   validates :uri, format: { with: URI.regexp }, if: proc { |a| a.uri.present? }
 

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -1,6 +1,7 @@
 class Vocabulary < ActiveRecord::Base
   extend FriendlyId
-  has_and_belongs_to_many :tags
+  has_many :sequences, dependent: :destroy
+  has_many :tags, through: :sequences
   validates :name, presence: true, uniqueness: true
 
   ##

--- a/app/policies/access_policy.rb
+++ b/app/policies/access_policy.rb
@@ -22,6 +22,7 @@ class AccessPolicy
       can :manage, Document
       can :manage, Tag
       can :manage, Vocabulary
+      can :manage, Sequence
       can :manage, Author
     end
 
@@ -35,6 +36,7 @@ class AccessPolicy
       can :manage, Document
       can :manage, Tag
       can :manage, Vocabulary
+      can :manage, Sequence
       can :manage, Author
     end
 

--- a/app/views/vocabularies/edit.html.erb
+++ b/app/views/vocabularies/edit.html.erb
@@ -5,7 +5,7 @@
 <h1>Edit vocabulary</h1>
 
 <p>
-  <%= link_to "View", vocabulary_path(@vocabulary) %>
+  <%= link_to "View/Reorder", vocabulary_path(@vocabulary) %>
   |
   <%= link_to "Delete", vocabulary_path(@vocabulary),
             method: :delete,

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -8,7 +8,7 @@
 <% @vocabularies.each do |vocabulary| %>
   <tr>
     <td><%= vocabulary.name %></td>
-    <td><%= link_to "View", vocabulary_path(vocabulary) %></td>
+    <td><%= link_to "View/Reorder", vocabulary_path(vocabulary) %></td>
     <td><%= link_to "Edit", edit_vocabulary_path(vocabulary) %></td>
     <td><%= link_to "Delete", vocabulary_path(vocabulary),
                               method: :delete,

--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -1,3 +1,10 @@
+<% content_for :head_script do %>
+  <script>
+    var pss_sequences_sort_path = '<%= sequences_sort_path %>';
+  </script>
+  <%= javascript_include_tag 'sequence', defer: 'defer' %>
+<% end %>
+
 <h1>Vocabulary: <%= @vocabulary.name %></h1>
 
 <p>
@@ -19,10 +26,18 @@
 </table>
 
 <h2>Tags</h2>
-<ul>
-<% @vocabulary.tags.each do |tag| %>
-  <li><%= link_to tag.label, tag_path(tag) %></li>
+<% if @vocabulary.sequences.present? %>
+  <p>The order below is the order in which tags will appear in a filter menu (if this vocuabulary is filterable). Drag and drop to re-order.</p>
+  <ul id='sequences'>
+  <% for sequence in @vocabulary.sequences %>
+    <%= content_tag_for(:li, sequence, class: 'ui-state-default') do %>
+      <span class="ui-icon ui-icon-arrowthick-2-n-s"></span>
+      <%= link_to sequence.tag.label, tag_path(sequence.tag) %>
+    <% end %>
+  <% end %>
+  </ul>
+<% else %>
+  <p>There are currently no tags.</p>
 <% end %>
-</ul>
 
 <p><%= link_to "Add new tag", new_tag_path(vocabulary_id: @vocabulary.id) %></p>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,6 +13,7 @@ Rails.application.config.assets.precompile += %w( style.js )
 Rails.application.config.assets.precompile += %w( openseadragon.js )
 Rails.application.config.assets.precompile += %w( results-bar.js )
 Rails.application.config.assets.precompile += %w( poster.js )
+Rails.application.config.assets.precompile += %w( sequence.js )
 
 # Precompile assets from gems
 Rails.application.config.assets.precompile += %w( dpla-colors.css dpla-fonts.css )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,5 +33,7 @@ Rails.application.routes.draw do
   resources :vocabularies
   resources :posters, only: [:index, :show]
 
+  match 'sequences/sort', controller: :sequences, action: :sort, via: :post
+
   root 'source_sets#index'
 end

--- a/db/migrate/20160310164755_rename_tags_vocabularies.rb
+++ b/db/migrate/20160310164755_rename_tags_vocabularies.rb
@@ -1,0 +1,9 @@
+class RenameTagsVocabularies < ActiveRecord::Migration
+  def self.up
+    rename_table :tags_vocabularies, :sequences
+  end
+
+  def self.down
+    rename_table :sequences, :tags_vocabularies
+  end
+end

--- a/db/migrate/20160314132414_add_position_to_sequences.rb
+++ b/db/migrate/20160314132414_add_position_to_sequences.rb
@@ -1,0 +1,5 @@
+class AddPositionToSequences < ActiveRecord::Migration
+  def change
+    add_column :sequences, :position, :integer
+  end
+end

--- a/db/migrate/20160314132424_set_position_values.rb
+++ b/db/migrate/20160314132424_set_position_values.rb
@@ -1,0 +1,19 @@
+class SetPositionValues < ActiveRecord::Migration
+  def self.up
+    ##
+    # Set initial position values for TagVocabulary.
+    # Each tag's poisiton within its associated vocabulaires is set based on
+    # its created_at date. This will preserve the current production order.
+    Vocabulary.all.each do |vocab|
+      vocab.tags.order(created_at: :asc).each_with_index do |tag, index|
+        s = Sequence.where(tag_id: tag.id).where(vocabulary_id: vocab.id).first
+        s.position = index
+        s.save
+      end
+    end
+  end
+
+  def self.down
+    Sequence.update_all(position: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160304170852) do
+ActiveRecord::Schema.define(version: 20160314132424) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -120,6 +120,15 @@ ActiveRecord::Schema.define(version: 20160304170852) do
     t.text     "meta"
   end
 
+  create_table "sequences", force: true do |t|
+    t.integer "vocabulary_id"
+    t.integer "tag_id"
+    t.integer "position"
+  end
+
+  add_index "sequences", ["tag_id"], name: "index_sequences_on_tag_id"
+  add_index "sequences", ["vocabulary_id"], name: "index_sequences_on_vocabulary_id"
+
   create_table "source_sets", force: true do |t|
     t.string   "name"
     t.boolean  "published",                  default: false
@@ -162,14 +171,6 @@ ActiveRecord::Schema.define(version: 20160304170852) do
     t.datetime "updated_at", null: false
     t.string   "slug"
   end
-
-  create_table "tags_vocabularies", force: true do |t|
-    t.integer "vocabulary_id"
-    t.integer "tag_id"
-  end
-
-  add_index "tags_vocabularies", ["tag_id"], name: "index_tags_vocabularies_on_tag_id"
-  add_index "tags_vocabularies", ["vocabulary_id"], name: "index_tags_vocabularies_on_vocabulary_id"
 
   create_table "videos", force: true do |t|
     t.string   "file_base"

--- a/spec/controllers/sequences_controller_spec.rb
+++ b/spec/controllers/sequences_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe SequencesController, type: :controller do
+  context 'admin logged in' do
+    login_admin
+
+    describe '#sort' do
+      it 'updates sequence positions' do
+        s1 = create(:sequence_factory, vocabulary_id: 1, tag_id: 1, position: 0)
+        s2 = create(:sequence_factory, vocabulary_id: 1, tag_id: 2, position: 1)
+        post :sort, sequence: [s2.id, s1.id]
+        expect(s2.reload.position).to eq 0
+        expect(s1.reload.position).to eq 1
+      end
+
+      it 'renders nothing' do
+        post :sort, sequence: []
+        expect(response.body).to be_blank
+      end
+    end
+  end
+end

--- a/spec/factories/sequence.rb
+++ b/spec/factories/sequence.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :sequence_factory, class: Sequence do
+    tag_id 1
+    vocabulary_id 1
+  end
+end

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe Sequence, type: :model do
+
+  let!(:sequence0) { create(:sequence_factory, tag_id: 1, vocabulary_id: 1) }
+
+  it 'belongs to a tag' do
+    expect(Sequence.reflect_on_association(:tag).macro).to eq :belongs_to
+  end
+
+  it 'belongs to a vocabulary' do
+    expect(Sequence.reflect_on_association(:vocabulary).macro).to eq :belongs_to
+  end
+
+  it 'orders by position' do
+    sequence1 = create(:sequence_factory, tag_id: 2, vocabulary_id: 2,
+                                          position: 1)
+    expect(Sequence.all).to eq [sequence0, sequence1]
+  end
+
+  describe '#set_position' do
+
+    it 'sets position for tag within existing vocabulary' do
+      sequence = build(:sequence_factory, position: nil, tag_id: 2,
+                                          vocabulary_id: 1)
+      sequence.save
+      expect(sequence.reload.position).to eq 1
+    end
+
+    it 'sets position for tag with new vocabulary' do
+      sequence = build(:sequence_factory, position: nil, tag_id: 2,
+                                          vocabulary_id: 2)
+      sequence.save
+      expect(sequence.reload.position).to eq 0
+    end
+
+    it 'makes no change if position is not nil' do
+      sequence = build(:sequence_factory, position: 8, tag_id: 2,
+                                          vocabulary_id: 1)
+      sequence.save
+      expect(sequence.reload.position).to eq 8
+    end
+  end
+
+  describe '#amend_positions' do
+
+    it 'resets positions within vocabulary' do
+      sequence = create(:sequence_factory, tag_id: 2, vocabulary_id: 1)
+      sequence0.destroy
+      expect(sequence.reload.position).to eq 0
+    end
+
+    it 'does not reset positions from other vocabularies' do
+      sequence1 = create(:sequence_factory, tag_id: 2, vocabulary_id: 2)
+      sequence2 = create(:sequence_factory, tag_id: 3, vocabulary_id: 2)
+      sequence0.destroy
+      expect(sequence1.reload.position).to eq 0
+      expect(sequence2.reload.position).to eq 1
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -7,9 +7,12 @@ describe Tag, type: :model do
       .to eq :has_and_belongs_to_many
   end
 
-  it 'has and belongs to many vocabularies' do
-    expect(Tag.reflect_on_association(:vocabularies).macro)
-      .to eq :has_and_belongs_to_many
+  it 'has many sequences' do
+    expect(Tag.reflect_on_association(:sequences).macro).to eq :has_many
+  end
+
+  it 'has many vocabularies' do
+    expect(Tag.reflect_on_association(:vocabularies).macro).to eq :has_many
   end
 
   it 'is invalid without label' do

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 describe Vocabulary, type: :model do
 
-  it 'has and belongs to many tags' do
-    expect(Vocabulary.reflect_on_association(:tags).macro)
-      .to eq :has_and_belongs_to_many
+  it 'has many sequences' do
+    expect(Vocabulary.reflect_on_association(:sequences).macro).to eq :has_many
+  end
+
+  it 'has many tags' do
+    expect(Vocabulary.reflect_on_association(:tags).macro).to eq :has_many
   end
 
   it 'is invalid without name' do


### PR DESCRIPTION
This allows admins to order tags within vocabularies.  This is important for vocabularies such as "time period", where admins will want tags to display to users in chronological order.  Currently, tags are ordered by their created date, so admins have to consciously create tags in the order in which they want them to display. 

Tags and vocabularies have a many-to-many relationship.  This changes the name of their join table from `tags_vocabularies` to `sequences` for clarity.  A new field, `position`, has been added to the `sequences` table to record the sequential order in which tags should appear within vocabularies.  A final migration sets a `position` value for all existing rows in the join table.

A new model, `Sequence` has methods that check/amend `position` values when a sequence is saved or destroyed.  The `Tag` and `Vocabulary` models are edited to assert their relationship with sequence.  Since the name of the table is no longer `tags_vocabularies`, some things need to be made explicit that were previously taken care of through naming conventions (ie. "Rails magic").

A new route is added to handle re-sorting sequences.  This route sends a `POST` request to update the `sequences` table.  This route is only available to admins (managers and editors).

Resorting sequences in the UI happens on the `vocabularies#show` view.  A JavaScript UI plugin introduces drag-and-drop sorting.  While this adds an additional dependency, it makes for good user experience, and also helps to ensure that the items within a sequence are correctly incremented (as opposed to human-entered values, which could be incorrectly incremented).

This addresses [ticket #8243](https://issues.dp.la/issues/8243).  It has been tested locally and on staging.