### PR TITLE
add tags to json api

### DIFF
--- a/app/views/source_sets/_index.json.erb
+++ b/app/views/source_sets/_index.json.erb
@@ -3,6 +3,24 @@
   "url": "<%= request.original_url %>",
   "@type": "ItemList",
   <% if @published_sets.present? %>
+    <% filters = filters_for_sets(@published_sets) %>
+    <% if filters.present? %>
+      "hasPart": [
+        <% filters.each do |vocab, tags| %>
+          {
+            "name": <%= vocab.name.to_json.html_safe %>,
+            "disambiguatingDescription": "tagList",
+            "itemListElement": [
+              <% for tag in tags %>
+                {
+                  "name": <%= tag.label.to_json.html_safe %>
+                }<%= ',' unless tag.equal?(tags.last) %>
+              <% end %>
+            ]
+          }<%= ',' unless vocab.equal?(filters.keys.last) %>
+        <% end %>
+      ],
+    <% end %>
     "numberOfItems": "<%= @published_sets.count %>",
     "itemListElement": [
       <% for set in @published_sets %>


### PR DESCRIPTION
This adds tag lists to the JSON API.  It is to help Postlight make Subject and Time Period dropdown menus on the landing page.  This addresses [ticket DT-1550](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1550).