### PR TITLE
Fix error logging exception message

### DIFF
--- a/app/controllers/concerns/encoder.rb
+++ b/app/controllers/concerns/encoder.rb
@@ -19,7 +19,7 @@ module Encoder
         create_transcoding_job(params[type.to_s][:key], model[:file_base],
                                Settings["#{type}_outputs"])
     rescue RuntimeError => e
-      msg = "Could not create #{model.capitalize} transcoding job: " \
+      msg = "Could not create #{type.to_s.capitalize} transcoding job: " \
             "#{e.message}"
       logger.error msg
       render json: { message: msg }, status: :internal_server_error


### PR DESCRIPTION
Fix error encountered in logging an exception's message in `Encoder#create_media`. The variable `model` is an ActiveRecord model, not a string, and does not have a `#capitalize` method. `type.to_s` does, and gets more to the point, anyway.
