### PR TITLE
Add admin username

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -418,6 +418,11 @@ input.form-submit {
   margin-bottom: 1em;
 }
 
+.pss-admin-form.admin input[type='text'] {
+  height: auto;
+  width: auto;
+}
+
 #tag_sequences {
   list-style-type: none;
   margin: 0;

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -62,7 +62,7 @@ class RegistrationsController < Devise::RegistrationsController
     authorize! :destroy, Admin
     @admin = Admin.find(params[:id])
     @admin.destroy
-    redirect_to registrations_path    
+    redirect_to registrations_path
   end
 
   protected
@@ -72,6 +72,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:account_update) << :status
+    devise_parameter_sanitizer.for(:account_update) << [:status, :username]
+    devise_parameter_sanitizer.for(:sign_up) << :username
   end
 end

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -12,11 +12,17 @@
 <%= form_for(resource,
              as: resource_name,
              url: registration_path(resource),
-             html: { class: 'pss-admin-form' }) do |f| %>
+             html: { class: 'pss-admin-form admin' }) do |f| %>
 
   <fieldset>
-    <%= f.label :email %><br />
+    <%= f.label :email %>
     <%= f.email_field :email, autofocus: true %>
+  </fieldset>
+
+  <fieldset>
+    <%= f.label :username %>
+    <div><em>(optional)</em></div>
+    <%= f.text_field :username %>
   </fieldset>
 
   <% if current_admin.id == resource.id %>

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -5,6 +5,7 @@
 <table>
 <% @admins.each do |admin| %>
   <tr>
+    <td><%= admin.username %></td>
     <td><%= admin.email %></td>
     <td><%= link_to "Edit", edit_registration_path(admin) %></td>
     <td><%= link_to "Delete", registration_path(admin),

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -7,10 +7,13 @@
 <%= form_for(resource,
              as: resource_name,
              url: registrations_path(resource),
-             html: { class: 'pss-admin-form' }) do |f| %>
+             html: { class: 'pss-admin-form admin' }) do |f| %>
 
   <%= f.label :email %>
   <%= f.email_field :email, autofocus: true %>
+
+  <%= f.label :username %>
+  <%= f.text_field :username %><br/>
 
   <%= f.submit "Create", class: 'form-submit' %>
 

--- a/db/migrate/20160317140404_add_username_to_admins.rb
+++ b/db/migrate/20160317140404_add_username_to_admins.rb
@@ -1,0 +1,5 @@
+class AddUsernameToAdmins < ActiveRecord::Migration
+  def change
+    add_column :admins, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160316201152) do
+ActiveRecord::Schema.define(version: 20160317140404) do
 
   create_table "admins", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20160316201152) do
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
     t.integer  "status",                 default: 0
+    t.string   "username"
   end
 
   add_index "admins", ["confirmation_token"], name: "index_admins_on_confirmation_token", unique: true

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -44,6 +44,12 @@ describe RegistrationsController, type: :controller do
         expect(resource.status).to eq 'manager'
       end
 
+      it 'updates the username' do
+        patch :update, id: resource.id, admin: { username: 'u' }
+        resource.reload
+        expect(resource.username).to eq 'u'
+      end
+
       context 'with an invalid email address' do
         it 'does not update the record' do
           patch :update, id: resource.id, admin: { email: 'x' }

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     confirmed_at DateTime.now
     confirmation_sent_at DateTime.now
     status 2
+    username 'Admin user'
   end
 
   factory :brandnew_admin_factory, class: Admin do
@@ -16,6 +17,7 @@ FactoryGirl.define do
   factory :unconfirmed_admin_factory, class: Admin do
     email 'test3@example.org'
     status 0
+    username 'User Name'
   end
 
   factory :reviewer_admin_factory, class: Admin do

--- a/spec/views/registrations/edit.html.erb_spec.rb
+++ b/spec/views/registrations/edit.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'registrations/edit.html.erb', type: :view do
+
+  let(:admin) { create(:admin_factory) }
+
+  before do
+    assign(:admin, admin)
+    sign_in admin
+    # stub devise methods
+    allow(view).to receive(:devise_mapping).and_return(Devise.mappings[:admin])
+    allow(view).to receive(:resource).and_return(admin)
+    allow(view).to receive(:resource_name).and_return(:admin)
+  end
+
+  it_behaves_like 'renderable view'
+
+  it 'shows admin email' do
+    render
+    expect(rendered).to include admin.email
+  end
+
+  it 'shows admin username' do
+    render
+    expect(rendered).to include admin.username
+  end
+end

--- a/spec/views/registrations/index.html.erb_spec.rb
+++ b/spec/views/registrations/index.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'registrations/index.html.erb', type: :view do
+
+  let(:admin) { create(:admin_factory) }
+  before { assign(:admins, [admin]) }
+
+  it_behaves_like 'renderable view'
+
+  it 'shows admin email' do
+    render
+    expect(rendered).to include admin.email
+  end
+
+  it 'shows admin username' do
+    render
+    expect(rendered).to include admin.username
+  end
+
+  it 'links to new registration path' do
+    render
+    expect(rendered).to include new_registration_path
+  end
+
+  it 'links to edit admin path' do
+    render
+    expect(rendered).to include edit_registration_path(admin)
+  end
+end

--- a/spec/views/registrations/new.html.erb_spec.rb
+++ b/spec/views/registrations/new.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'registrations/new.html.erb', type: :view do
+
+  let(:admin) { create(:admin_factory) }
+
+  before do
+    assign(:admin, admin)
+    # stub devise methods
+    allow(view).to receive(:resource).and_return(admin)
+    allow(view).to receive(:resource_name).and_return(:admin)
+  end
+
+  it_behaves_like 'renderable view'
+end


### PR DESCRIPTION
This adds a `username` field to admins.  This will help managers to identify other admins who may not have easily identifiable email addresses.  `username` is not a required field.

In summary:

- A `username` field is added to the `admins` table.
- `username` is included as a permitted param for `new` and `update` controller methods.
- `username` is added to `index`, `new`, and `edit` views.
- Controller tests (with associated factories) make sure that `username` can be created and edited.
- View specs for `index`, `new`, and `edit` are added.
- A little CSS styling makes it look nice.

This addresses [#8264](https://issues.dp.la/issues/8264).  It has been tested locally.