### PR TITLE
render guide markdown on source show view

### DIFF
--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -89,7 +89,7 @@
   <h2>Teaching Guide<%= 's' if guides.count > 1 %></h2>
   <p>
     This source appears in 
-    <%= raw guides.collect { |guide| link_to guide.name, guide }.to_sentence %>.
+    <%= raw guides.collect { |guide| link_to inline_markdown(guide.name), guide }.to_sentence %>.
   </p>
 </div>
 


### PR DESCRIPTION
This renders the name of a guide in markdown on the source show view.  Some guides have markdown elements, such as italics for book titles.  

This has been tested locally.  It addresses [ticket #8365](https://issues.dp.la/issues/8365).