### PR TITLE
add error message if javascript disabled

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -18,6 +18,13 @@ table td {
   padding-bottom: 0.2em;
 }
 
+.error {
+  background-color: #EDEDED;
+  border: 2px solid #DD4E00;
+  padding: 1em;
+  margin-bottom: 2em;
+}
+
 /*
  * Use js-off to hide elements if javascript is disabled.
  * @see assets/javascripts/style.js

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -29,7 +29,14 @@
 <div class='source'>
   <h1><%= inline_markdown(@source.display_name) %></h1>
 
-  <%= render_media_asset %>
+  <div class='js-off'>
+    <%= render_media_asset %>
+  </div>
+  <noscript>
+    <div class='error'>
+      Your browser cannot render this media object because it does not support JavaScript.  Please enable JavaScript if you would like to access this media object.
+    </div>
+  </noscript>
 
   <aside>
     <div class='module blue line'>


### PR DESCRIPTION
If a user does not have JavaScript enabled in their browser, they cannot load media assets. Audio and video files will not play; images will not load; and the document viewer does not load interactive features, such as scroll and zoom.  Instead of trying and failing to render the media objects, this displays an error message to users explaining that they need JavaScript. 

The `div` containing the media object is given the class `js-off`, which by default does not display.  A JavaScript function displays all objects with this class when the page loads.  See https://github.com/dpla/primary-source-sets/blob/develop/app/assets/javascripts/style.js#L10

The rendered message looks like this:

<img width="684" alt="screen shot 2016-04-26 at 1 23 33 pm" src="https://cloud.githubusercontent.com/assets/3615206/14827978/dd13cc60-0bb2-11e6-8609-1311d7b5bc6b.png">
