### PR TITLE
hide av download button on chrome with css

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -20,5 +20,6 @@
  *= require primary_source_sets.css
  *= require poster.css
  *= require jquery-ui/sortable
+ *= require av_download.css
  *= require_self
  */

--- a/app/assets/stylesheets/av_download.css
+++ b/app/assets/stylesheets/av_download.css
@@ -1,0 +1,14 @@
+video::-webkit-media-controls {
+    overflow: hidden !important
+}
+video::-webkit-media-controls-enclosure {
+    width: calc(100% + 32px);
+    margin-left: auto;
+}
+audio::-webkit-media-controls {
+    overflow: hidden !important
+}
+audio::-webkit-media-controls-enclosure {
+    width: calc(100% + 32px);
+    margin-left: auto;
+}


### PR DESCRIPTION
This uses a CSS hack to hide download buttons on audio and video elements in Chrome.

This has been deployed to staging for testing.  I have tested it on all my available browsers and devices, as well as the Chrome viewport controls.  Further testing would be appreciated!  We need to ensure not only that the download button is hidden on Chrome, but also that no other controls are accidentally hidden on other browsers.

You can use these examples on staging:
Audio example: https://staging.dp.la/primary-source-sets/sources/5
Video example: https://staging.dp.la/primary-source-sets/sources/6

And compare with these examples on production:
Audio example: https://dp.la/primary-source-sets/sources/1211
Video example: https://dp.la/primary-source-sets/sources/1208

This addresses [ticket DT-1145](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1145).