### PR TITLE
Improve workflow links for building associations between objects.

### DIFF
--- a/app/assets/javascripts/form.js
+++ b/app/assets/javascripts/form.js
@@ -29,6 +29,8 @@
     $('.expand-control').html('show').show();
     $('.expand-content').hide();
 
+    showExpansibleAnchors();
+
     /* 
      * Show/hide function for expansible content.
      * .expand-control is a DOM element that users can click to show or hide
@@ -45,4 +47,25 @@
       }
     });
   });
+
+  /*
+   * Show expansible content if content block is indicated in URL jump anchor.
+   * For example, if the URL is:
+   *   http://example.com/sets/my-set/edit#author
+   * then the expansible block with the 'author' jump anchor tag will be shown.
+   */
+  function showExpansibleAnchors() {
+    var anchors = expansibleAnchors();
+    for (a in anchors) {
+      var block = $('a[name=' + anchors[a] + ']').closest('.expansible');
+      block.find('.expand-control').html('hide');
+      block.find('.expand-content').show();
+    }
+  }
+
+  function expansibleAnchors() {
+    var anchors = document.location.toString().split('#');
+    anchors.shift();
+    return anchors;
+  }
 })();

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -25,6 +25,7 @@
   </p>
 
   <div class='expansible'>
+    <a name='sets'></a>
     <h2><%= f.label :sets %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>
@@ -40,6 +41,7 @@
   </div>
 
   <div class='expansible'>
+    <a name='guides'></a>
     <h2><%= f.label :guides %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -19,6 +19,9 @@
 </table>
 
 <h2>Sets</h2>
+<% unless current_admin.present? && current_admin.reviewer? %>
+  <%= link_to 'Add/remove sets', edit_author_path(@author, anchor: 'sets') %>
+<% end %>
 <ul>
 <% @author.source_sets.each do |source_set| %>
   <li><%= link_to inline_markdown(source_set.name), source_set_path(source_set) %></li>
@@ -26,6 +29,9 @@
 </ul>
 
 <h2>Teaching guides</h2>
+<% unless current_admin.present? && current_admin.reviewer? %>
+  <%= link_to 'Add/remove guides', edit_author_path(@author, anchor: 'guides') %>
+<% end %>
 <ul>
   <% @author.guides.each do |guide| %>
     <li><%= link_to inline_markdown(guide.name), guide_path(guide) %></li>

--- a/app/views/guides/_form.html.erb
+++ b/app/views/guides/_form.html.erb
@@ -35,6 +35,7 @@
   </p>
 
   <div class='expansible'>
+    <a name='author'></a>
     <h2><%= f.label :author %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -123,5 +123,9 @@
     </tr>
   </table>
 
-  <p><%= link_to "Add new author", new_author_path(guide_id: @guide.id) %></p>
+  <br/>
+
+  <div>
+    <%= link_to "Add/remove author", edit_guide_path(@guide, anchor: 'author') %> or <%= link_to "create new author", new_author_path(guide_id: @guide.id) %>
+  </div>
 <% end %>

--- a/app/views/source_sets/_form.html.erb
+++ b/app/views/source_sets/_form.html.erb
@@ -54,6 +54,7 @@
   </p>
 
   <div class='expansible'>
+    <a name='author'></a>
     <h2><%= f.label :author %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>
@@ -69,6 +70,7 @@
   </div>
 
   <div class='expansible'>
+    <a name='tag'></a>
     <h2><%= f.label :tag %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -145,24 +145,14 @@
         <% end %>
       </td>
     </tr>
-    <tr>
-      <td valign="top"><strong>Tags:</strong></td>
-      <td>
-        <% @source_set.tags.each do |tag| %>
-          <%= link_to tag.label, tag_path(tag) %><br/>
-        <% end %>
-      </td>
-    </tr>
   </table>
 
+  <br/>
+
   <% unless current_admin.reviewer? %>
-    <p><%= link_to "Add new tag", new_tag_path(source_set_id: @source_set.id) %></p>
-
-    <p><%= link_to "Add new author", new_author_path(source_set_id: @source_set.id) %></p>
-
-    <p><%= link_to "Add new source", new_source_set_source_path(@source_set.id) %></p>
-
-    <p><%= link_to "Add new teaching guide", new_source_set_guide_path(@source_set.id) %></p>
+    <div><%= link_to 'Add/remove authors', edit_source_set_path(@source_set, anchor: 'author') %> or <%= link_to 'create new author', new_author_path(source_set_id: @source_set.id) %></div>
+    <div><%= link_to 'Add/remove tags', edit_source_set_path(@source_set, anchor: 'tag') %> or <%= link_to 'create new tag', new_tag_path(source_set_id: @source_set.id) %></div>
+    <div><%= link_to "Create new source", new_source_set_source_path(@source_set.id) %></div>
+    <div><%= link_to "Create new teaching guide", new_source_set_guide_path(@source_set.id) %></div>
   <% end %>
-
 <% end %>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -53,6 +53,7 @@
   </p>
 
   <div class='expansible'>
+    <a name='main-media-asset'></a>
     <h2>Main media asset</h2>
     <a class='expand-control'>show</a>
 
@@ -101,6 +102,7 @@
   </div>
 
   <div class='expansible'>
+    <a name='thumbnail'></a>
     <h2><%= f.label :thumbnail %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>
@@ -116,6 +118,7 @@
   </div>
 
   <div class='expansible'>
+    <a name='small-image'></a>
     <h2><%= f.label :small_image %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -119,15 +119,30 @@
   <% unless current_admin.reviewer? %>
     <h3>Media assets</h2>
 
-    <p>
-      <%= link_to "Add new image", new_image_path(source_id: @source.id) %>
-      |
-      <%= link_to "Add new document", new_document_path(source_id: @source.id) %>
-      |
-      <%= link_to "Add new audio", new_audio_path(source_id: @source.id) %>
-      |
-      <%= link_to "Add new video", new_video_path(source_id: @source.id) %>
-    </p>
+    <div>
+      <%= link_to 'Add/remove main media asset', edit_source_path(@source, anchor: 'main-media-asset') %>
+    </div>
+    <div>
+      <%= link_to 'Add/remove thumbnail', edit_source_path(@source, anchor: 'thumbnail') %>
+    </div>
+    <div>
+      <%= link_to 'Add/remove small image', edit_source_path(@source, anchor: 'small-image') %>
+    </div>
+    <br/>
+    <div>
+      <%= link_to "Create new image", new_image_path(source_id: @source.id) %>
+    </div>
+    <div>
+      <%= link_to "Create new document", new_document_path(source_id: @source.id) %>
+    </div>
+    <div>
+      <%= link_to "Create new audio", new_audio_path(source_id: @source.id) %>
+    </div>
+    <div>
+      <%= link_to "Create new video", new_video_path(source_id: @source.id) %>
+    </div>
+
+    <br/>
 
     <table>
 

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -30,6 +30,7 @@
   </p>
 
   <div class='expansible'>
+    <a name='vocabularies'></a>
     <h2><%= f.label :vocabularies %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>
@@ -45,7 +46,8 @@
   </div>
 
   <div class='expansible'>
-    <h2><%= f.label :source_sets %></h2>
+    <a name='sets'></a>
+    <h2><%= f.label :sets %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>
       <% source_sets = SourceSet.all %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -19,6 +19,7 @@
 </table>
 
 <h2>Vocabularies</h2>
+<%= link_to 'Add/remove vocabularies', edit_tag_path(@tag, anchor: 'vocabularies') %>
 <ul>
   <% @tag.vocabularies.each do |vocabulary| %>
     <li><%= link_to vocabulary.name, vocabulary_path(vocabulary) %></li>
@@ -26,8 +27,9 @@
 </ul>
 
 <h2>Sets</h2>
+<%= link_to 'Add/remove sets', edit_tag_path(@tag, anchor: 'sets') %>
 <ul>
-<% @tag.source_sets.each do |source_set| %>
-  <li><%= link_to inline_markdown(source_set.name), source_set_path(source_set) %></li>
-<% end %>
+  <% @tag.source_sets.each do |source_set| %>
+    <li><%= link_to inline_markdown(source_set.name), source_set_path(source_set) %></li>
+  <% end %>
 </ul>

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -30,6 +30,7 @@
   </p>
 
   <div class='expansible'>
+    <a name='tags'></a>
     <h2><%= f.label :tags %></h2>
     <a class='expand-control'>show</a>
     <div class='expand-content'>

--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -26,6 +26,9 @@
 </table>
 
 <h2>Tags</h2>
+<div>
+  <%= link_to 'Add/remove tags', edit_vocabulary_path(@vocabulary, anchor: 'tags') %> or <%= link_to "create new tag", new_tag_path(vocabulary_id: @vocabulary.id) %>
+</div>
 <% if @vocabulary.tag_sequences.present? %>
   <p>The order below is the order in which tags will appear in a filter menu (if this vocuabulary is filterable). Drag and drop to re-order.</p>
   <ul id='tag_sequences'>
@@ -39,5 +42,3 @@
 <% else %>
   <p>There are currently no tags.</p>
 <% end %>
-
-<p><%= link_to "Add new tag", new_tag_path(vocabulary_id: @vocabulary.id) %></p>


### PR DESCRIPTION
This improves the ways that admins can manage associations between objects using forms.

Before this PR, there were links on various #show views that allowed users to create _new_, associated objects.  For example, on the `/sets/123` view, there was a link that said "Add new tag", which linked to `/tags/new?source_set_id=123`.  The new tags form would be pre-populated with the set id to assert the association.  

Admins could also build associations between _existing_ objects on various #new and #edit forms.  For example, on `sets/123/edit`, there was a menu of existing tags that an admin could select in order to associate them with the set.

This was confusing for admins because they needed to go to separate views to do related tasks, ie. associating tags with a given set.

This improves the workflow by adding links on #show views to manage associations with _both new and existing_ objects.  Referring to the previous example, the `sets/123` view now has two links.  The first, "Create new tag", links to `/tags/new?source_set_id=123`.  The second, "add/remove tags", links to `sets/123/edit#tag`, on which they can select from a menu of existing tags.  The `#tag` jump link in the URI triggers the expansion of the tags menu, which would otherwise be collapsed by default.

This addresses [ticket #8355](https://issues.dp.la/issues/8355).