### PR TITLE
social media share buttons

### DIFF
--- a/app/assets/javascripts/social.js
+++ b/app/assets/javascripts/social.js
@@ -1,0 +1,19 @@
+$(window).load(function() {
+
+  ///// Social media buttons
+  if ($('.shareSave').length) {
+    (function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
+      fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));
+
+    (function() {
+      var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
+      po.src = 'https://apis.google.com/js/plusone.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+    })();
+  }
+});

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -285,6 +285,8 @@
 
 .breadcrumbs {
   padding: 0 0 10px 0;
+  display: inline-block;
+  float: left;
 }
 
 iframe {
@@ -474,6 +476,13 @@ input.form-submit {
   width: 100%;
   height: 100%;
   background-color: #6592A6;
+}
+
+/* Social share */
+
+ul.shareSave {
+  display: inline-block;
+  float: right;
 }
 
 /* Mobile layout */

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -5,12 +5,15 @@
                                           action: 'show',
                                           id: @guide.slug,
                                           only_path: false,
-                                          trailing_slash: true) %>' /> 
+                                          trailing_slash: true) %>' />
+  <%= javascript_include_tag 'social', defer: 'defer' %>
 <% end %>
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>
 <% end %>
+
+<%= render partial: 'shared/share' %>
 
 <div class="breadcrumbs">
   <%= render_breadcrumbs separator: ' / ' %>

--- a/app/views/shared/_share.html.erb
+++ b/app/views/shared/_share.html.erb
@@ -1,0 +1,28 @@
+<ul class='shareSave'>
+  <li class='btn share'>
+    <a href=''>Share</a>
+    <ul>
+      <li>
+        <div class='sharebtn'>
+          <div id='fb-root'></div>
+          <div class='fb-like' data-layout='button_count' data-send='false'
+               data-show-faces='false' data-width='450'></div>
+        </div>
+      </li>
+      <li>
+        <div class='sharebtn'>
+          <a class='twitter-share-button' href='https://twitter.com/share'>
+            Tweet
+          </a>
+          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
+          </script>
+        </div>
+      </li>
+      <li>
+        <div class='sharebtn'>
+          <div class='g-plusone' datasize='medium'></div>
+        </div>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -12,11 +12,14 @@
           src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"
           defer></script>
   <%= javascript_include_tag 'carousel', defer: 'defer' %>
+  <%= javascript_include_tag 'social', defer: 'defer' %>
 <% end %>
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>
 <% end %>
+
+<%= render partial: 'shared/share' %>
 
 <div class="breadcrumbs">
   <%= render_breadcrumbs separator: ' / ' %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -12,11 +12,14 @@
           src="http://cdn.jsdelivr.net/jquery.slick/1.5.9/slick.min.js"
           defer></script>
   <%= javascript_include_tag 'carousel', defer: 'defer' %>
+  <%= javascript_include_tag 'social', defer: 'defer' %>
 <% end %>
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>
 <% end %>
+
+<%= render partial: 'shared/share' %>
 
 <div class="breadcrumbs">
   <%= render_breadcrumbs separator: ' / ' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,6 +13,7 @@ Rails.application.config.assets.precompile += %w( style.js )
 Rails.application.config.assets.precompile += %w( openseadragon.js )
 Rails.application.config.assets.precompile += %w( results-bar.js )
 Rails.application.config.assets.precompile += %w( poster.js )
+Rails.application.config.assets.precompile += %w( social.js )
 Rails.application.config.assets.precompile += %w( tag_sequence.js )
 
 # Precompile assets from gems


### PR DESCRIPTION
This adds social media share buttons to sets, sources, and guides (show views only).  The HTML and javascript are copied exactly from the frontend application for consistency and ease of maintenance.  A small amount of CSS improves the display.

This addresses [ticket #7922](https://issues.dp.la/issues/7922).  