### PR TITLE
add content jumplinks

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -19,7 +19,7 @@
   <%= render_breadcrumbs separator: ' / ' %>
 </div>
 
-<div class='guide'>
+<div class='guide' id='content'>
 
   <article>
     <div class='title-outer-container'>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -19,7 +19,7 @@
 
 <%= render partial: 'shared/share' %>
 
-<div class='all-sets'>
+<div class='all-sets' id='content'>
 
   <h1><%= link_to 'Primary Source Sets', source_sets_path %></h1>
 

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -25,7 +25,7 @@
   <%= render_breadcrumbs separator: ' / ' %>
 </div>
 
-<div class='set'>
+<div class='set' id='content'>
 
   <article>
     <div class='title-outer-container'>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -26,7 +26,7 @@
   <%= render_breadcrumbs separator: ' / ' %>
 </div>
 
-<div class='source'>
+<div class='source' id='content'>
   <h1><%= inline_markdown(@source.display_name) %></h1>
 
   <div class='js-off'>


### PR DESCRIPTION
This adds jumplinks to public-facing pages that improve accessibility of the website.  

Prior to this PR, there were jumplinks to HTML elements with `id='content'` in our accessibility menu (see https://github.com/dpla/primary-source-sets/blob/develop/app/views/shared/_jump_links.html.erb#L5).  However, we were not actually implementing these links.  This PR adds HTML elements with `id='content'` to all public-facing pages.

Now, for example, you could use the following link to access the main content of the page:  `/primary-source-sets#content`

This has been tested locally.  It addresses [ticket #8385](https://issues.dp.la/issues/8385).