### PR TITLE
add citation and provider to source json

### DIFF
--- a/app/views/sources/_show.json.erb
+++ b/app/views/sources/_show.json.erb
@@ -60,6 +60,28 @@
           ]<%= ',' if @dpla_item.present? %>
         <% end %>
         <% if @dpla_item.present? %>
+          <% if @dpla_item.provider.present? %>
+            "provider": {
+              "@type": "Organization",
+              "name": "<%= @dpla_item.provider %>"
+            },
+          <% end %>
+          "citation": [
+            <% if @source.credits.present? %>
+              {
+                "@type": "CreativeWork",
+                "text": "<%= @source.credits %>",
+                "disabmiguationDescription": "credits"
+              }<%= "," if @source.citation.present? %>
+            <% end %>
+            <% if @source.citation.present? %>
+              {
+                "@type": "CreativeWork",
+                "text": "<%= @source.citation %>",
+                "disabmiguationDescription": "citation"
+              }
+            <% end %>
+          ],
           "dct:references": [
             <% if @dpla_item.digital_resource_url.present? %>
               {


### PR DESCRIPTION
This adds citations and the provider name to the source JSON for the PSS API.  This will unblock the following Trello tickets, which relate to the new frontend rollout:

https://trello.com/c/xAYaWGcn/76-instead-of-item-source-and-dpla-record-the-links-should-be-view-on-provider-and-view-in-dpla

https://trello.com/c/OpBS2LoS/19-source-pages-for-primary-source-sets-are-missing-courtesy-statements

This PR addresses [DT-1647](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1647).  It has been tested locally.