### PR TITLE
add meta referrer tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport"
           content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="origin-when-cross-origin" />
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600,600italic'
           rel='stylesheet' type='text/css'>
     <%= stylesheet_link_tag 'application', media: 'all' %>


### PR DESCRIPTION
This adds a meta referrer tag to the head of each page.  This will allow external sites not using HTTPS to track traffic from DPLA.  It has been tested on staging.  This addresses ticket [DT-1201](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1201).