### PR TITLE
add spacing to tables

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -13,6 +13,11 @@
   clear: both;
 }
 
+table td {
+  padding-right: 0.6em;
+  padding-bottom: 0.2em;
+}
+
 /*
  * Use js-off to hide elements if javascript is disabled.
  * @see assets/javascripts/style.js


### PR DESCRIPTION
This adds padding to tables for legibility.  Many admin views contain HTML tables. These tables currently have no padding or margins, making them difficult to read.  HTML tables are not used in any other capacity in the application.

Before spacing was added:
![screen shot 2016-04-01 at 3 53 10 pm](https://cloud.githubusercontent.com/assets/3615206/14218407/f9b685f0-f821-11e5-9815-94cb75cb9537.png)

After spacing was added:
![screen shot 2016-04-01 at 3 52 45 pm](https://cloud.githubusercontent.com/assets/3615206/14218414/009f97bc-f822-11e5-9cd5-84dcc7287d2f.png)


This addresses [ticket #8353](https://issues.dp.la/issues/8353).