### PR TITLE
Add link to provider's digital resource.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'access-granted', '~> 1.0.0'
 # As of jasmine-jquery-rails v2.0.3, jasmine-jquery-rails is not compatible with
 # rake 11.0.0
 gem 'rake', '< 11.0'
+gem 'DPLibrary', git: 'https://github.com/dpla/DPLibrary.git',
+                 branch: 'feature/add-new-prop-and-id-path'
 
 group :test, :development do
   gem 'rspec-core', '~> 3.3.2'

--- a/app/controllers/concerns/api_queryer.rb
+++ b/app/controllers/concerns/api_queryer.rb
@@ -1,0 +1,25 @@
+##
+# ApiQueryer: a mixin for controllers that need to query the DPLA API
+# and receive a DPLibrary::DocumentCollection
+#
+module ApiQueryer
+  extend ActiveSupport::Concern
+
+  ##
+  # Given one or more DPLA item IDs, return an array of items
+  #
+  # @param [Array<String>] *ids  One or more item IDs
+  # @return Array                Array of DPLibrary::Document
+  #
+  def dpla_items(*ids)
+    begin
+      DPLibrary::DocumentCollection.new(id: Array(ids)).documents
+    rescue NoMethodError
+      # Until specific exceptions are added to DPLibrary,
+      # DocumentCollection.new will fail with a NoMethodError if it's given a
+      # bad API key or item ID. Until that's addressed, handle NoMethodError.
+      logger.error "Bad API key #{Settings.api.key} or item IDs #{Array(ids)}"
+      return []
+    end
+  end
+end

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -6,6 +6,7 @@ class SourcesController < ApplicationController
   include VideoPlayerHelper
   include AudioPlayerHelper
   include MarkdownHelper
+  include ApiQueryer
   before_filter :load_source_set, only: [:index, :new, :create]
   before_action :authenticate_admin!,
                 only: [:new, :edit, :create, :update, :destroy]
@@ -23,7 +24,10 @@ class SourcesController < ApplicationController
     add_breadcrumb 'Source', source_path(@source)
     ma = @source.main_asset
     @file_base_or_name = nil
-    
+    dpla_item = dpla_items(@source.aggregation).first  # see ApiQueryer
+    @digital_resource_url = dpla_item.url unless dpla_item.nil?
+    @provider_name = dpla_item.provider.name unless dpla_item.nil?
+
     if ma.present?
       @file_base_or_name =
         ma.respond_to?(:file_base) ? ma.file_base : ma.file_name

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -35,8 +35,12 @@
         <h2>Credits</h2>
         <%= markdown(@source.credits) %>
         <h2>Need more information?</h2>
-        <%= link_to 'View the description of this item in DPLA',
-                    frontend_path('item/' + @source.aggregation) %>
+        <p><%= link_to 'View the description of this item in DPLA',
+                    frontend_path('item/' + @source.aggregation) %></p>
+        <% if !@provider_name.nil? %>
+        <p><%= link_to "View the item on #{@provider_name}",
+                    @digital_resource_url %></p>
+        <% end %>
       </div>
     </div>
   </aside>

--- a/config/initializers/dplibrary.rb
+++ b/config/initializers/dplibrary.rb
@@ -1,0 +1,1 @@
+DPLibrary.api_key = Settings.api.key

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,9 @@ wordpress:
 exhibtions:
   url: http://exmaple.com/
 
+api:
+  key: CHANGEME
+
 app_scheme: 'http://'
 # app_host may include port
 app_host: 'localhost:3000'

--- a/spec/controllers/concerns/api_queryer_spec.rb
+++ b/spec/controllers/concerns/api_queryer_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+module ConcernDouble
+  class ApiQueryerDouble < ApplicationController
+    include ApiQueryer
+  end
+end
+
+describe ApiQueryer do
+
+  context 'when included' do
+
+    subject { ConcernDouble::ApiQueryerDouble.new }
+    let(:documentcollection) { double() }
+    before do
+      allow(DPLibrary::DocumentCollection)
+        .to receive(:new).and_return(documentcollection)
+      allow(documentcollection).to receive(:documents).and_return([])
+    end
+
+    describe '#dpla_items' do
+      it 'queries the DPLA API for the item ID' do
+        expect(DPLibrary::DocumentCollection)
+          .to receive(:new).with({id: ['x']})
+          .and_return(documentcollection)
+        subject.dpla_items('x')
+      end
+
+      context 'when the query fails due to bad ID or API key' do
+        let (:apikey) { 'thekey' }
+        let (:id) { 'theid' }
+        before do
+          allow(DPLibrary::DocumentCollection).to receive(:new)
+            .and_raise(NoMethodError)
+          allow(Settings).to receive_message_chain(:api, :key)
+            .and_return(apikey)
+        end
+
+        it 'logs an error with the API key and item ID' do
+          msg = "Bad API key #{apikey} or item IDs #{Array(id)}"
+          expect(Rails.logger).to receive(:error).with(msg)
+          subject.dpla_items(id)
+        end
+
+        it 'returns an empty array' do
+          expect(subject.dpla_items(id)).to eq([])
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -25,6 +25,11 @@ describe SourcesController, type: :controller do
       :new, :edit, :create, :update, :destroy
 
     describe '#show' do
+      it 'calls ApiQueryer#dpla_items with the DPLA ID' do
+        expect(subject).to receive(:dpla_items).with(resource.aggregation)
+          .and_return([])
+        get :show, id: resource.id
+      end
 
       context 'with a source belonging to an unpublished set' do
         it 'redirects to the sign-in page' do

--- a/spec/views/sources/show.html.erb_spec.rb
+++ b/spec/views/sources/show.html.erb_spec.rb
@@ -16,6 +16,32 @@ describe 'sources/show.html.erb', type: :view do
     expect(rendered).to include(source.aggregation)
   end
 
+  context 'with a successful API request' do
+    let (:url) { 'http://example.org/' }
+    let (:provider) { 'X' }
+    before do
+      assign(:digital_resource_url, url)
+      assign(:provider_name, provider)
+    end
+
+    it 'renders the provider link' do
+      render
+      expect(rendered)
+        .to include("<a href=\"#{url}\">View the item on #{provider}")
+    end
+  end
+
+  context 'with a failed API request' do
+    before do
+      assign(:digital_resource_url, nil)
+      assign(:provider_name, nil)
+    end
+
+    it 'does not render any provider link' do
+      expect(rendered).not_to include('View the item on')
+    end
+  end
+
   context 'logged in manager' do
     before do
       admin = create(:admin_factory)


### PR DESCRIPTION
This addresses https://issues.dp.la/issues/8098, adding a link to the provider's digital resource on the source page.

I didn't add any tests, because the real work is handled by DPLibrary, which has -- or should have -- its own tests. Let me know if you think the `logger.error` call in `ApiQueryer` should be tested.

Is it best to have the API functionality in a concern?  I think it probably is, but want to make sure that sits well with you.

I have `ApiQueryer#dpla_items` taking variable arguments, because originally I thought it would be like a model's `find` method, which does just that.  I'm not so sure now, though. Let me know if you think it would be best simply taking an array. I don't really know the circumstances under which we'll be querying multiple item IDs some day.
