### PR TITLE
Use Settings.app_scheme instead of hardcoded protocol in helper test

### DIFF
--- a/spec/helpers/source_helper_spec.rb
+++ b/spec/helpers/source_helper_spec.rb
@@ -98,7 +98,7 @@ describe SourcesHelper, type: :helper do
 
         it 'renders thumbnail' do
           expect(helper.render_thumbnail(source))
-          .to include "src=\"http://#{Settings.aws.cloudfront_domain}/" \
+          .to include "src=\"#{Settings.app_scheme}#{Settings.aws.cloudfront_domain}/" \
                       "#{thumbnail.file_name}\""
         end
 


### PR DESCRIPTION
This fixes a test that was failing for me locally.  In a helper test, it uses the value from `Settings.app_scheme` instead of a hardcoded `http://` to construct a URL.  This is related to the switch to SSL.