### PR TITLE
change bundler without syntax

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,7 @@ require 'rails/all'
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-Bundler.require(:dpla_branding) if Bundler.settings.without.exclude? :dpla_branding
+Bundler.require(:dpla_branding) if Bundler.settings[:without].exclude? :dpla_branding
 
 module PrimarySourceSets
   class Application < Rails::Application


### PR DESCRIPTION
This fixes syntax to align with a change in Bundler 1.6 (see https://github.com/bundler/bundler/commit/8ccf49c3b4a086f1e0cad2130dc30c04304175b7#diff-75219bd6bc0defc0e7f4ba322d92f950L198).  This fixes deployment to staging, which was failing.