### PR TITLE
pin DPLibrary gem to v0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,7 @@ gem 'access-granted', '~> 1.0.0'
 # As of jasmine-jquery-rails v2.0.3, jasmine-jquery-rails is not compatible with
 # rake 11.0.0
 gem 'rake', '< 11.0'
-gem 'DPLibrary', git: 'https://github.com/phereford/DPLibrary.git',
-                 branch: 'master'
+gem 'DPLibrary', '~> 0.1'
 gem 'dalli', '~> 2.0'
 
 group :test, :development do


### PR DESCRIPTION
This pins the DPLibrary gem to a release version, rather than pulling from the master branch.