### PR TITLE
handle array of provider URLs

### DIFF
--- a/app/models/dpla_item.rb
+++ b/app/models/dpla_item.rb
@@ -34,7 +34,7 @@ class DplaItem < ActiveModelBase
   end
 
   def digital_resource_url
-    item.try(:url)
+    Array(item.try(:url)).first
   end
 
   def title


### PR DESCRIPTION
This handles an array of provider URLs coming through the DPLA API.  Currently, Digital Maine's provider URLs are in array format.  This has been tested on staging.