### PR TITLE
add guide and set menus to authors form

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -51,6 +51,9 @@ class AuthorsController < ApplicationController
   private
 
   def author_params
-    params.require(:author).permit(:name, :affiliation)
+    params.require(:author).permit(:name,
+                                   :affiliation,
+                                   source_set_ids: [],
+                                   guide_ids: [])
   end
 end

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -15,6 +15,8 @@ class AuthorsController < ApplicationController
 
   def new
     @author = Author.new
+    @author.source_set_ids = [params[:source_set_id]]
+    @author.guide_ids = [params[:guide_id]]
   end
 
   def edit

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -23,6 +23,36 @@
     <strong><%= f.label :affiliation %></strong>
     <%= f.text_field :affiliation %>
   </p>
+
+  <div class='expansible'>
+    <h2><%= f.label :sets %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% sets = SourceSet.all %>
+      <% if sets.present? %>
+        <%= f.collection_check_boxes(:source_set_ids, sets, :id, :name) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no sets.</p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class='expansible'>
+    <h2><%= f.label :guides %></h2>
+    <a class='expand-control'>show</a>
+    <div class='expand-content'>
+      <% guides = Guide.all %>
+      <% if guides.present? %>
+        <%= f.collection_check_boxes(:guide_ids, guides, :id, :name) do |b| %>
+          <%= b.label { b.check_box + b.text } %><br />
+        <% end %>
+      <% else %>
+        <p>There are currently no guides.</p>
+      <% end %>
+    </div>
+  </div>
   
   <p>
     <%= f.submit 'Submit', class: 'form-submit' %>

--- a/app/views/authors/edit.html.erb
+++ b/app/views/authors/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <h1>Edit author</h1>
 
 <p>

--- a/app/views/authors/new.html.erb
+++ b/app/views/authors/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'form' %>
+<% end %>
+
 <p><%= link_to "Back to authors", authors_path %></p>
 
 <h1>New author</h1>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -122,4 +122,6 @@
       <td><%= link_to inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set)%></td>
     </tr>
   </table>
+
+  <p><%= link_to "Add new author", new_author_path(guide_id: @guide.id) %></p>
 <% end %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -158,6 +158,8 @@
   <% unless current_admin.reviewer? %>
     <p><%= link_to "Add new tag", new_tag_path(source_set_id: @source_set.id) %></p>
 
+    <p><%= link_to "Add new author", new_author_path(source_set_id: @source_set.id) %></p>
+
     <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
 
     <p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -14,5 +14,21 @@ describe AuthorsController, type: :controller do
     it_behaves_like 'basic controller', :index, :show, :create, :update,
                                         :destroy
     it_behaves_like 'redirecting controller', :create
+
+    describe '#new' do
+      it 'adds source_set_id from param' do
+        source_set = create(:source_set_factory)
+        get :new, source_set_id: source_set.id
+        expect(assigns(:author).source_set_ids)
+          .to contain_exactly(source_set.id)
+      end
+
+      it 'adds guide_id from param' do
+        guide = create(:guide_factory)
+        get :new, guide_id: guide.id
+        expect(assigns(:author).guide_ids)
+          .to contain_exactly(guide.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds checkbox menus to the forms to create and edit authors. The menus allow admins to associate authors with existing sets or guides. Similar checkbox menus already appear on create/edit forms for sets, guides, sources, vocabularies, and tags.  Existing JavaScript code is included - this JavaScript allows end users to expand and collapse menus for easy readability.

This also allows you to specify a set or guide to be associated with the author in the URL for the new author form.  So, for example, `/authors/new?guide_id=1` will pre-populate the guides menu so that the guide with id=1 is checked.  This will help admin workflow.  A similar feature already exists for tags and vocabularies.

This addresses [ticket #8297](https://issues.dp.la/issues/8297).