### PR TITLE
track use of items for hubs

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -26,8 +26,7 @@ class SourcesController < ApplicationController
     ma = @source.main_asset
     @file_base_or_name = nil
     dpla_item = dpla_items(@source.aggregation).first  # see ApiQueryer
-    @digital_resource_url = dpla_item.url unless dpla_item.nil?
-    @provider_name = dpla_item.provider.name unless dpla_item.nil?
+    parse_dpla_item(dpla_item)
 
     if ma.present?
       @file_base_or_name =
@@ -93,5 +92,16 @@ class SourcesController < ApplicationController
 
   def load_source_set
     @source_set = SourceSet.friendly.find(params[:source_set_id])
+  end
+
+  def parse_dpla_item(dpla_item)
+    return unless dpla_item.present?
+    @digital_resource_url = dpla_item.try(:url)
+    @provider_name = dpla_item.try(:provider).try(:name)
+    data_provider = dpla_item.try(:source)
+    intermediate_provider = dpla_item.try(:intermediate_provider)
+    @contributing_institution = 
+      [data_provider, intermediate_provider].compact.join('; ')
+    @title = Array(dpla_item.try(:title)).flatten.first
   end
 end

--- a/app/views/sources/_hub_analytics.html.erb
+++ b/app/views/sources/_hub_analytics.html.erb
@@ -1,0 +1,10 @@
+<% if Settings.googleanalytics.tracker && @provider_name.present? %>
+  <script>
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'View Primary Source : <%= @provider_name %>',
+      eventAction: '<%= @contributing_institution %>',
+      eventLabel: '<%= "#{@source.aggregation} : #{@title}" %>'
+    });
+  </script>
+<% end %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -17,6 +17,7 @@
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>
+  <%= render partial: 'sources/hub_analytics' %>
 <% end %>
 
 <%= render partial: 'shared/share' %>


### PR DESCRIPTION
This uses Google Analytics to track use of hubs' items.

When a `/source/show` page is loaded in a browser window, a message is sent to Google Analytics with the DPLA item ID, provider name, contributing institution, and title.  It matches the message sent to Google Analytics when an item is viewed in the DPLA portal.

Testing on staging, the message sent to Google Analytics is:

<img width="744" alt="screen shot 2016-04-06 at 4 24 15 pm" src="https://cloud.githubusercontent.com/assets/3615206/14332130/1b5f0946-fc16-11e5-8921-62f43bfb3221.png">

If you want to test yourself on staging you can use the [Google analytics debugger Chrome plugin](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en).

This addresses [ticket #8065](https://issues.dp.la/issues/8065).