### PR TITLE
Add SSL settings for the Devise gem

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: Settings.app_host,
     script_name: Settings.relative_url_root,
-    protocol: Settings.app_scheme.tr(':/', '')
+    protocol: 'https'
   }
   config.action_mailer.delivery_method =
     Settings.action_mailer.delivery_method.to_sym
@@ -91,4 +91,9 @@ Rails.application.configure do
   # Initialize the Google Analytics tracker
   # GoogleAnaltyics is defined in the google-analtyics-rails gem
   GoogleAnalytics.tracker = Settings.googleanalytics.tracker
+
+  # Devise SSL
+  config.to_prepare { Devise::SessionsController.force_ssl }
+  config.to_prepare { Devise::RegistrationsController.force_ssl }
+  config.to_prepare { Devise::PasswordsController.force_ssl }
 end


### PR DESCRIPTION
This adds SSL configurations for the `Devise` gem, which manages user accounts.  It restores the browser feature that allows current users to create new user accounts.  This feature was broken before.

This has been tested on staging.  It addresses [ticket DT-1319](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1319).