### PR TITLE
add links to new objects in show views for admins

### DIFF
--- a/app/views/audios/show.html.erb
+++ b/app/views/audios/show.html.erb
@@ -1,6 +1,8 @@
 <h1>Audio: <%= @audio.file_base %></h1>
 
 <p>
+  <%= link_to "New", new_audio_path %>
+  |
   <%= link_to "Delete", 
                audio_path(@audio), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@audio.file_base}?" } %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,6 +1,8 @@
 <h1>Author: <%= @author.name %></h1>
 
 <p>
+  <%= link_to "New", new_author_path %>
+  |
   <%= link_to "Edit", edit_author_path(@author) %>
   |
   <%= link_to "Delete", author_path(@author), method: :delete,

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,6 +1,8 @@
 <h1>Document: <%= @document.file_name %></h1>
 
 <p>
+  <%= link_to "New", new_document_path %>
+  |
   <%= link_to "Delete", 
                document_path(@document), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@document.file_name}?" } %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -108,6 +108,8 @@
 
   <% unless current_admin.reviewer? %>
     <p>
+      <%= link_to "New", new_source_set_guide_path(@guide.source_set.id) %>
+      |
       <%= link_to "Edit", edit_guide_path(@guide) %>
       |
       <%= link_to "Delete", 

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -5,6 +5,8 @@
 <h1>Image: <%= @image.file_name %></h1>
 
 <p>
+  <%= link_to "New", new_image_path %>
+  |
   <%= link_to "Delete", 
                image_path(@image), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@image.file_name}?" } %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -117,6 +117,8 @@
 
   <% unless current_admin.reviewer? %>
     <p>
+      <%= link_to "New", new_source_set_path %>
+      |
       <%= link_to "Edit", edit_source_set_path(@source_set) %>
       |
       <%= link_to "Delete", source_set_path(@source_set), method: :delete,

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -98,6 +98,8 @@
 
   <% unless current_admin.reviewer? %>
     <p>
+      <%= link_to "New", new_source_set_source_path(@source.source_set.id) %>
+      |
       <%= link_to "Edit", edit_source_path(@source) %>
       |
       <%= link_to "Delete", 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,6 +1,8 @@
 <h1>Tag: <%= @tag.label %></h1>
 
 <p>
+  <%= link_to "New", new_tag_path %>
+  |
   <%= link_to "Edit", edit_tag_path(@tag) %>
   |
   <%= link_to "Delete", tag_path(@tag), method: :delete,

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -1,6 +1,8 @@
 <h1>Video: <%= @video.file_base %></h1>
 
 <p>
+  <%= link_to "New", new_video_path %>
+  |
   <%= link_to "Delete", 
                video_path(@video), method: :delete,
                data: { confirm: "Are you sure you want to delete #{@video.file_base}?" } %>

--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -8,6 +8,8 @@
 <h1>Vocabulary: <%= @vocabulary.name %></h1>
 
 <p>
+  <%= link_to "New", new_vocabulary_path %>
+  |
   <%= link_to "Edit", edit_vocabulary_path(@vocabulary) %>
   |
   <%= link_to "Delete", vocabulary_path(@vocabulary), method: :delete,


### PR DESCRIPTION
This adds links to create new objects on their `show` views.  Links are only visible to logged-in admins.  This will help streamline data entry.  It addresses [ticket #8364](https://issues.dp.la/issues/8364).