### PR TITLE
order filters_for_sets by tag_sequences.position

### DIFF
--- a/app/helpers/source_sets_helper.rb
+++ b/app/helpers/source_sets_helper.rb
@@ -31,6 +31,7 @@ module SourceSetsHelper
       tag_list = Tag.joins(:source_sets, :vocabularies)
                     .where(source_sets: { id: ss_ids })
                     .where(vocabularies: { id: vocab.id })
+                    .order('tag_sequences.position asc')
                     .uniq
 
       # Return the vocab and associated tag list.

--- a/spec/helpers/source_sets_helper_spec.rb
+++ b/spec/helpers/source_sets_helper_spec.rb
@@ -50,6 +50,19 @@ describe SourceSetsHelper, type: :helper do
         expect(helper.filters_for_sets(source_sets).values.flatten)
           .to contain_exactly tag_a
       end
+
+      it 'returns tags ordered by tag sequence position' do
+        vocab_a.tags << tag_c
+        # reverse tag sequence position of vocab_a tags
+        tsa = tag_a.tag_sequences.where(vocabulary_id: vocab_a.id)
+                   .where(tag_id: tag_a.id).first
+        tsa.update_attribute(:position, 1)
+        tsc = tag_c.tag_sequences.where(vocabulary_id: vocab_a.id)
+                   .where(tag_id: tag_c.id).first
+        tsc.update_attribute(:position, 0)
+        expect(helper.filters_for_sets(source_sets)[vocab_a])
+          .to match [tag_c, tag_a]
+      end
     end
   end
 


### PR DESCRIPTION
This fixes a bug introduced in PR#165.  On source_sets#index, the tags listed in the dropdown menu were out of order.  They are supposed to be ordered according to the "position" field in the "tag_sequences" table.  This PR fixes the dropdown menus this so that the positions defined in the tag_sequences table are enforced.

This has been tested locally and is working as expected.  It addresses [ticket #8424](https://issues.dp.la/issues/8424).