### PR TITLE
Feature/view caching

### DIFF
--- a/app/assets/stylesheets/primary_source_sets.css
+++ b/app/assets/stylesheets/primary_source_sets.css
@@ -227,8 +227,8 @@ table td {
   margin-bottom: 2em;
 }
 
-.set .related-sets {
-  margin: 2em 0;
+.related-sets .tag-list {
+  display: none;
 }
 
 /* Source tile */

--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -11,10 +11,8 @@ class SourceSetsController < ApplicationController
   def index
     @tags = get_tags_from_params
     @order = params[:order]
-    @published_sets = SourceSet.includes(:small_images).published
-                               .order_by(@order).with_tags(@tags)
-    @unpublished_sets = SourceSet.includes(:small_images).unpublished
-                                 .order_by(@order).with_tags(@tags)
+    @published_sets = SourceSet.published.order_by(@order).with_tags(@tags)
+    @unpublished_sets = SourceSet.unpublished.order_by(@order).with_tags(@tags)
   end
 
   def show

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,6 +1,28 @@
 class Image < ActiveRecord::Base
   has_many :attachments, as: :asset, dependent: :destroy
-  has_many :sources, through: :attachments
+  has_many :sources, through: :attachments,
+                     after_add: :touch_source,
+                     before_remove: :touch_source
   validates :file_name, presence: :true
   validates :size, presence: :true
+  after_update :touch_associated_sources
+  # prepend before_destroy so it is exectued before dependent: :destroy
+  before_destroy :touch_associated_sources, prepend: true
+  after_touch :touch_associated_sources
+
+  private
+
+  ##
+  # Update cache keys of all associated sources.
+  # Update cache keys of all sets associated with those sources.
+  def touch_associated_sources
+    Source.touch_sources_with_image(self)
+  end
+
+  ##
+  # Update cache key of a given source.
+  # Update cache key of all sets associated with that source.
+  def touch_source(source)
+    source.touch
+  end
 end

--- a/app/models/source_set.rb
+++ b/app/models/source_set.rb
@@ -5,7 +5,8 @@ class SourceSet < ActiveRecord::Base
   has_many :guides, dependent: :destroy
   has_one :featured_source, -> { where featured: true }, class_name: 'Source'
   has_many :small_images, through: :featured_source
-  has_and_belongs_to_many :tags
+  has_and_belongs_to_many :tags, after_add: :touch_self,
+                                 before_remove: :touch_self
   has_and_belongs_to_many :filter_tags, -> { filterable }, class_name: 'Tag'
   validates :name, presence: true
   validates_numericality_of :year, only_integer: true, allow_nil: true,
@@ -82,6 +83,26 @@ class SourceSet < ActiveRecord::Base
   end
 
   ##
+  # Update the cache key of all source sets associated with any of a given tag
+  # or group of tags. If a source set is associated with at least one on the
+  # given tags, it will be updated.
+  # @param tags Tag OR [ActiveRecord::Relation<Tag>]
+  def self.touch_sets_with_tags(tags)
+    ids = tags.class.name == 'Tag' ? tags.id : tags.ids
+    joins(:tags).where(tags: { id: ids }).update_all(updated_at: Time.now)
+  end
+
+  ##
+  # Update the cache key of all source sets associated with any of a given
+  # source or group of sources. If a source set is associated with at least 
+  # one on the given sources, it will be updated.
+  # @param sources Source OR [ActiveRecord::Relation<Source>]
+  def self.touch_sets_with_sources(sources)
+    ids = sources.class.name == 'Source' ? sources.id : sources.ids
+    joins(:sources).where(sources: { id: ids }).update_all(updated_at: Time.now)
+  end
+
+  ##
   # If the set is being published, save the current timestamp.
   # If the set was already published, do not save the current timestamp.
   # If the set is unpublished, clear the timestamp.
@@ -91,5 +112,15 @@ class SourceSet < ActiveRecord::Base
     elsif self.published == false
       self.published_at = nil
     end
+  end
+
+  private
+
+  ##
+  # Update cache key of self.
+  # @param ActiveRecord
+  def touch_self(record)
+    return if self.new_record? # cannot update unsaved record
+    self.touch
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,10 +1,16 @@
 class Tag < ActiveRecord::Base
   extend FriendlyId
-  has_and_belongs_to_many :source_sets
+  has_and_belongs_to_many :source_sets, after_add: :touch_source_set,
+                                        before_remove: :touch_source_set
   has_many :tag_sequences, dependent: :destroy
-  has_many :vocabularies, through: :tag_sequences
+  has_many :vocabularies, through: :tag_sequences,
+                          after_add: :touch_self,
+                          before_remove: :touch_self
   validates :label, presence: true, uniqueness: true
   validates :uri, format: { with: URI.regexp }, if: proc { |a| a.uri.present? }
+  after_update :touch_associated_source_sets
+  before_destroy :touch_associated_source_sets
+  after_touch :touch_associated_source_sets
 
   ##
   # FriendlyId generates a human-readable slug to be used in the URL, in place
@@ -23,4 +29,43 @@ class Tag < ActiveRecord::Base
                         joins(:vocabularies)
                           .where(vocabularies: { filter: true })
                       end)
+
+  ##
+  # @param Vocabulary
+  # @return [ActiveRecord::Association<Tag>]
+  def self.with_vocabulary(vocab)
+    joins(:vocabularies).where(vocabularies: { id: vocab.id })
+  end
+
+  ##
+  # Update the cache key of all tags associated with a given vocabulary.
+  # Update the cache key of all source sets associated with the tags.
+  # @param Vocabulary
+  def self.touch_tags_with_vocab(vocab)
+    # Note that update_all does not trigger ActiveRecord callbacks.
+    with_vocabulary(vocab).update_all(updated_at: Time.now)
+    SourceSet.touch_sets_with_tags(with_vocabulary(vocab))
+  end
+
+  private
+
+  ##
+  # Update cache keys of self and all associated source sets.
+  # @param ActiveRecord
+  def touch_self(record)
+    return if self.new_record? # cannot touch unsaved record
+    self.touch
+  end
+
+  ##
+  # Update timestamp of a given source set.
+  def touch_source_set(set)
+    set.touch
+  end
+
+  ##
+  # Update timestamps of all source sets associated with self.
+  def touch_associated_source_sets
+    SourceSet.touch_sets_with_tags(self)
+  end
 end

--- a/app/views/source_sets/_set_tile.html.erb
+++ b/app/views/source_sets/_set_tile.html.erb
@@ -1,16 +1,15 @@
-<section class='module set-tile'>
-  <div class='set-container'>
-    <% if set.featured_image.present? %>
-      <%= link_to((image_tag base_src + set.featured_image.file_name,
-                             alt: set.featured_image.alt_text.present? ? 
-                               set.featured_image.alt_text : set.name),
-                  source_set_path(set)) %>
-    <% end %>
-    <div class='set-name-container'>
-      <%= link_to inline_markdown(set.name), source_set_path(set) %>
-    </div>
-
-    <% if render_tags %>
+<% cache set do %>
+  <section class='module set-tile'>
+    <div class='set-container'>
+      <% if set.featured_image.present? %>
+        <%= link_to((image_tag base_src + set.featured_image.file_name,
+                               alt: set.featured_image.alt_text.present? ? 
+                                 set.featured_image.alt_text : set.name),
+                    source_set_path(set)) %>
+      <% end %>
+      <div class='set-name-container'>
+        <%= link_to inline_markdown(set.name), source_set_path(set) %>
+      </div>
 
       <ul class='tag-list'>
         <% set.filter_tags.each do |tag| %>
@@ -20,6 +19,6 @@
           </li>
         <% end %>
       </ul>
-    <% end %>
-  </div>
-</section>
+    </div>
+  </section>
+<% end %>

--- a/app/views/source_sets/index.html.erb
+++ b/app/views/source_sets/index.html.erb
@@ -55,7 +55,7 @@
         <%= label_tag('tags[]', "#{vocab.name}:") %>
 
         <% if selected_tags_in(tags).count == 0 %>
-          <%# render dropdown menu %>
+          <%# dropdown menu %>
           <%= select_tag('tags[]',
                          options_for_select(tag_filter_options(tags),
                                             selected_slugs_in(tags))) %>
@@ -63,7 +63,7 @@
           <noscript><%= submit_tag 'Re-sort', name: nil %></noscript>
 
         <% else %>
-          <%# render pill tags %>
+          <%# pill tags %>
           <ul class='tag-list inline-block'>
             <% selected_tags_in(tags).each do |tag| %>
               <li class='tag'>

--- a/app/views/source_sets/show.html.erb
+++ b/app/views/source_sets/show.html.erb
@@ -63,7 +63,7 @@
     <%= markdown(@source_set.overview) %>
   </div>
 
-  <%= render 'source_list' %>
+  <%= render partial: 'source_sets/source_list' %>
 
   <% if @source_set.resources.present? %>
     <div class='resources-outer-container'>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -34,10 +34,14 @@
   <h1><%= inline_markdown(@source.display_name) %></h1>
 
   <div class='flex-container'>
+    <%# Template Dependency: sources/audio %>
+    <%# Template Dependency: sources/document %>
+    <%# Template Dependency: sources/image %>
+    <%# Template Dependency: sources/video %>
     <%= render_media_asset %>
     <noscript>
       <div class='error'>
-        Your browser cannot render this media object because it does not support JavaScript.  Please enable JavaScript if you would like to access this media object.
+        Your browser cannot show this media object because it does not support JavaScript.  Please enable JavaScript if you would like to access this media object.
       </div>
     </noscript>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,9 +9,9 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
+  # Show full error reports and caching is turned on.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -15,4 +15,60 @@ describe Image, type: :model do
     attributes[:file_name] = nil
     expect(described_class.new(attributes)).not_to be_valid
   end
+
+  describe 'cache dependencies' do
+    let(:image) { create(:image_factory) }
+    let(:source) { create(:source_factory) }
+    let(:set) { create(:source_set_factory) }
+
+    before { set.sources << source }
+
+    context 'when updated' do
+      before(:each) { source.images << image }
+
+      it 'changes cache key of associated source' do
+        expect{ image.update_attribute(:alt_text, 'new text') }
+          .to change{ source.reload.cache_key }
+      end
+
+      it 'changes cache key of sets of associated sources' do
+        expect{ image.update_attribute(:alt_text, 'new text') }
+          .to change{ set.reload.cache_key }
+      end
+    end
+
+    context 'when deleted' do
+      before(:each) { source.images << image }
+
+      it 'changes cache key of associated source' do
+        expect{ image.destroy }.to change{ source.reload.cache_key }
+      end
+
+      it 'changes cache key of set of associated sources' do
+        expect{ image.destroy }.to change{ set.reload.cache_key }
+      end
+    end
+
+    context 'when source association created' do
+      it 'changes cache key of associated source' do
+        expect{ image.sources << source }.to change{ source.reload.cache_key }
+      end
+
+      it 'changes cache key of set of associated sources' do
+        expect{ image.sources << source }.to change{ set.reload.cache_key }
+      end
+    end
+
+    context 'when source association deleted' do
+      before(:each) { source.images << image }
+
+      it 'changes cache key of associated source' do
+        expect{ image.destroy }.to change{ source.reload.cache_key }
+      end
+
+      it 'changes cache key of set of associated sources' do
+        expect{ image.destroy }.to change{ set.reload.cache_key }
+      end
+    end
+  end
 end

--- a/spec/models/source_set_spec.rb
+++ b/spec/models/source_set_spec.rb
@@ -215,4 +215,18 @@ describe SourceSet, type: :model do
       expect(set.reload.published_at).to eq time
     end
   end
+
+  describe 'cache dependencies' do
+    let(:tag) { create(:tag_factory) }
+    let(:set) { create(:source_set_factory) }
+
+    it 'changes cache key when new tag association saved' do
+      expect{ set.tags << tag }.to change{ set.reload.cache_key }
+    end
+
+    it 'changes cache key when tag association deleted' do
+      set.tags << tag
+      expect{ set.tags.delete(tag) }.to change{ set.reload.cache_key }
+    end
+  end
 end

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -24,6 +24,12 @@ describe Vocabulary, type: :model do
     expect(Vocabulary.create(name: 'Little My').slug).to eq 'little-my'
   end
 
+  it 'dependent destroys tag sequences' do
+    vocab = create(:vocabulary_factory)
+    vocab.tags << create(:tag_factory)
+    expect{ vocab.destroy }.to change{ TagSequence.count }.by -1
+  end
+
   context 'with filterable vocabs' do
     let(:filterable) { create(:vocabulary_factory, filter: true) }
 
@@ -43,6 +49,63 @@ describe Vocabulary, type: :model do
     describe '#filterable' do
       it 'returns vocubularies where filter is true' do
         expect(Vocabulary.filterable).to contain_exactly(filterable)
+      end
+    end
+  end
+
+  describe 'cache dependencies' do
+    let(:vocab) { create(:vocabulary_factory) }
+    let(:tag) { create(:tag_factory) }
+    let(:set) { create(:source_set_factory) }
+
+    before(:each) do
+      vocab.tags << tag
+      set.tags << tag
+    end
+
+    context 'when updated' do
+      it 'changes cache keys of associated tags' do
+        expect{ vocab.update_attribute(:name, 'new name') }
+          .to change{ tag.reload.cache_key }
+      end
+
+      it 'changes cache keys of source sets of associated tags' do
+        expect{ vocab.update_attribute(:filter, true) }
+          .to change{ set.reload.cache_key }
+      end
+    end
+
+    context 'when new tag association saved' do
+      let(:vocab2) { create(:vocabulary_factory, name: '2nd name') }
+
+      it 'changes cache key of associated tag' do
+        expect{ vocab2.tags << tag }.to change{ tag.reload.cache_key }
+      end
+
+      it 'changes cache keys of source sets of associated tag' do
+        expect{ vocab2.tags << tag }.to change{ set.reload.cache_key }
+      end
+    end
+
+    context 'when tag association deleted' do
+      it 'changes cache key of associated tag' do
+        expect{ vocab.tags.delete(tag) }
+          .to change{ tag.reload.cache_key }
+      end
+
+      it 'changes cache keys of source sets of associated tag' do
+        expect{ vocab.tags.delete(tag) }
+          .to change{ set.reload.cache_key }
+      end
+    end
+
+    context 'when vocab deleted' do
+      it 'changes cache keys of associated tags' do
+        expect{ vocab.destroy }.to change{ tag.reload.cache_key }
+      end
+
+      it 'changes cache keys of source sets of associated tags' do
+        expect{ vocab.destroy }.to change{ set.reload.cache_key }
       end
     end
   end


### PR DESCRIPTION
This adds view fragment caching for set tiles in order to decrease page load time.  It makes use of [cache digests](https://github.com/rails/cache_digests), which comes with Rails 4.  Set tiles appear on `source_sets#index` and `source_sets#show` (in the "Related primary source sets" carousel").  They look like this:

<img width="376" alt="screen shot 2016-05-27 at 2 42 06 pm" src="https://cloud.githubusercontent.com/assets/3615206/15617941/4de50052-2419-11e6-91a4-3a50f13f5633.png">

Logs show that rendering these tiles greatly slows page load time, and because of the nature of the required database calls, they cannot be effectively cached in the controller.  However, they are a good candidate for fragment caching, especially considering that they are relatively static - the associated image and tags change very infrequently.  This has been tested locally, and significantly reduces page load time.

Changes in this PR include:

* In the views, template dependencies are articulated according the cache digests conventions.  While this particular PR does not make use of template dependencies, it is now set correctly for any future fragment caching.  You can double-check this in your console by running, for example: `rake cache_digests:nested_dependencies TEMPLATE=source_sets/index`.

* Caching is turned on in the development environment for testing purposes (see `config/environments/development.rb`).

* Since the set tiles conceptually represent a set, the cache key for each set tile fragment is tied to the sets table; whenever the sets table is touched, the key expires.  The tricky part is that correctly rendering a set tile depends on data not only from the sets table, but also from sources, images, tags, and vocabularies.  So we need to make sure that when an entry in any one of these tables is updated or destroyed, or when an association between any of these tables is added or removed, the sets table id also updated.   That's what all the changes in the models are about.  It's easy in the `Source` model because a Rails method already exists to take of all these dependencies for `belong_to` relationships - but for all other types of relationships, we have to code it out.

* JavaScript is used to to hide the tags for the set tiles in the `source_sets#show` "Related primary source sets" carousel".  This is so that the same cache fragments can be used in both contexts.  The carousel already depends on JavaScript to render, and defaults to a simple list of sets (as opposed to set tiles) if JavaScript is disabled.  

* Extensive tests to ensure expected behavior.

In the future, I would like to refactor this to eliminate redundancies and make into something more generally useful in different contexts.  I would also like to add one or more fragment caches in other parts of the application.  But for now it might be worth seeing how this behaves in production environment and iterating later.