### PR TITLE
change header text for related sets and sources

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -18,9 +18,10 @@ class SourcesController < ApplicationController
 
   def show
     @source = Source.find(params[:id])
+    @source_set = @source.source_set
     check_login_and_authorize(:read, Source) \
-      unless @source.source_set.published?
-    add_breadcrumb inline_markdown(@source.source_set.name), source_set_path(@source.source_set)
+      unless @source_set.published?
+    add_breadcrumb inline_markdown(@source_set.name), source_set_path(@source_set)
     add_breadcrumb 'Source', source_path(@source)
     ma = @source.main_asset
     @file_base_or_name = nil

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -81,7 +81,7 @@
 <div class='related-sets'>
   <% related = @source_set.related_sets %>
   <% if related.present? %>
-    <h2>Related sets</h2>
+    <h2>Related primary source sets</h2>
 
     <div class='carousel-container js-off'>
       <div class='multiple-items slider carousel'>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :head_script do %>
   <title><%= plaintext_from_md(@source.name) %></title>
-  <meta name='description' content="This <%= @source.main_asset.class.name.downcase %> is part of '<%= strip_tags(inline_markdown(@source.source_set.name)) %>', a primary source set for educational use." />
+  <meta name='description' content="This <%= @source.main_asset.class.name.downcase %> is part of '<%= strip_tags(inline_markdown(@source_set.name)) %>', a primary source set for educational use." />
   <link rel='canonical' href='<%= url_for(controller: 'sources',
                                           action: 'show',
                                           id: @source.id,
@@ -51,7 +51,7 @@
 </div>
 
 <div class='related-sources'>
-  <h2>More sources from this set:</h1>
+  <h2>More primary sources about <%= link_to(inline_markdown(@source_set.name), source_set_path(@source_set)) %></h2>
   
   <div class='carousel-container js-off'>
     <div class='multiple-items slider carousel'>
@@ -100,7 +100,7 @@
   <table>
     <tr>
       <td><strong>Set: </strong></td>
-      <td><%= link_to inline_markdown(@source.source_set.name), source_set_path(@source.source_set)%></td>
+      <td><%= link_to inline_markdown(@source_set.name), source_set_path(@source_set)%></td>
     </tr>
     <tr>
       <td><strong>DPLA item URI: </strong></td>

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -25,6 +25,11 @@ describe SourcesController, type: :controller do
       :new, :edit, :create, :update, :destroy
 
     describe '#show' do
+      it 'sets @source_set variable' do
+        get :show, id: resource.id
+        expect(assigns(:source_set)).to eq resource.source_set
+      end
+
       it 'calls ApiQueryer#dpla_items with the DPLA ID' do
         expect(subject).to receive(:dpla_items).with(resource.aggregation)
           .and_return([])
@@ -48,5 +53,4 @@ describe SourcesController, type: :controller do
       end
     end
   end
-
 end


### PR DESCRIPTION
This changes the `<h2>` text for related set and sources for clarity.

It also sets a `@source_set` variable for `source#show` - I noticed there were several calls to `@source.source_set`, and wanted to reduce calls to the database.

This addresses [ticket #8323](https://issues.dp.la/issues/8323).