### PR TITLE
change dplafest main menu link

### DIFF
--- a/app/views/shared/_top_nav.html.erb
+++ b/app/views/shared/_top_nav.html.erb
@@ -66,7 +66,7 @@
     <li><%= link_to "Groups", wordpress_path('/get-involved/groups/') %></li>
     <li><%= link_to "Workshops", wordpress_path('/get-involved/workshops/') %></li>
     <li><%= link_to "Events", wordpress_path('/get-involved/events/') %></li>
-    <li><%= link_to "DPLAfest", wordpress_path('/get-involved/dplafest/april-2016/') %></li>
+    <li><%= link_to "DPLAfest", wordpress_path('/get-involved/dplafest/') %></li>
     <li><%= link_to "Follow Us", wordpress_path('/get-involved/follow/') %></li>
   </ul>
 </li>


### PR DESCRIPTION
Change the DPLAfest link in the main menu.  This addresses [ticket #8552](https://issues.dp.la/issues/8552).