### PR TITLE
configure x-frame-options

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module PrimarySourceSets
 
     # Autoload contents of lib
     config.autoload_paths += %W(#{config.root}/lib/primary-source-sets)
+
+    # Allow X-Frame access from known requesters
+    config.action_dispatch.default_headers = {
+        'X-Frame-Options' => Settings.http_headers.x_frame_options
+    }
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -113,3 +113,7 @@ action_mailer:
 cache:
   store: null_store
   opts:
+
+# default http response headers
+http_headers:
+  x_frame_options: 'SAMEORIGIN'


### PR DESCRIPTION
This allows us to set X-Frame-Options for primary source sets.  Along with accompanying changes to [automation](https://github.com/dpla/automation/pull/205) and [aws](https://github.com/dpla/aws/pull/47), it will allow OER commons to display an iframe of primary source sets.  OER commons indexes our sets in their educational resources discovery tool.

I have run a local deployment with the aws and automation changes, and verified with curl:

<img width="631" alt="screen shot 2016-11-02 at 9 22 09 am" src="https://cloud.githubusercontent.com/assets/3615206/19930968/25e8721a-a0e1-11e6-8abf-67aed58ea02e.png">


This addresses [ticket #8490](https://issues.dp.la/issues/8490).