### PR TITLE
Kludge in "rep" thumbnail images for Postlight frontend

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,4 +76,9 @@ module ApplicationHelper
     "via=#{Settings.twitter_username}&" \
     "text=#{content_for :title}"
   end
+
+  def rep_file_name(filename)
+    filename.sub(/(?:_sm|_thumb)?(\.[a-z]*)$/, '_rep\1')
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,7 +78,7 @@ module ApplicationHelper
   end
 
   def rep_file_name(filename)
-    filename.sub(/(?:_sm|_thumb)?(\.[a-z]*)$/, '_rep\1')
+    filename.sub(/(?:_sm|_thumb)?(\.[a-z]*)$/i, '_rep\1')
   end
 
 end

--- a/app/views/source_sets/_index.json.erb
+++ b/app/views/source_sets/_index.json.erb
@@ -28,7 +28,10 @@
           "@id": "<%= source_set_url(set) %>",
           "@type": "CreativeWork",
           <% if set.featured_image.present? %>
+
             "thumbnailUrl": "<%= base_src + set.featured_image.file_name %>",
+            "repImageUrl": "<%= base_src + rep_file_name(set.featured_image.file_name) %>",
+
           <% end %>
           "numberOfItems": "<%= set.sources.count %>",
           <% tags = set.tags.filterable %>

--- a/app/views/source_sets/_show.json.erb
+++ b/app/views/source_sets/_show.json.erb
@@ -6,6 +6,7 @@
   "name": <%= @source_set.name.to_json.html_safe %>,
   <% if @source_set.featured_image.present? %>
     "thumbnailUrl": "<%= base_src + @source_set.featured_image.file_name %>",
+    "repImageUrl": "<%= base_src + rep_file_name(@source_set.featured_image.file_name) %>",
   <% end %>
   "dateCreated": "<%= @source_set.created_at.strftime("%Y-%m-%d") %>",
   "dct:created": "<%= @source_set.created_at.strftime("%Y-%m-%d") %>",
@@ -71,6 +72,7 @@
           <% thumbnail = source.thumbnail %>
           <% if thumbnail.present? %>
             "thumbnailUrl": "<%= base_src + thumbnail.file_name %>",
+            "repImageUrl": "<%= base_src + rep_file_name(thumbnail.file_name) %>",
           <% end %>
           "name": <%= source.name.to_json.html_safe %>,
           "mainEntity": [
@@ -112,6 +114,7 @@
           "@id": "<%= source_set_url(rs) %>",
           <% if rs.featured_image.present? %>
             "thumbnailUrl": "<%= base_src + rs.featured_image.file_name %>",
+            "repImageUrl": "<%= base_src + rep_file_name(rs.featured_image.file_name) %>",
           <% end %>
           "name": <%= rs.name.to_json.html_safe %>
         }<%= ',' unless rs.equal?(@related.last) %>

--- a/app/views/sources/_show.json.erb
+++ b/app/views/sources/_show.json.erb
@@ -5,6 +5,7 @@
   <% thumbnail = @source.thumbnail %>
   <% if thumbnail.present? %>
     "thumbnailUrl": "<%= base_src + thumbnail.file_name %>",
+    "repImageUrl": "%= base_src + rep_file_name(thumbnail.file_name) %>",
   <% end %>
   <% if @source.name.present? %>
     "name": <%= @source.name.to_json.html_safe %>,
@@ -86,6 +87,7 @@
           <% thumbnail = rs.thumbnail %>
           <% if thumbnail.present? %>
             "thumbnailUrl": "<%= base_src + thumbnail.file_name %>",
+            "repImageUrl": "<%= base_src + rep_file_name(thumbnail.file_name) %>",
           <% end %>
           <% if rs.name.present? %>
             "name": <%= rs.name.to_json.html_safe %>,

--- a/app/views/sources/_show.json.erb
+++ b/app/views/sources/_show.json.erb
@@ -5,7 +5,7 @@
   <% thumbnail = @source.thumbnail %>
   <% if thumbnail.present? %>
     "thumbnailUrl": "<%= base_src + thumbnail.file_name %>",
-    "repImageUrl": "%= base_src + rep_file_name(thumbnail.file_name) %>",
+    "repImageUrl": "<%= base_src + rep_file_name(thumbnail.file_name) %>",
   <% end %>
   <% if @source.name.present? %>
     "name": <%= @source.name.to_json.html_safe %>,


### PR DESCRIPTION
Add "repImageUrl" properties alongside existing "thumbnailUrl" properties in the API.  These new properties are file names that are the same as the thumbnail images, except that they have "_thumb" or "_sm" torn off, if they are present, and the basename ends with "_rep".

See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1615

I've solicited feedback from Postlight about this, but maybe in the meantime this can be reviewed so it's ready to go if they think it's OK.
