### PR TITLE
Fix/set tile render

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -92,6 +92,14 @@ table td {
 
 /* Source set tile */
 
+.all-sets .threeCol .module {
+  width: 32.5%;
+}
+
+.set-tile .set-container {
+  background-color: #6592A6;
+}
+
 .set-tile.module {
   border-color: #6592A6;
   padding: 0;
@@ -105,7 +113,6 @@ table td {
 
 .set-tile .set-name-container {
   padding: 1em;
-  background-color: #6592A6;
 }
 
 .set-tile .set-name-container a {
@@ -534,7 +541,7 @@ ul.shareSave {
     width: 100%;
   }
 
-  .all-sets .module {
+  .all-sets .threeCol .module {
     width: 100%;
   }
 }


### PR DESCRIPTION
#This improves the rendering of set tiles in two ways:

1) It expands the width of the tiles so that they take up the entire available width of the page.
2) They eliminate the occasional white line that was appearing under set tiles if they were not exactly the expected pixel dimensions.

This has been tested locally.  It addresses [#8371](https://issues.dp.la/issues/8371).

Before:

![screen shot 2016-04-27 at 5 25 46 pm](https://cloud.githubusercontent.com/assets/3615206/14868763/55c0cfba-0c9d-11e6-91dd-40744817d047.png)

After: 

![screen shot 2016-04-27 at 5 27 05 pm](https://cloud.githubusercontent.com/assets/3615206/14868773/632db29e-0c9d-11e6-958d-9267e0aed021.png)
