### PR TITLE
Fix Google Docs Viewer URL generation

### DIFF
--- a/app/views/sources/_document.html.erb
+++ b/app/views/sources/_document.html.erb
@@ -1,7 +1,7 @@
 <article class='document js-off'>
   <div class='media-outer-container'>
     <div class='media-inner-container'>
-      <iframe src="https://docs.google.com/viewer?url=<%= 'https:' + base_src + @source.main_asset.file_name %>&embedded=true" frameborder="0"></iframe>
+      <iframe src="https://docs.google.com/viewer?url=<%= base_src + @source.main_asset.file_name %>&embedded=true" frameborder="0"></iframe>
     </div>
   </div>
 </article>


### PR DESCRIPTION
In document view, do not add 'https://' to the beginning of the PDF URL, because `#base_src` already adds the scheme.