### PR TITLE
Update ebooks link in nav bar

### DIFF
--- a/app/views/shared/_top_nav.html.erb
+++ b/app/views/shared/_top_nav.html.erb
@@ -60,7 +60,7 @@
   <% end %>
   <ul>
     <li><%= link_to "Community Reps", wordpress_path('/get-involved/reps/') %></li>
-    <li><%= link_to "Curation Corps", wordpress_path('/get-involved/dpla-ebooks/dpla-collection-curation-corps/') %></li>
+    <li><%= link_to "Ebooks", wordpress_path('/get-involved/dpla-ebooks/') %></li>
     <li><%= link_to "GIF IT UP", wordpress_path('/gif-it-up/gif-it-up-2015/') %></li>
     <li><%= link_to "Groups", wordpress_path('/get-involved/groups/') %></li>
     <li><%= link_to "Workshops", wordpress_path('/get-involved/workshops/') %></li>


### PR DESCRIPTION
Change the "Curation Corps" link in the navbar to "Ebooks".  This addresses [ticket #8358](https://issues.dp.la/issues/8358).