### PR TITLE
remove events from menu

### DIFF
--- a/app/views/shared/_top_nav.html.erb
+++ b/app/views/shared/_top_nav.html.erb
@@ -65,7 +65,6 @@
     <li><%= link_to "GIF IT UP", wordpress_path('/gif-it-up/') %></li>
     <li><%= link_to "Groups", wordpress_path('/get-involved/groups/') %></li>
     <li><%= link_to "Workshops", wordpress_path('/get-involved/workshops/') %></li>
-    <li><%= link_to "Events", wordpress_path('/get-involved/events/') %></li>
     <li><%= link_to "DPLAfest", wordpress_path('/get-involved/dplafest/') %></li>
     <li><%= link_to "Follow Us", wordpress_path('/get-involved/follow/') %></li>
   </ul>


### PR DESCRIPTION
This removes the "Events" link from the "Get Involved" menu.  It has been tested on staging.  It addresses [DT-1195](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1195).