### PR TITLE
fix header layout on source page

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -262,6 +262,10 @@ table td {
 
 /* Source */
 
+.source h1 {
+  clear: both;
+}
+
 .source .media-outer-container {
   padding: 34%;
   width: 100%;


### PR DESCRIPTION
This fixes the style of the `<h1>` element on `/source/show`.  Before this fix, the new social media share button was causing it to float in an odd and unattractive way:

<img width="1262" alt="screen shot 2016-04-04 at 4 34 57 pm" src="https://cloud.githubusercontent.com/assets/3615206/14263314/f6b0e3ec-fa87-11e5-9f7c-484fc16d59a7.png">

Now, it floats in a lovely and sensible way:

![screen shot 2016-04-04 at 5 09 41 pm](https://cloud.githubusercontent.com/assets/3615206/14263362/28899828-fa88-11e5-9425-76bbb7f0ba82.png)

This addresses [ticket #8357](https://issues.dp.la/issues/8357).

