### PR TITLE
fix order by db call for postgresql

### DIFF
--- a/app/helpers/source_sets_helper.rb
+++ b/app/helpers/source_sets_helper.rb
@@ -28,7 +28,8 @@ module SourceSetsHelper
 
       # Get all tags associated with the vocab.
       # Ignore tags that aren't associated with any of the source_sets.
-      tag_list = Tag.joins(:source_sets, :vocabularies)
+      tag_list = Tag.select('tags.*, tag_sequences.position')
+                    .joins(:source_sets, :vocabularies)
                     .where(source_sets: { id: ss_ids })
                     .where(vocabularies: { id: vocab.id })
                     .order('tag_sequences.position asc')


### PR DESCRIPTION
This fixes a bug introduced in [PR#169](https://github.com/dpla/primary-source-sets/pull/169/files).  #169 was tested and worked locally (sqlite database), but failed when deployed to staging (postgresql database).  Postgresql requires that any columns in a ORDER BY clause also appear in a SELECT clause.

This has been tested on staging.  It addresses [ticket #8242](https://issues.dp.la/issues/8424).