### PR TITLE
add twitter widget js

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <%= branding_stylesheets %>
     <%= javascript_include_tag 'application' %><%# do not defer %>
     <%= javascript_include_tag 'style', defer: 'defer' %>
+    <script src='https://platform.twitter.com/widgets.js'></script>
     <%= csrf_meta_tags %>
     <title><%= yield :title %></title>
     <%= yield :head_script %>


### PR DESCRIPTION
This fixes a bug introduced in [PR#157](https://github.com/dpla/primary-source-sets/pull/157).  I deleted the code that included the Twitter widgets JavaScript library, and forgot to add it back in again.  Without this library, the twitter button renders as a simple link, as opposed to a stylized button.