### PR TITLE
add https to doc viewer link

### DIFF
--- a/app/views/sources/_document.html.erb
+++ b/app/views/sources/_document.html.erb
@@ -1,7 +1,7 @@
 <article class='document'>
   <div class='media-outer-container'>
     <div class='media-inner-container'>
-      <iframe src="https://docs.google.com/viewer?url=<%= base_src + @source.main_asset.file_name %>&embedded=true" frameborder="0"></iframe>
+      <iframe src="https://docs.google.com/viewer?url=<%= 'https:' + base_src + @source.main_asset.file_name %>&embedded=true" frameborder="0"></iframe>
     </div>
   </div>
 </article>


### PR DESCRIPTION
This fixes the Google document viewer to work with HTTPS.