### PR TITLE
embed json-ld in html pages

### DIFF
--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -6,6 +6,9 @@
                                           only_path: false,
                                           trailing_slash: true) %>' />
   <%= javascript_include_tag 'social', defer: 'defer' %>
+  <script type='application/ld+json'>
+    <%= render partial: 'guides/show.json' %>
+  </script>
 <% end %>
 
 <% content_for :title, plaintext_from_md(@guide.name) %>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -12,6 +12,9 @@
           defer></script>
   <%= javascript_include_tag 'carousel', defer: 'defer' %>
   <%= javascript_include_tag 'social', defer: 'defer' %>
+  <script type='application/ld+json'>
+    <%= render partial: 'source_sets/show.json' %>
+  </script>
 <% end %>
 
 <% content_for :title, plaintext_from_md(@source_set.name) %>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -12,6 +12,9 @@
           defer></script>
   <%= javascript_include_tag 'carousel', defer: 'defer' %>
   <%= javascript_include_tag 'social', defer: 'defer' %>
+  <script type='application/ld+json'>
+    <%= render partial: 'sources/show.json' %>
+  </script>
 <% end %>
 
 <% content_for :title, plaintext_from_md(@source.name) %>


### PR DESCRIPTION
This embeds the JSON-LD markup for sets, guides, and sources within the HTML.  It is intended to boost SEO.  The JSON-LD partials already exist.

This addresses [#8187](https://issues.dp.la/issues/8187).