### PR TITLE
validate that aggregation is only letters and numbers

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -34,7 +34,9 @@ class Source < ActiveRecord::Base
                         source: :asset,
                         source_type: 'Image'
 
-  validates :aggregation, presence: true
+  validates :aggregation, presence: true, 
+                          format: { with: /\A[a-zA-Z0-9]+\z/,
+                                    message: 'can only be letters and numbers' }
 
   default_scope { order('created_at ASC') }
 

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -36,6 +36,14 @@ describe Source, type: :model do
     expect(Source.new(aggregation: nil)).not_to be_valid
   end
 
+  it 'is invalid if aggregation has whitespace characters' do
+    expect(Source.new(aggregation: '123 abc')).not_to be_valid
+  end
+
+  it 'is invalid if aggregation has special characters' do
+    expect(Source.new(aggregation: '123*ABC')).not_to be_valid
+  end
+
   it 'orders by created date' do
     source_1 = source
     source_2 = create(:source_factory, name: 'source 2')


### PR DESCRIPTION
This adds a validation to the `Source` model ensuring that the value for an aggregation (ie. the ID of an item in DPLA) is comprised of letters and numbers.  This will help to prevent errors elsewhere in the system, where links are formed to items in the frontend using the aggregation (ie.  http://dp.la/item/90aade1f9d91965c921026d3b0dc2d8f). 

This addresses [ticket #8330](https://issues.dp.la/issues/8330).