### PR TITLE
custom language for auto-generated twitter post

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,4 +54,18 @@ module ApplicationHelper
       image_name
     end
   end
+
+  ##
+  # Generate a Twitter web intent link using the URL and title of the current
+  # page.
+  #
+  # @return String
+  # @see https://dev.twitter.com/web/tweet-button/parameters
+  def twitter_web_intent
+    'https://twitter.com/share?' \
+    "url=#{request.original_url}&" \
+    "related=#{Settings.twitter_username}&" \
+    "via=#{Settings.twitter_username}&" \
+    "text=#{content_for :title}"
+  end
 end

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :head_script do %>
-  <title><%= plaintext_from_md(@guide.name) %></title>
   <meta name='description' content="This teaching guide helps instructors use a specific primary source set, '<%= strip_tags(inline_markdown(@guide.source_set.name)) %>', in the classroom." />
   <link rel='canonical' href='<%= url_for(controller: 'guides',
                                           action: 'show',
@@ -8,6 +7,8 @@
                                           trailing_slash: true) %>' />
   <%= javascript_include_tag 'social', defer: 'defer' %>
 <% end %>
+
+<% content_for :title, plaintext_from_md(@guide.name) %>
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <%= javascript_include_tag 'application' %><%# do not defer %>
     <%= javascript_include_tag 'style', defer: 'defer' %>
     <%= csrf_meta_tags %>
+    <title><%= yield :title %></title>
     <%= yield :head_script %>
   </head>
   <body>

--- a/app/views/shared/_share.html.erb
+++ b/app/views/shared/_share.html.erb
@@ -11,11 +11,9 @@
       </li>
       <li>
         <div class='sharebtn'>
-          <a class='twitter-share-button' href='https://twitter.com/share'>
+          <a class='twitter-share-button' href='<%= twitter_web_intent %>'>
             Tweet
           </a>
-          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
-          </script>
         </div>
       </li>
       <li>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -1,9 +1,10 @@
 <% content_for :head_script do %>
-  <title>Primary Source Sets</title>
   <meta name='description' content="DPLA Primary Source Sets are designed to help students develop their critical thinking skills by exploring topics in history, literature, and culture through primary sources." />
   <%= javascript_include_tag 'results-bar', defer: 'defer' %>
   <%= javascript_include_tag 'social', defer: 'defer' %>
 <% end %>
+
+<% content_for :title, 'Primary Source Sets' %>
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :head_script do %>
-  <title><%= plaintext_from_md(@source_set.name) %></title>
   <meta name='description' content="<%= @source_set.description %>" />
   <link rel='canonical' href='<%= url_for(controller: 'source_sets',
                                           action: 'show',
@@ -14,6 +13,8 @@
   <%= javascript_include_tag 'carousel', defer: 'defer' %>
   <%= javascript_include_tag 'social', defer: 'defer' %>
 <% end %>
+
+<% content_for :title, plaintext_from_md(@source_set.name) %>
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :head_script do %>
-  <title><%= plaintext_from_md(@source.name) %></title>
   <meta name='description' content="This <%= @source.main_asset.class.name.downcase %> is part of '<%= strip_tags(inline_markdown(@source_set.name)) %>', a primary source set for educational use." />
   <link rel='canonical' href='<%= url_for(controller: 'sources',
                                           action: 'show',
@@ -14,6 +13,8 @@
   <%= javascript_include_tag 'carousel', defer: 'defer' %>
   <%= javascript_include_tag 'social', defer: 'defer' %>
 <% end %>
+
+<% content_for :title, plaintext_from_md(@source.name) %>
 
 <% content_for :foot_script do %>
   <%= render partial: 'shared/analytics' %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -86,4 +86,15 @@ describe ApplicationHelper, type: :helper do
       expect(helper.base_src).to eq 'something-example.com/'
     end
   end
+
+  describe '#twitter_web_intent' do
+    it 'includes the original url' do
+      expect(helper.twitter_web_intent).to include helper.request.original_url
+    end
+
+    it 'includes the page title' do
+      allow(helper).to receive(:content_for).with(:title).and_return('title')
+      expect(helper.twitter_web_intent).to include 'title'
+    end
+  end
 end


### PR DESCRIPTION
This adds custom language for an auto-generate tweet, which includes the page URL, page title and "@dpla".  In order to easily include the page title in the tweet, page titles are now accessible with `content_for`.  The twitter account name, `dpla`, is already defined in the settings file through aws: https://github.com/dpla/aws/blob/0e10b825dbb3d66fb3930d583376ceddc5fda9a8/ansible/group_vars/production#L40

Now, for example, when you click on the Twitter share button from `/primary-source-sets/`, you are taken to a page where you see this:

![screen shot 2016-04-27 at 5 32 21 pm](https://cloud.githubusercontent.com/assets/3615206/14868900/2e997ed6-0c9e-11e6-9b0d-6bb08675fec6.png)

This has been tested locally.  It addresses [ticket #8360](https://issues.dp.la/issues/8360).