### PR TITLE
allow basic controller tests to run

### DIFF
--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -12,9 +12,7 @@ describe SourcesController, type: :controller do
   context 'with the user logged-in' do
     login_admin
 
-    # FIXME: tests in 'basic controller' need to have mocks for
-    # @file_base_or_name?
-    it_behaves_like 'basic controller', :update #, :show
+    it_behaves_like 'basic controller', :update, :show
     it_behaves_like 'nested controller', :index, :create, :destroy
     it_behaves_like 'redirecting controller', :create
   end


### PR DESCRIPTION
This addresses a "FIXME" note that was left in a controller spec.  Apparently a previous iteration of the code base prevented it from running a shared example test.  Now, it runs just fine.  The instance variable mentioned in the comment, `@file_base_or_name`, is by default set to `nil` in the controller `:show` method, which seems to eliminate the need for a mock.