### PR TITLE
catch standarderror when fetching items from DPLA API

### DIFF
--- a/app/models/dpla_item.rb
+++ b/app/models/dpla_item.rb
@@ -26,6 +26,10 @@ class DplaItem < ActiveModelBase
       # bad API key or item ID. Until that's addressed, handle NoMethodError.
       logger.error "Bad API key #{Settings.api.key} or item IDs #{Array(ids)}"
       return []
+    rescue StandardError => e
+      logger.error "Error occurred when attempting to fetch items from DPLA API:"
+      logger.error(e)
+      return []
     end
   end
 


### PR DESCRIPTION
This catches `StandardError` when attempting to fetch items from the DPLA API.  `StandardError` is quite broad, so we're playing it very safe here.  We could just catch `Faraday::Error::ParsingError` which works for the specific problem of an item ID not being found in the DPLA index.  However, it occurs to me that there could be other errors bubbling up here as well, like network errors.  And I imagine that no matter what the error, we would just want to log it and return something benign that won't cause the webpage to crash.  So I opted for `StandardError` but please let me know if you don't agree.

This has been tested locally.  It addresses https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2197