### PR TITLE
move javascript to head with defer attribute

### DIFF
--- a/app/views/audios/new.html.erb
+++ b/app/views/audios/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :foot_script do %>
+<% content_for :head_script do %>
 
   <script>
       var pss_create_asset_path = '<%= audios_path() %>';
@@ -6,7 +6,7 @@
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
-  <%= javascript_include_tag 'avupload' %>
+  <%= javascript_include_tag 'avupload', defer: 'defer' %>
 
 <% end %>
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :foot_script do %>
+<% content_for :head_script do %>
 
   <script>
       var pss_create_asset_path = '<%= documents_path() %>';
@@ -6,7 +6,7 @@
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
-  <%= javascript_include_tag 'docupload' %>
+  <%= javascript_include_tag 'docupload', defer: 'defer' %>
 
 <% end %>
 

--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <h1>Edit teaching guide</h1>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <p><%= link_to "Back to set", source_set_path(@source_set) %></p>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :foot_script do %>
+<% content_for :head_script do %>
 
   <script>
       var pss_create_asset_path = '<%= images_path() %>';
@@ -6,7 +6,7 @@
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
-  <%= javascript_include_tag 'imgupload' %>
+  <%= javascript_include_tag 'imgupload', defer: 'defer' %>
 
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,8 @@
           rel='stylesheet' type='text/css'>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= branding_stylesheets %>
-    <%= javascript_include_tag 'application' %>
+    <%= javascript_include_tag 'application' %><%# do not defer %>
+    <%= javascript_include_tag 'style', defer: 'defer' %>
     <%= csrf_meta_tags %>
     <%= yield :head_script %>
   </head>
@@ -26,5 +27,4 @@
     <%= render partial: 'shared/jump_links' %>
   </body>
   <%= yield :foot_script %>
-  <%= javascript_include_tag 'style' %>
 </html>

--- a/app/views/posters/show.html.erb
+++ b/app/views/posters/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :foot_script do %>
+<% content_for :head_script do %>
   <%= javascript_include_tag 'poster', defer: 'defer' %>
 <% end %>
 

--- a/app/views/source_sets/edit.html.erb
+++ b/app/views/source_sets/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <h1>Edit set</h1>

--- a/app/views/source_sets/new.html.erb
+++ b/app/views/source_sets/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <h1>New set</h1>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -8,12 +8,13 @@
                                           trailing_slash: true) %>' />
   <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css' />
   <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick-theme.css' />
+  <script type="text/javascript"
+          src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"
+          defer></script>
+  <%= javascript_include_tag 'carousel', defer: 'defer' %>
 <% end %>
 
 <% content_for :foot_script do %>
-  <%= javascript_include_tag 'carousel' %>
-  <script type="text/javascript"
-          src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
   <%= render partial: 'shared/analytics' %>
 <% end %>
 

--- a/app/views/sources/_image.html.erb
+++ b/app/views/sources/_image.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head_script do %>
-<% javascript_include_tag 'openseadragon', defer: 'defer' %>
+  <%= javascript_include_tag 'openseadragon', defer: 'defer' %>
 <% end %>
 
 <article class='image'>

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <h1>Edit source</h1>

--- a/app/views/sources/new.html.erb
+++ b/app/views/sources/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <p><%= link_to "Back to set", source_set_path(@source_set) %></p>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -8,13 +8,13 @@
                                           trailing_slash: true) %>' />
   <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.css' />
   <link rel="stylesheet" type="text/css" href= 'http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick-theme.css' />
+  <script type="text/javascript"
+          src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"
+          defer></script>
+  <%= javascript_include_tag 'carousel', defer: 'defer' %>
 <% end %>
 
 <% content_for :foot_script do %>
-  <%= javascript_include_tag 'lightbox' %>
-  <%= javascript_include_tag 'carousel' %>
-  <script type="text/javascript"
-          src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"></script>
   <%= render partial: 'shared/analytics' %>
 <% end %>
 

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <h1>Edit tag</h1>

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <p><%= link_to "Back to tags", tags_path %></p>

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :foot_script do %>
+<% content_for :head_script do %>
 
   <script>
       var pss_create_asset_path = '<%= videos_path() %>';
@@ -6,7 +6,7 @@
       var source_id = '<%= @source.present? ? @source.id : nil %>';
   </script>
 
-  <%= javascript_include_tag 'avupload' %>
+  <%= javascript_include_tag 'avupload', defer: 'defer' %>
 
 <% end %>
 

--- a/app/views/vocabularies/edit.html.erb
+++ b/app/views/vocabularies/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <h1>Edit vocabulary</h1>

--- a/app/views/vocabularies/new.html.erb
+++ b/app/views/vocabularies/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :foot_script do %>
-  <%= javascript_include_tag 'form' %>
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form', defer: 'defer' %>
 <% end %>
 
 <p><%= link_to "Back to vocabularies", vocabularies_path %></p>


### PR DESCRIPTION
This moves all included javascript files to the HTML `<head>` and uses the `defer` tag to ensure that the javascripts do not load until after the page has finished parsing.  Before, we were inconsistently using the `defer` tag and putting included javascript files in both the `<head>` and after the `<body>`.

The `defer` attribute is supported by all major browsers of reasonably recent versions: http://www.w3schools.com/tags/att_script_defer.asp

This has been tested in a local deployment, but since we do not have full tests for all javascript functionality, it should be deployed and manually tested by a second set of eyes.

This addresses [ticket #8248](https://issues.dp.la/issues/8248).