### PR TITLE
JSON-LD show views for set, guide, and source

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -15,9 +15,21 @@ class GuidesController < ApplicationController
 
   def show
     @guide = Guide.friendly.find(params[:id])
+    @source_set = @guide.source_set
+    @authors = @guide.authors
     check_login_and_authorize(:read, Guide) unless @guide.source_set.published?
     add_breadcrumb inline_markdown(@guide.source_set.name), source_set_path(@guide.source_set)
     add_breadcrumb 'Guide', guide_path(@guide)
+
+    ##
+    # Render HTML or JSON formats unless controller has already redirected or
+    # rendered (ie. in the check_login_and_authorize method).
+    unless performed?
+      respond_to do |format|
+        format.html
+        format.json { render partial: 'guides/show.json.erb' }
+      end
+    end
   end
 
   def new

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -19,6 +19,20 @@ class SourceSetsController < ApplicationController
     @source_set = SourceSet.friendly.find(params[:id])
     check_login_and_authorize(:read, SourceSet) unless @source_set.published?
     add_breadcrumb inline_markdown(@source_set.name), source_set_path(@source_set)
+    @authors = @source_set.authors
+    @sources = @source_set.sources
+    @guides = @source_set.guides
+    @tags = @source_set.tags
+
+    ##
+    # Render HTML or JSON formats unless controller has already redirected or
+    # rendered (ie. in the check_login_and_authorize method).
+    unless performed?
+      respond_to do |format|
+        format.html
+        format.json { render partial: 'source_sets/show.json.erb' }
+      end
+    end
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,14 @@ module ApplicationHelper
     Settings.wordpress.url.chomp('/') + '/' + path.sub(/^\/+/) { $1 }
   end
 
+  ##
+  # Returns frontend path with correctly joining '/'
+  # @param path String (with or without leading slash)
+  # @return String
+  def api_path(path = '')
+    Settings.api.url.chomp('/') + '/' + path.sub(/^\/+/) { $1 }
+  end
+
   def base_src
     Settings.app_scheme + Settings.aws.cloudfront_domain + '/'
   end

--- a/app/helpers/audio_player_helper.rb
+++ b/app/helpers/audio_player_helper.rb
@@ -13,12 +13,16 @@ module AudioPlayerHelper
     outputs.each do |out|
       extension = out['extension']
       suffix = out.fetch('suffix', '')
-      src = Settings.app_scheme + Settings.aws.cloudfront_domain + '/' \
-        + audio.file_base + suffix + ".#{extension}"
+      src = audio_file_path(audio.file_base, suffix, extension)
       rv << "<source src=\"#{src}\" type=\"#{mimetype[extension]}\"/>\n"
     end
     rv << "Your browser does not support HTML5 audio.\n"
     rv << "</audio>\n"
     rv
+  end
+
+  def audio_file_path(file_base, suffix, extension)
+    Settings.app_scheme + Settings.aws.cloudfront_domain + '/' \
+      + file_base + suffix + ".#{extension}"
   end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -20,8 +20,11 @@ module MarkdownHelper
     strip_p_tags(markdown(text))
   end
 
+  ##
+  # @return String a plain text representation of the markdown string given in
+  # 'text'.  Removes trailing newline.
   def plaintext_from_md(text)
-    Redcarpet::Markdown.new(Redcarpet::Render::StripDown).render(text)
+    Redcarpet::Markdown.new(Redcarpet::Render::StripDown).render(text).chomp
   end
 
   private

--- a/app/helpers/video_player_helper.rb
+++ b/app/helpers/video_player_helper.rb
@@ -12,13 +12,16 @@ module VideoPlayerHelper
     rv = "<video preload=\"none\" controls>\n"
     outputs.each do |out|
       extension = out['extension']
-      suffix = out.fetch('suffix', '')
-      src = Settings.app_scheme + Settings.aws.cloudfront_domain + '/' \
-        + video.file_base + ".#{extension}"
+      src = video_file_path(video.file_base, extension)
       rv << "<source src=\"#{src}\" type=\"#{mimetype[extension]}\"/>\n"
     end
     rv << "Your browser does not support HTML5 video.\n"
     rv << "</video>\n"
     rv
+  end
+
+  def video_file_path(file_base, extension)
+    Settings.app_scheme + Settings.aws.cloudfront_domain + '/' \
+      + file_base + ".#{extension}"
   end
 end

--- a/app/views/guides/_show.json.erb
+++ b/app/views/guides/_show.json.erb
@@ -1,0 +1,35 @@
+{
+  <%= render partial: 'shared/context.json' %>,
+  "@id": "<%= guide_url(@guide) %>",
+  "@type": "CreativeWork",
+  "name": <%= @guide.name.to_json.html_safe %>,
+  "dateCreated": "<%= @guide.created_at.strftime("%Y-%m-%d") %>",
+  "dct:created": "<%= @guide.created_at.strftime("%Y-%m-%d") %>",
+  "dateModified": "<%= @guide.updated_at.strftime("%Y-%m-%d") %>",
+  "dct:modified": "<%= @guide.updated_at.strftime("%Y-%m-%d") %>",
+  <% if @authors.present? %>
+    "author": [
+      <% for author in @authors %>
+        {
+          "@type": "Person",
+          <% if author.affiliation.present? %>
+            "affiliation": {
+              "@type": "Organization",
+              "name": "<%= author.affiliation %>"
+            },
+            <% end %>
+          "name": "<%= author.name %>"
+        }<%= ',' unless author.equal?(@authors.last) %>
+      <% end %>
+    ],
+  <% end %>
+  <% text = [@guide.questions, @guide.activity].compact.join("\r\n\r\n") %>
+  <% if text.present? %>
+    "text": <%= text.to_json.html_safe %>,
+  <% end %>
+  "isPartOf": {
+    "@id": "<%= source_set_url(@source_set) %>",
+    "@type": "CreativeWork",
+    "name": <%= @source_set.name.to_json.html_safe %>
+  }
+}

--- a/app/views/shared/_context.json.erb
+++ b/app/views/shared/_context.json.erb
@@ -1,0 +1,16 @@
+"@context": {
+  "@vocab": "http://schema.org/",
+  "ccss": "http://www.corestandards.org/",
+  "dct": "http://purl.org/dc/terms/",
+  "dcmitype": "http://purl.org/dc/dcmitype/",
+  "edm": "http://www.europeana.eu/schemas/edm",
+  "ore": "http://www.openarchives.org/ore/terms/",
+  "text": {
+    "@id": "http://schema.org/text",
+    "@type": "http://ns.ontowiki.net/SysOnt/Markdown"
+  },
+  "name": {
+    "@id": "http://schema.org/text",
+    "@type": "http://ns.ontowiki.net/SysOnt/Markdown"
+  }
+}

--- a/app/views/source_sets/_show.json.erb
+++ b/app/views/source_sets/_show.json.erb
@@ -1,0 +1,186 @@
+{
+  <%= render partial: 'shared/context.json' %>,
+  "@id": "<%= source_set_url(@source_set) %>",
+  "@type": "CreativeWork",
+  "dct:type": "dcmitype:InteractiveResource",
+  "name": <%= @source_set.name.to_json.html_safe %>,
+  <% if @source_set.featured_image.present? %>
+    "thumbnailUrl": "<%= base_src + @source_set.featured_image.file_name %>",
+  <% end %>
+  "dateCreated": "<%= @source_set.created_at.strftime("%Y-%m-%d") %>",
+  "dct:created": "<%= @source_set.created_at.strftime("%Y-%m-%d") %>",
+  "dateModified": "<%= @source_set.updated_at.strftime("%Y-%m-%d") %>",
+  "dct:modified": "<%= @source_set.updated_at.strftime("%Y-%m-%d") %>",
+  <% if @tags.present? %>
+    "about": [
+      <% for tag in @tags %>
+        {
+          "@type": "Thing",
+          "name": "<%= tag.label %>"<%= ',' if tag.uri.present? %>
+          <% if tag.uri.present? %>
+            "sameAs": "<%= tag.uri %>"
+          <% end %>
+        }<%= ',' unless tag.equal?(@tags.last) %>
+      <% end %>
+    ],
+  <% end %>
+  <% if @source_set.description.present? %>
+    "description": "<%= @source_set.description %>",
+  <% end %>
+  <% if @authors.present? %>
+    "author": [
+      <% for author in @authors %>
+        {
+          "@type": "Person",
+          <% if author.affiliation.present? %>
+            "affiliation": {
+              "@type": "Organization",
+              "name": "<%= author.affiliation %>"
+            },
+            <% end %>
+          "name": "<%= author.name %>"
+        }<%= ',' unless author.equal?(@authors.last) %>
+      <% end %>
+    ],
+  <% end %>
+  "publisher": {
+    "@id": "<%= frontend_path %>",
+    "@type": "Organization",
+    "name": "Digital Public Library of America",
+    "email": "info@dp.la"
+  },
+  <% text = [@source_set.overview, @source_set.resources].compact
+                                                         .join("\r\n\r\n") %>
+  <% if text.present? %>
+    "text": <%= text.to_json.html_safe %>,
+  <% end %>
+  <% if @guides.present? || @sources.present? %>
+    "hasPart": [
+      <% if @guides.present? %>
+        <% for guide in @guides %>
+          {
+            "@id": "<%= guide_url(guide) %>",
+            "@type": "CreativeWork",
+            "name": <%= guide.name.to_json.html_safe %>
+          }<%= ',' if not (guide.equal?(@guides.last) && @sources.blank?) %>
+        <% end %>
+      <% end %>
+      <% if @sources.present? %>
+        <% for source in @sources %>
+          {
+            "@id": "<%= source_url(source) %>",
+            "@type": "CreativeWork",
+            <% thumbnail = source.thumbnail %>
+            <% if thumbnail.present? %>
+              "thumbnailUrl": "<%= base_src + thumbnail.file_name %>",
+            <% end %>
+            "name": <%= source.name.to_json.html_safe %>
+          }<%= ',' unless source.equal?(@sources.last) %>
+        <% end %>
+      <% end %>
+    ],
+  <% end %>
+  "inLanguage": [
+    {
+      "@id": "http://lexvo.org/id/term/eng/English",
+      "@type": "Language",
+      "name": "English"
+    }
+  ],
+  "learningResourceType": "Source Set",
+  "license": "http://dp.la/info/terms/",
+  "typicalAgeRange": "11-18",
+  "accessbilityFeature": [
+    "captions",
+    "structuralNavigation",
+    "audioControl",
+    "videoControl"
+  ],
+  "accessibilityHazard": [
+    "noFlashingHazard",
+    "motionSimulation",
+    "noSoundHazard"
+  ],
+  "accessibilityControl": [
+    "fullMouseControl"
+  ],
+  "educationalAlignment": [
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.RH.6-8.7",
+      "targetUrl": "ccss:ELA-Literacy/RH/6-8/7/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.RH.6-8.7",
+      "targetUrl": "ccss:ELA-Literacy/RH/6-8/7/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.RH.6-8.9",
+      "targetUrl": "ccss:ELA-Literacy/RH/6-8/9/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.RH.9-10.9",
+      "targetUrl": "ccss:ELA-Literacy/RH/9-10/9/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.RH.11-12.7",
+      "targetUrl": "ccss:ELA-Literacy/RH/11-12/7/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.RH.11-12.9",
+      "targetUrl": "ccss:ELA-Literacy/RH/11-12/9/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.CCRA.R.7",
+      "targetUrl": "ccss:ELA-Literacy/CCRA/R/7/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.CCRA.W.8",
+      "targetUrl": "ccss:ELA-Literacy/CCRA/W/8/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.WHST.6-8.8",
+      "targetUrl": "ccss:ELA-Literacy/WHST/6-8/8/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.WHST.9-10.8",
+      "targetUrl": "ccss:ELA-Literacy/WHST/9-10/8/"
+    },
+    {
+      "@type": "AlignmentObject",
+      "alignmentType": "requires",
+      "educationalFramework": "Common Core State Standards",
+      "targetName": "CCSS.ELA-Literacy.WHST.11-12.8",
+      "targetUrl": "ccss:ELA-Literacy/WHST/11-12/8/"
+    }
+  ]
+}

--- a/app/views/sources/_show.json.erb
+++ b/app/views/sources/_show.json.erb
@@ -1,0 +1,81 @@
+{
+  <%= render partial: 'shared/context.json' %>,
+  "@id": "<%= source_url(@source) %>",
+  "@type": "CreativeWork",
+  <% thumbnail = @source.thumbnail %>
+  <% if thumbnail.present? %>
+    "thumbnailUrl": "<%= base_src + thumbnail.file_name %>",
+  <% end %>
+  <% if @source.name.present? %>
+    "name": <%= @source.name.to_json.html_safe %>,
+  <% end %>
+  "dateCreated": "<%= @source.created_at.strftime("%Y-%m-%d") %>",
+  "dct:created": "<%= @source.created_at.strftime("%Y-%m-%d") %>",
+  "dateModified": "<%= @source.updated_at.strftime("%Y-%m-%d") %>",
+  "dct:modified": "<%= @source.updated_at.strftime("%Y-%m-%d") %>",
+  "mainEntity": [
+    {
+      "@type": "CreativeWork",
+      <% if @main_asset.present? %>
+        "associatedMedia": [
+          <% if @main_asset.is_a?(Document) || @main_asset.is_a?(Image) %>
+            {
+              "fileFormat": "<%= @main_asset.file_name.split('.').last %>",
+              "contentUrl": "<%= @main_asset.file_name %>"
+            }
+          <% elsif @main_asset.is_a? Video %>
+            <% outs = JSON.parse(@main_asset.meta)['output_settings'] %>
+            <% for out in outs %>
+              {
+                "fileFormat": "<%= out['extension'] %>",
+                "contentUrl": "<%= video_file_path(@main_asset.file_base,
+                                                   out['extension']) %>"
+              }<%= ',' unless out.equal?(outs.last) %>
+            <% end %>
+          <% elsif @main_asset.is_a? Audio %>
+            <% outs = JSON.parse(@main_asset.meta)['output_settings'] %>
+            <% for out in outs %>
+              {
+                "fileFormat": "<%= out['extension'] %>",
+                "contentUrl": "<%= audio_file_path(@main_asset.file_base,
+                                                   out.fetch('suffix', ''),
+                                                   out['extension']) %>"
+              }<%= ',' unless out.equal?(outs.last) %>
+            <% end %>
+          <% end %>
+        ],
+        "dct:references": [
+          <% if !@provider_name.nil? %>
+            {
+              "@id": "<%= @digital_resource_url %>",
+              "@type": "WebPage"
+            },
+          <% end %>
+          {
+            "@id": "<%= "http:#{frontend_path('item/' + @source.aggregation)}" %>",
+            "@type": "ore:Aggregation",
+            "sameAs": "<%= "http:#{api_path('items/' + @source.aggregation)}" %>"
+          }
+        ],
+      <% end %>
+      <% if @source.citation.present? %>
+        "dct:citation": <%= @source.citation.to_json.html_safe %>,
+      <% end %>
+      <% if @source.credits.present? %>
+        "dct:provenance": {
+          "@type": "dct:ProvenanceStatement",
+          "name": <%= @source.credits.to_json.html_safe %>
+        },
+      <% end %>
+      "@type": "MediaObject"
+    }
+  ],
+  <% if @source.textual_content.present? %>
+    "text": <%= @source.textual_content.to_json.html_safe %>,
+  <% end %>
+  "isPartOf": {
+    "@id": "<%= source_set_url(@source_set) %>",
+    "@type": "CreativeWork",
+    "name": <%= @source_set.name.to_json.html_safe %>
+  }
+}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,15 +7,16 @@ devise:
   mailer_sender: email@example.org
 
 frontend:
-  url: http://example.com/
+  url: //example.com/
 
 wordpress:
- url: http://example.com/
+ url: //example.com/
 
 exhibtions:
-  url: http://exmaple.com/
+  url: //exmaple.com/
 
 api:
+  url: //example.com/
   key: CHANGEME
 
 app_scheme: 'http://'

--- a/etc/PrimarySourceSetDataModelSample.json
+++ b/etc/PrimarySourceSetDataModelSample.json
@@ -9,6 +9,10 @@
     "text": {
       "@id": "http://schema.org/text",
       "@type": "http://ns.ontowiki.net/SysOnt/Markdown"
+    },
+    "name": {
+      "@id": "http://schema.org/text",
+      "@type": "http://ns.ontowiki.net/SysOnt/Markdown"
     }
   },
   "@id": "http://dp.la/sets/french-and-indian-war",
@@ -17,36 +21,18 @@
   "name": "The French and Indian War",
   "thumbnailUrl": "http://dp.la/assets/path-to-thumbnail.jpg",
   "dateCreated": "2015-08-08",
+  "dct:created": "2015-08-08",
   "dateModified": "2015-08-20",
+  "dct:modified": "2015-08-20",
   "about": [
-    { 
+    {
       "@type": "Thing",
       "name": "History" 
     },
-    { 
+    {
       "@type": "Thing",
-      "name": "Social Studies"
-    },
-    { 
-      "@type": "Thing",
-      "name": "French and Indian War" 
-    },
-    { 
-      "@type": "Thing",
-      "name": "Seven Years' War"
-    },
-    { 
-      "@type": "Thing",
-      "name": "Thirteen Colonies"
-    }
-  ],
-  "dct:temporal": [
-    { 
-      "@id": "ushist:united-states-era-2",
-      "@type": "edm:TimeSpan",
-      "name": "Colonization & Settlement (1585-1763)",
-      "edm:begin": "1585",
-      "edm:end": "1763"
+      "name": "French and Indian War",
+      "sameAs": "http://educational-schema.org/french-and-indian-war"
     }
   ],
   "description": "This collection uses primary sources to explore the French and Indian War.",
@@ -76,10 +62,14 @@
   },
   "text": "The French and Indian War helped set the stage for the American Revolution. Between the years 1754 and 1763, major powers engaged in a global struggle, the Seven Years war. In North America, the conflict between the French and British Empires included indigenous nations. This collection of documents, images, maps, and artifacts help provide the various perspectives on the war, both from the leadership, and the more marginalized groups. By analyzing, exploring, and interpreting these primary sources, inquirers will gain insight into the experience of 18th-century warfare, from the point of view of the \"winners\" and the \"losers.\"",
   "hasPart": [
-    { 
+    {
       "@id": "http://dp.la/sets/french-and-indinan-war/guide/23",
       "@type": "CreativeWork",
       "name": "Teaching Guide: Perspectives of the French and Indian War",
+      "dateCreated": "2015-08-09",
+      "dct:created": "2015-08-09",
+      "dateModified": "2015-08-11",
+      "dct:modified": "2015-08-11",
       "author": [
         {
           "@type": "Person",
@@ -105,25 +95,37 @@
       "@type": "CreativeWork",
       "thumbnailUrl": "http://dp.la/assets/path-to-thumbnail.jpg",
       "name": "Diary of Major George Washington, 1753",
-      "mainEntity": {
-        "@type": "CreativeWork",
-        "associatedMedia": [
-          {
-            "@type": "MediaObject",
-            "fileFormat": "pdf",
-            "contentUrl": "http://path-to-file",
-            "dct:references": {
+      "dateCreated": "2015-08-08",
+      "dct:created": "2015-08-08",
+      "dateModified": "2015-08-08",
+      "dct:modified": "2015-08-08",
+      "mainEntity": [
+        {
+          "@type": "CreativeWork",
+          "associatedMedia": [
+            {
+              "@type": "MediaObject",
+              "fileFormat": "pdf",
+              "contentUrl": "http://path-to-file"
+            }
+          ],
+          "dct:references": [
+            {
               "@id": "http://dp.la/item/87037c8c0dc514bfd19bddbce9ff2ce7",
               "@type": "ore:Aggregation"
             },
-            "dct:citation": "Washington, George. *The journal of Major George Washington.* Chicago: The Newberry Library, 1958. Page 53.",
-            "dct:provenance": {
-              "@type": "dct:ProvenanceStatement",
-              "name": "Courtesy of The Univeristy of Michigan via HathiTrust"
+            {
+              "@id": "http://catalog.hathitrust.org/Record/009923002",
+              "@type": "WebPage"
             }
+          ],
+          "dct:citation": "Washington, George. *The journal of Major George Washington.* Chicago: The Newberry Library, 1958. Page 53.",
+          "dct:provenance": {
+            "@type": "dct:ProvenanceStatement",
+            "name": "Courtesy of The Univeristy of Michigan via HathiTrust"
           }
-        ]
-      },
+        }
+      ],
       "text": "Excerpt from Wednesday, October 31st, 1753:\n\"I was comissioned and appointed by the Honourable Robert Dinwidde, Esq; Governor, etc. of Virginia to visit and deliver a Letter to the Commandant of the French Forces on the Hioin, and set out on the indended Journey the same day ; and proceeded with him to Alexandria, where we provided Necessaries ; from thence we went to Winchester, and got Baggage, Horses, etc., and from thence we pursued the new Road to Wills-Creek, where we arrive the 14th of November.\""
     }
   ],
@@ -138,7 +140,7 @@
   "license": "http://dp.la/info/terms/",
   "typicalAgeRange": "11-18",
   "accessbilityFeature": [
-    "captions", 
+    "captions",
     "structuralNavigation",
     "audioControl",
     "videoControl"

--- a/spec/controllers/guides_controller_spec.rb
+++ b/spec/controllers/guides_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe GuidesController, type: :controller do
 
   let(:resource) { create(:guide_factory) }
+  let(:published_guide) { create(:published_guide_factory) }
   let(:attributes) { attributes_for(:guide_factory) }
   let(:invalid_attributes) { attributes_for(:invalid_guide_factory) }
   let(:parent_model) { resource.source_set }
@@ -15,6 +16,37 @@ describe GuidesController, type: :controller do
     it_behaves_like 'basic controller', :show, :update
     it_behaves_like 'nested controller', :index, :create, :destroy
     it_behaves_like 'redirecting controller', :create
+
+    describe '#show' do
+
+      it 'sets the @source_set variable' do
+        get :show, id: resource.id
+        expect(assigns(:source_set)).to eq resource.source_set
+      end
+
+      it 'sets the @authors variable' do
+        resource.authors << [create(:author_factory)]
+        get :show, id: resource.id
+        expect(assigns(:authors).first).to eq resource.authors.first
+      end
+
+      describe 'request for json format' do
+
+        context 'with a guide belonging to an unpublished set' do
+          it 'renders the show json partial' do
+            get :show, id: resource.id, format: :json
+            expect(response).to render_template(partial: '_show.json.erb')
+          end
+        end
+
+        context 'with a guide belonging to a published set' do
+          it 'renders the show json partial' do
+            get :show, id: published_guide.id, format: :json
+            expect(response).to render_template(partial: '_show.json.erb')
+          end
+        end
+      end
+    end
   end
 
   context 'with the user not logged-in' do
@@ -32,14 +64,28 @@ describe GuidesController, type: :controller do
       end
 
       context 'with a guide belonging to a published set' do
-        let(:published_guide) { create(:published_guide_factory) }
-
         it 'shows the guide' do
           get :show, id: published_guide.id
           expect(response).to render_template :show
         end
       end
 
+      describe 'request for json format' do
+
+        context 'with a guide belonging to an unpublished set' do
+          it 'redirects to the sign-in page' do
+            get :show, id: resource.id, format: :json
+            expect(response).to redirect_to new_admin_session_path
+          end
+        end
+
+        context 'with a guide belonging to a published set' do
+          it 'renders the show json partial' do
+            get :show, id: published_guide.id, format: :json
+            expect(response).to render_template(partial: '_show.json.erb')
+          end
+        end
+      end
     end
   end
 end

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -67,6 +67,49 @@ describe SourceSetsController, type: :controller do
         expect(response).to render_template :index
       end
     end
+
+    describe '#show' do
+
+      it 'sets @authors variable' do
+        resource.authors << [create(:author_factory)]
+        get :show, id: resource.id
+        expect(assigns(:authors).first).to eq resource.authors.first
+      end
+
+      it 'sets @sources variable' do
+        create(:source_factory, source_set: resource)
+        get :show, id: resource.id
+        expect(assigns(:sources).first).to eq resource.sources.first
+      end
+
+      it 'sets @guides variable' do
+        create(:guide_factory, source_set: resource)
+        get :show, id: resource.id
+        expect(assigns(:guides).first).to eq resource.guides.first
+      end
+
+      it 'sets @tags variable' do
+        resource.tags << [create(:tag_factory)]
+        get :show, id: resource.id
+        expect(assigns(:tags).first).to eq resource.tags.first
+      end
+
+      describe 'request for json format' do
+        context 'with a published set' do
+          it 'renders the show json partial' do
+            get :show, id: published.id, format: :json
+            expect(response).to render_template(partial: '_show.json.erb')
+          end
+        end
+
+        context 'with an unpublished set' do
+          it 'renders the show json partial' do
+            get :show, id: resource.id, format: :json
+            expect(response).to render_template(partial: '_show.json.erb')
+          end
+        end
+      end
+    end
   end
 
   context 'with the user not logged-in' do
@@ -78,7 +121,7 @@ describe SourceSetsController, type: :controller do
 
       context 'with an unpublished set' do
         it 'redirects to the sign-in page' do
-          get :show, id: resource.id
+          get :show, id: resource.id, format: :html
           expect(response).to redirect_to new_admin_session_path
         end
       end
@@ -92,6 +135,21 @@ describe SourceSetsController, type: :controller do
         end
       end
 
+      describe 'request for json format' do
+        context 'with an unpublished set' do
+          it 'redirects to sign-in login' do
+            get :show, id: resource.id, format: :json
+            expect(response).to redirect_to new_admin_session_path
+          end
+        end
+
+        context 'with a published set' do
+          it 'renders the show json partial' do
+            get :show, id: published.id, format: :json
+            expect(response).to render_template(partial: '_show.json.erb')
+          end
+        end
+      end
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,54 +6,35 @@ describe ApplicationHelper, type: :helper do
     before { stub_const('DplaFrontendAssets', double) }
   end
 
-  describe '#markdown' do
-
-    it 'renders HTML from a markdown String' do
-      text = '**Moomin!**'
-      expect(helper.markdown(text)).to eq("<p><strong>Moomin!</strong></p>\n")
-    end
-
-    it 'raises a TypeError if input is not a String' do
-      invalid_input = 123
-      expect{ helper.markdown(invalid_input) }.to raise_error(TypeError)
-     end
-  end
-
-  describe '#inline_markdown' do
-
-    it 'strips enclosing <p> tags' do
-      text = '**Moomin!**'
-      expect(helper.inline_markdown(text)).to eq("<strong>Moomin!</strong>")
-    end
-
-    it 'leaves enclosing <p> tags if there are internal <p> tags' do
-      text = '<p>Moomin!</p><p>Snorkmaiden</p>'
-      expect(helper.inline_markdown(text))
-        .to eq("<p>Moomin!</p><p>Snorkmaiden</p>\n")
-    end
-  end
-
   describe '#frontend_path' do
     it 'constructs a URI with correct /s' do
       allow(Settings).to receive_message_chain(:frontend, :url)
-        .and_return 'http://example.com/'
-      expect(helper.frontend_path('/path')).to eq 'http://example.com/path'
+        .and_return '//example.com/'
+      expect(helper.frontend_path('/path')).to eq '//example.com/path'
     end
   end
 
   describe '#exhibitions_path' do
     it 'constructs a URI with correct /s' do
       allow(Settings).to receive_message_chain(:exhibitions, :url)
-        .and_return 'http://example.com'
-      expect(helper.exhibitions_path('path')).to eq 'http://example.com/path'
+        .and_return '//example.com'
+      expect(helper.exhibitions_path('path')).to eq '//example.com/path'
     end
   end
 
   describe '#wordpress_path' do
     it 'constructs a URI with correct /s' do
       allow(Settings).to receive_message_chain(:wordpress, :url)
-        .and_return 'http://example.com/'
-      expect(helper.wordpress_path('path/')).to eq 'http://example.com/path/'
+        .and_return '//example.com/'
+      expect(helper.wordpress_path('path/')).to eq '//example.com/path/'
+    end
+  end
+
+  describe '#api_path' do
+    it 'constructs a URI with correct /s' do
+      allow(Settings).to receive_message_chain(:api, :url)
+        .and_return '//example.com/'
+      expect(helper.api_path('path/')).to eq '//example.com/path/'
     end
   end
 

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe MarkdownHelper, type: :helper do
+
+  describe '#markdown' do
+
+    it 'renders HTML from a markdown String' do
+      text = '**Moomin!**'
+      expect(helper.markdown(text)).to eq("<p><strong>Moomin!</strong></p>\n")
+    end
+
+    it 'raises a TypeError if input is not a String' do
+      invalid_input = 123
+      expect { helper.markdown(invalid_input) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#inline_markdown' do
+
+    it 'strips enclosing <p> tags' do
+      text = '**Moomin!**'
+      expect(helper.inline_markdown(text)).to eq('<strong>Moomin!</strong>')
+    end
+
+    it 'leaves enclosing <p> tags if there are internal <p> tags' do
+      text = '<p>Moomin!</p><p>Snorkmaiden</p>'
+      expect(helper.inline_markdown(text))
+        .to eq("<p>Moomin!</p><p>Snorkmaiden</p>\n")
+    end
+  end
+
+  describe 'plaintext_from_md' do
+    it 'renders plaintext' do
+      text = '**Moomin!**'
+      expect(helper.plaintext_from_md(text)).to eq 'Moomin!'
+    end
+  end
+end

--- a/spec/support/shared_examples/valid_json_view.rb
+++ b/spec/support/shared_examples/valid_json_view.rb
@@ -1,0 +1,8 @@
+##
+# This checks that a view renders valid json.
+shared_examples 'valid json view' do
+  it 'renders valid json' do
+    render
+    expect { JSON.parse(rendered) }.not_to raise_error
+  end
+end

--- a/spec/views/guides/_show.json.erb_spec.rb
+++ b/spec/views/guides/_show.json.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'guides/_show.json.erb', type: :view do
+
+  before do
+    guide = create(:guide_factory)
+    guide.authors << [create(:author_factory)]
+    assign(:guide, guide)
+    assign(:source_set, guide.source_set)
+    assign(:authors, guide.authors)
+  end
+
+  it_behaves_like 'renderable view'
+  it_behaves_like 'valid json view'
+end

--- a/spec/views/source_sets/_show.json.erb_spec.rb
+++ b/spec/views/source_sets/_show.json.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'source_sets/_show.json.erb', type: :view do
+
+  before do
+    source_set = create(:source_set_factory)
+    source_set.authors << [create(:author_factory)]
+    source_set.guides << [create(:guide_factory)]
+    source_set.sources << [create(:source_factory)]
+    source_set.tags << [create(:tag_factory)]
+    assign(:source_set, source_set)
+    assign(:authors, source_set.authors)
+    assign(:guides, source_set.guides)
+    assign(:sources, source_set.sources)
+    assign(:tags, source_set.tags)
+  end
+
+  it_behaves_like 'renderable view'
+  it_behaves_like 'valid json view'
+end

--- a/spec/views/sources/_show.json.erb_spec.rb
+++ b/spec/views/sources/_show.json.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe 'sources/_show.json.erb', type: :view do
+
+  let(:source) { create(:source_factory) }
+
+  before do
+    assign(:source, source)
+    assign(:source_set, source.source_set)
+  end
+
+  it_behaves_like 'renderable view'
+
+  context 'with document asset' do
+    before { assign(:main_asset, create(:document_factory)) }
+    it_behaves_like 'valid json view'
+  end
+
+  context 'with image asset' do
+    before { assign(:main_asset, create(:image_factory)) }
+    it_behaves_like 'valid json view'
+  end
+
+  context 'with audio asset' do
+    before { assign(:main_asset, create(:audio_factory)) }
+    it_behaves_like 'valid json view'
+  end
+
+  context 'with video asset' do
+    before { assign(:main_asset, create(:video_factory)) }
+    it_behaves_like 'valid json view'
+  end
+end


### PR DESCRIPTION
This adds the option to get sets, sources, or guides in JSON-LD format, according to our data model for this project.

Changes include:
* Updates to the sample data model in `etc/PrimarySourceSetDataModelSample.json` to reflect available metadata and correct object structure.
* Controllers respond to requests for `json` format.  For code simplicity, a few instance variables are added to the controllers.  It is outside the scope of this PR to refactor `html` views to use these new instance variables, but that work is slotted in another upcoming ticket.
* `.json` view templates are added.
* A few helpers are refactored so that they will work with both `html` and `json` views.
* Specs for controllers, views, and helpers are added/updated.  A few methods are moved out of the `application_helper_spec` and into `markdown_helper_spec` b/c they should have been in `markdown_helper_spec` in the first place. 

This has been tested locally.  This addresses [ticket #7944](https://issues.dp.la/issues/7944).

If it would be helpful for testing purposes, we can deploy this branch to staging.