### PR TITLE
Add support for cache_store sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'access-granted', '~> 1.0.0'
 gem 'rake', '< 11.0'
 gem 'DPLibrary', git: 'https://github.com/phereford/DPLibrary.git',
                  branch: 'master'
+gem 'dalli', '~> 2.0'
 
 group :test, :development do
   gem 'rspec-core', '~> 3.3.2'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,4 +47,10 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Configure cache store.
+  # YAML Hash values (see memory_store example in settings.yml) get turned into
+  # Config::Options objects, but we need them as hashes.
+  cache_settings = Settings.cache.to_hash
+  config.cache_store = cache_settings[:store].to_sym, *cache_settings[:opts]
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,9 +53,6 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"
 
@@ -87,4 +84,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  cache_settings = Settings.cache.to_hash
+  config.cache_store = cache_settings[:store].to_sym, *cache_settings[:opts]
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_primary-source-sets_session'
+store = Settings.cache.store == 'null_store' ? :cookie_store : :cache_store
+Rails.application.config.session_store store,
+                                       key: '_primary-source-sets_session',
+                                       path: Settings.relative_url_root

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -88,3 +88,28 @@ action_mailer:
     # `sendmail' executable.  (I.e. the :smtp option for ActionMailer's
     # `delivery_method'.)
     port: 1025
+
+# Override `cache` with options that suit the particular cache store.
+#
+# Example 1:
+# cache:
+#   store: mem_cache_store
+#   opts:
+#     - host1
+#     - host2
+#     - { namespace: 'pss' }
+#
+# Example 2:
+# cache:
+#   store: file_store
+#   opts: "/path/to/cache/dir"
+#
+# Example 3:
+# cache:
+#   store: memory_store
+#   opts:
+#     size: 67108864
+#
+cache:
+  store: null_store
+  opts:

--- a/provisioning/provision.yml
+++ b/provisioning/provision.yml
@@ -19,6 +19,7 @@
         - libpq-dev
         - build-essential
         - libfontconfig1-dev
+        - memcached
 
 - hosts: all
   # do as "vagrant" user


### PR DESCRIPTION
* Add the ability to use the rails `cache_store` session handler.
* Set up the Rails `cache_store`.
* Add the `dali` gem to support memcached.

Is this a good way to set up the Rails cache_store, for other use in addition to sessions?

Is there some better way to set `config.cache_store` that doesn't duplicate code between `development.rb` and `production.rb`? I wasn't able to make it work by creating my own initializer.

The `memcached` package is added to the VM, so you can run `vagrant provision` on it and it will be started. You can then update your `settings.local.yml` with a host `localhost` if you want to use memcached. For example:
```
cache:
  store: mem_cache_store
  opts:
    - localhost
```
