### PR TITLE
css for dimensional manipulations source, source and set show views

### DIFF
--- a/app/assets/javascripts/style.js
+++ b/app/assets/javascripts/style.js
@@ -12,38 +12,13 @@
    });
 
   $(document).ready(function() {
-    setAsideHeight();
     setNameContainerHeight();
   });
 
   $(window).resize(function() {
-    setAsideHeight();
     setNameContainerHeight();
   })
 })();
-
-/*
- * Extend the height of the aside module to be at least as tall as the rendered
- * media asset.
- */
-function setAsideHeight() {
-  var height = $('.source aside .module').outerHeight();
-  var minHeight = $('.source .media-inner-container').height();
-  if (minHeight > height) {
-    $('.source aside .module').outerHeight(minHeight);
-  }
-
-  // resize header on set page
-  var moduleHeight = $('.set .guide-link .module').outerHeight();
-  var titleHeight = $('.set .title-outer-container').outerHeight();
-
-  if (moduleHeight < titleHeight) {
-    $('.set .guide-link .module').outerHeight(titleHeight);
-  }
-  if (titleHeight < moduleHeight) {
-    $('.set .title-outer-container').outerHeight(moduleHeight);
-  }
-}
 
 /*
  * This dynamically styles the boxes (class = set-name-container) that contain

--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -13,6 +13,13 @@
   clear: both;
 }
 
+.flex-container {
+  display: -ms-flexbox; /* IE 10 */
+  display: -webkit-flex; /* Safari */
+  display: flex;
+  clear: both;
+}
+
 table td {
   padding-right: 0.6em;
   padding-bottom: 0.2em;
@@ -22,7 +29,7 @@ table td {
   background-color: #EDEDED;
   border: 2px solid #DD4E00;
   padding: 1em;
-  margin-bottom: 2em;
+  margin: 0 2em 2em 0;
 }
 
 /*
@@ -34,12 +41,7 @@ table td {
 }
 
 .primary-source-sets aside {
-  margin-left: 1em;
-  margin-bottom: 1em;
-}
-
-.primary-source-sets .moduleSection {
-  margin-bottom: 2em;
+  margin-left: auto;
 }
 
 .primary-source-sets .contact-outer-container {
@@ -64,11 +66,6 @@ table td {
 .set .byline, .guide .byline {
   display: block;
   margin-top: 1em;
-}
-
-.set .guide-link .moduleSection,
-.guide  .set-link .moduleSection {
-  margin-bottom: 1em;
 }
 
 /* SourceSets index styles */
@@ -193,8 +190,16 @@ table td {
 
 /* SourceSet styles */
 
-.set .title-outer-container {
+.set article {
   background-color: #6592A6;
+}
+
+.set aside {
+  margin-bottom: 0;
+  background-color: #EDEDED;
+}
+
+.set .title-outer-container {
   margin-bottom: 2em;
 }
 
@@ -262,6 +267,10 @@ table td {
 
 /* Guide styles */
 
+.guide  .set-link .moduleSection {
+  margin-bottom: 1em;
+}
+
 .guide .textual-content {
   margin-top: 1.5em;
 }
@@ -280,16 +289,30 @@ table td {
   clear: both;
 }
 
-.source .media-outer-container {
-  padding: 34%;
-  width: 100%;
-  box-sizing: border-box;
+.source .flex-container {
+  min-height: 500px;
+}
+
+.source article {
   position: relative;
+}
+
+.source aside {
+  background-color: #EDEDED;
+  margin-bottom: 0;
+}
+
+.source .media-outer-container {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 .source article.audio .media-outer-container {
   padding: 3em;
-  background-color: #555;
+  background-color: #333;
 }
 
 .source .media-inner-container {
@@ -307,7 +330,6 @@ table td {
 }
 
 .source .textual-content {
-  clear: left;
   padding-top: 2em;
   margin-bottom: 3em;
 }
@@ -334,11 +356,13 @@ video {
 }
 
 audio {
-  margin: 0px auto;
+  margin: auto;
   display: block;
   width: 90%;
-  padding-top: 2em;
-  padding-bottom: 1em;
+  position: absolute;
+  top: 50%;
+  bottom: 50%;
+  right: 5%;
 }
 
 .related-sources, .related-sets {
@@ -543,6 +567,30 @@ ul.shareSave {
 
   .all-sets .threeCol .module {
     width: 100%;
+  }
+
+  .flex-container {
+    display: initial;
+  }
+
+  .source .media-outer-container {
+    position: relative;
+    padding: 34%;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .source aside {
+    margin-bottom: 5%;
+  }
+
+  .set aside {
+    margin-bottom: 5%;
+    margin-top: 5%;
+  }
+
+  .error {
+    margin: 0 0 2em 0;
   }
 }
 

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -28,31 +28,33 @@
 
 <div class='set' id='content'>
 
-  <article>
-    <div class='title-outer-container'>
-      <div class='title-inner-container'>
-        <h1><%= inline_markdown(@source_set.name) %></h1>
-        <span class='subheading'>Primary Source Set</span>
-        <% if @source_set.authors.present? %>
-          <span class='byline'>By <%= @source_set.author_list.to_sentence %></span>
-        <% end %>
-      </div>
-    </div>
-  </article>
-
-  <aside class='guide-link'>
-    <div class='module yellow line'>
-      <div class='moduleSection'>
-        <h2>Teaching guide</h2>
-        <p>
-          <% if @source_set.guides.present? %>
-            <%= link_to inline_markdown(@source_set.guides.first.name),
-                        guide_path(@source_set.guides.first) %>
+  <div class='flex-container'>
+    <article>
+      <div class='title-outer-container'>
+        <div class='title-inner-container'>
+          <h1><%= inline_markdown(@source_set.name) %></h1>
+          <span class='subheading'>Primary Source Set</span>
+          <% if @source_set.authors.present? %>
+            <span class='byline'>By <%= @source_set.author_list.to_sentence %></span>
           <% end %>
-        </p>
+        </div>
       </div>
-    </div>
-  </aside>
+    </article>
+
+    <aside class='guide-link'>
+      <div class='module yellow line'>
+        <div class='moduleSection'>
+          <h2>Teaching guide</h2>
+          <p>
+            <% if @source_set.guides.present? %>
+              <%= link_to inline_markdown(@source_set.guides.first.name),
+                          guide_path(@source_set.guides.first) %>
+            <% end %>
+          </p>
+        </div>
+      </div>
+    </aside>
+  </div>
 
   <div class='overview'>
     <%= markdown(@source_set.overview) %>

--- a/app/views/sources/_audio.html.erb
+++ b/app/views/sources/_audio.html.erb
@@ -1,4 +1,4 @@
-<article class='audio'>
+<article class='audio js-off'>
   <div class='media-outer-container'>
     <div class='media-inner-container'>
       <%= raw audio_player(@source.main_asset) %>

--- a/app/views/sources/_document.html.erb
+++ b/app/views/sources/_document.html.erb
@@ -1,4 +1,4 @@
-<article class='document'>
+<article class='document js-off'>
   <div class='media-outer-container'>
     <div class='media-inner-container'>
       <iframe src="https://docs.google.com/viewer?url=<%= 'https:' + base_src + @source.main_asset.file_name %>&embedded=true" frameborder="0"></iframe>

--- a/app/views/sources/_image.html.erb
+++ b/app/views/sources/_image.html.erb
@@ -2,8 +2,8 @@
   <%= javascript_include_tag 'openseadragon', defer: 'defer' %>
 <% end %>
 
-<article class='image'>
-  <div class='media-outer-container image'>
+<article class='image js-off'>
+  <div class='media-outer-container'>
     <div class='media-inner-container'>
 
       <div id="osd-viewer" oncontextmenu="return false;"></div>

--- a/app/views/sources/_video.html.erb
+++ b/app/views/sources/_video.html.erb
@@ -1,4 +1,4 @@
-<article class='video'>
+<article class='video js-off'>
   <div class='media-outer-container'>
     <div class='media-inner-container'>
       <%= raw video_player(@source.main_asset) %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -30,37 +30,37 @@
 <div class='source' id='content'>
   <h1><%= inline_markdown(@source.display_name) %></h1>
 
-  <div class='js-off'>
+  <div class='flex-container'>
     <%= render_media_asset %>
-  </div>
-  <noscript>
-    <div class='error'>
-      Your browser cannot render this media object because it does not support JavaScript.  Please enable JavaScript if you would like to access this media object.
-    </div>
-  </noscript>
-
-  <aside>
-    <div class='module blue line'>
-      <div class='moduleSection wrap'>
-        <h2>For this source, consider:</h2>
-        <ul>
-          <li>the author's point of view</li>
-          <li>the author's purpose</li>
-          <li>historical context</li>
-          <li>audience</li> 
-        </ul>
-        <h2>Citation information</h2>
-        <%= markdown(@source.citation) %>
-        <%= markdown(@source.credits) %>
-        <p><%= link_to 'View the description of this item in DPLA',
-                    frontend_path('item/' + @source.aggregation) %></p>
-        <% if !@provider_name.nil? %>
-        <p><%= link_to "View the item on #{@provider_name}",
-                    @digital_resource_url %></p>
-        <% end %>
+    <noscript>
+      <div class='error'>
+        Your browser cannot render this media object because it does not support JavaScript.  Please enable JavaScript if you would like to access this media object.
       </div>
-    </div>
-  </aside>
+    </noscript>
+
+    <aside>
+      <div class='module blue line'>
+        <div class='moduleSection wrap'>
+          <h2>For this source, consider:</h2>
+          <ul>
+            <li>the author's point of view</li>
+            <li>the author's purpose</li>
+            <li>historical context</li>
+            <li>audience</li>
+          </ul>
+          <h2>Citation information</h2>
+          <%= markdown(@source.citation) %>
+          <%= markdown(@source.credits) %>
+          <p><%= link_to 'View the description of this item in DPLA',
+                      frontend_path('item/' + @source.aggregation) %></p>
+          <% if !@provider_name.nil? %>
+          <p><%= link_to "View the item on #{@provider_name}",
+                      @digital_resource_url %></p>
+          <% end %>
+        </div>
+      </div>
+    </aside>
+  </div>
 
   <div class='textual-content'>
     <%= markdown(@source.textual_content) %>


### PR DESCRIPTION
fix/css-dimensional-manipulation

This uses CSS instead of JavaScript for most dimensional manipulation.  This will improve user experience for people with JavaScript disabled in their browsers.  The changes in this PR also improves UX overall by making the views slightly more responsive for all browsers.

Before, JavaScript was used to ensure that certain boxes on a page were the same height within a responsive design.  This instead uses the CSS3 flexbox feature.

There is one dimensional manipulation that is still handled with JavaScript, but I think it is outside the scope of this PR because 1) the solution would be complex and therefore time consuming, 2) it requires a different kind of solution than the one employed in this PR, and 3) the degradation of UX for those without JavaScript is tiny and strictly aesthetic, so it is not as high a priority.  See: https://github.com/dpla/primary-source-sets/blob/846e17bce19bd6d7f5d0dc52d84ceedb60dc5101/app/assets/javascripts/style.js#L29  I have made a [new ticket](https://issues.dp.la/issues/8371)
 to capture the work that needs to be done to address this issue.

This has been tested on Chrome, Safari, Firefox, Microsoft Edge, Android, and Safari mobile.  It should be tested on Internet Explorer before merge (I'm working on getting access to IE).

This addresses [#8230](https://issues.dp.la/issues/8230).