### PR TITLE
restore BUNDLED WITH

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,3 +284,6 @@ DEPENDENCIES
   unicorn (= 4.8.3)
   zencoder (~> 2.5.1)
   zencoder-fetcher (~> 0.2.8)
+
+BUNDLED WITH
+  1.13.2


### PR DESCRIPTION
This restores two lines from `Gemfile.lock` that accidentally got into my git history and committed with the last PR.