### PR TITLE
only show published sets in related sets slider

### DIFF
--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -34,13 +34,13 @@ class SourceSet < ActiveRecord::Base
   end
 
   ##
-  # Returns sets with at least two matching tags (not including self).
+  # Returns published sets with at least two matching tags (not including self).
   # Results are ordered so that sets with the highest number of matching tags
   # appear first.
   #
   # @return [Array<SourceSet>]
   def related_sets
-    sets = tags.map { |tag| [tag.source_sets] }.flatten - [self]
+    sets = tags.map { |tag| [tag.source_sets.published] }.flatten - [self]
     sets_with_count = sets.each_with_object(Hash.new(0)) do |set, count|
       count[set] += 1
     end

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -150,10 +150,10 @@ describe SourceSet, type: :model do
     let(:b_tag) { create(:tag_factory, label: 'b') }
     let(:c_tag) { create(:tag_factory, label: 'c') }
 
-    let(:set_1) { create(:source_set_factory) }
-    let(:set_2) { create(:source_set_factory) }
-    let(:set_3) { create(:source_set_factory) }
-    let(:set_4) { create(:source_set_factory) }
+    let(:set_1) { create(:source_set_factory, published: true) }
+    let(:set_2) { create(:source_set_factory, published: true) }
+    let(:set_3) { create(:source_set_factory, published: true) }
+    let(:set_4) { create(:source_set_factory, published: true) }
 
     before do
       set_1.tags << [a_tag, b_tag, c_tag]
@@ -166,12 +166,19 @@ describe SourceSet, type: :model do
       expect(set_1.related_sets).to be_a(Array)
     end
 
-    it 'returns sets with at least two matching tags' do
+    it 'returns published sets with at least two matching tags' do
       expect(set_1.related_sets).to contain_exactly(set_2, set_3)
     end
 
     it 'orders sets by number of matching tags' do
       expect(set_1.related_sets.first).to eq(set_3)
+    end
+
+    it 'does not return unpublished sets' do
+      set_2.published = false
+      set_2.save
+      set_2.reload
+      expect(set_1.related_sets).not_to include(set_2)
     end
   end
 


### PR DESCRIPTION
This fixes the `related_sets` method of the SourceSet model to only return published sets, as opposed to both published and unpublished sets.  The `related_sets` method is used to populate the "Related sets" carousel on the `sets/show` view.  Since unpublished sets are not accessible to the public, they should not be included in the slider.

This is a high-priority fix as it is currently holding up data entry for the final content release.

This has been tested locally.  It addresses [ticket #8362](https://issues.dp.la/issues/8362).