### PR TITLE
add json view for sets#index

### DIFF
--- a/app/controllers/source_sets_controller.rb
+++ b/app/controllers/source_sets_controller.rb
@@ -13,6 +13,16 @@ class SourceSetsController < ApplicationController
     @order = params[:order]
     @published_sets = SourceSet.published.order_by(@order).with_tags(@tags)
     @unpublished_sets = SourceSet.unpublished.order_by(@order).with_tags(@tags)
+
+    ##
+    # Render HTML or JSON formats unless controller has already redirected or
+    # rendered (ie. in the check_login_and_authorize method).
+    unless performed?
+      respond_to do |format|
+        format.html
+        format.json { render partial: 'source_sets/index.json.erb' }
+      end
+    end
   end
 
   def show

--- a/app/views/source_sets/_index.json.erb
+++ b/app/views/source_sets/_index.json.erb
@@ -1,0 +1,17 @@
+{
+  <%= render partial: 'shared/context.json' %>,
+  "url": "<%= request.original_url %>",
+  "@type": "ItemList",
+  <% if @published_sets.present? %>
+    "numberOfItems": "<%= @published_sets.count %>",
+    "itemListElement": [
+      <% for set in @published_sets %>
+        {
+          "@id": "<%= source_set_url(set) %>",
+          "@type": "CreativeWork",
+          "name": <%= set.name.to_json.html_safe %>
+        }<%= ',' unless set.equal?(@published_sets.last) %>
+      <% end %>
+    ]
+  <% end %>
+}

--- a/spec/controllers/source_sets_controller_spec.rb
+++ b/spec/controllers/source_sets_controller_spec.rb
@@ -66,6 +66,11 @@ describe SourceSetsController, type: :controller do
         get :index
         expect(response).to render_template :index
       end
+
+      it 'renders the index json partial' do
+        get :index, format: :json
+        expect(response).to render_template(partial: '_index.json.erb')
+      end
     end
 
     describe '#show' do

--- a/spec/views/source_sets/_index.json.erb_spec.rb
+++ b/spec/views/source_sets/_index.json.erb_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'source_sets/_index.json.erb', type: :view do
+
+  before do
+    create(:source_set_factory, name: 'Snorkmaiden', published: true)
+    assign(:published_sets, SourceSet.published)
+  end
+
+  it_behaves_like 'renderable view'
+  it_behaves_like 'valid json view'
+end


### PR DESCRIPTION
This adds a JSON view for the `sets#index` page.  It lists the URIs of all the sets, which will allow us to harvest sets via HTTP.  It also lists the name and schema.org type for each set, which follows precedent set elsewhere in the app (ie. https://github.com/dpla/primary-source-sets/blob/develop/app/views/source_sets/_show.json.erb#L57:L80).

This is the first step to addressing [ticket DT-1393](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1393).  It has been tested locally and on staging.  It is currently deployed to staging, in case anyone wants to use it to test the primary source sets harvester.

The second step to addressing ticket DT-1393 is [ingestion3#17](https://github.com/dpla/ingestion3/pull/17).