### PR TITLE
lock phantomjs to v1.9.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :test, :development do
   gem 'json-ld', '~>1.1.9'
   gem 'jasmine', '~> 2.0'
   gem 'jasmine-jquery-rails', '~> 2.0'
+  gem 'phantomjs', '1.9.8'
 end
 
 group :development do


### PR DESCRIPTION
This locks the `phantomjs` version to 1.9.8.  This will hopefully solve the problem of failing CI builds.  This addresses [ticket #8367](https://issues.dp.la/issues/8367).